### PR TITLE
truncate center coordinates to ints after /2

### DIFF
--- a/SeamlessCloning/normal_versus_mixed_clone.py
+++ b/SeamlessCloning/normal_versus_mixed_clone.py
@@ -16,7 +16,7 @@ mask = 255 * np.ones(obj.shape, obj.dtype)
 
 # The location of the center of the src in the dst
 width, height, channels = im.shape
-center = (height/2, width/2)
+center = (int(height/2), int(width/2))
 
 # Seamlessly clone src into dst and put the results in output
 normal_clone = cv2.seamlessClone(obj, im, mask, center, cv2.NORMAL_CLONE)


### PR DESCRIPTION
This seems to be required by cv2.seamlessClone, which otherwise gives a TypeError on line 26 (expected integer, got float)

I was using python 3.5.3
- menpo::opencv3=3.1.0=py35_0
- numpy=1.12.0=py35_0