### PR TITLE
fix hog.compute crash on windows

### DIFF
--- a/digits-classification/train_digits.cpp
+++ b/digits-classification/train_digits.cpp
@@ -105,9 +105,9 @@ void CreateDeskewedTrainTest(vector<Mat> &deskewedTrainCells,vector<Mat> &deskew
 
 HOGDescriptor hog(
         Size(20,20), //winSize
-        Size(10,10), //blocksize
-        Size(5,5), //blockStride,
-        Size(10,10), //cellSize,
+        Size(8,8), //blocksize
+        Size(4,4), //blockStride,
+        Size(8,8), //cellSize,
                  9, //nbins,
                   1, //derivAper,
                  -1, //winSigma,

--- a/digits-classification/train_digits.py
+++ b/digits-classification/train_digits.py
@@ -82,9 +82,9 @@ def preprocess_simple(digits):
 
 def get_hog() : 
     winSize = (20,20)
-    blockSize = (10,10)
-    blockStride = (5,5)
-    cellSize = (10,10)
+    blockSize = (8,8)
+    blockStride = (4,4)
+    cellSize = (8,8)
     nbins = 9
     derivAperture = 1
     winSigma = -1.


### PR DESCRIPTION
hog.compute() crashes on Windows for given values of blockSize(10, 10), blockStride(5, 5) and cellSize(10, 10) because of a function call to cv::alignSize.
This digit classification code works well on both Windows and Linux for current values of parameters in this PR.
I will update the root cause in this thread for this inconsistent behaviour after further analysis.