### PR TITLE
Update multi-person-openpose.cpp

### DIFF
--- a/OpenPose-Multi-Person/multi-person-openpose.cpp
+++ b/OpenPose-Multi-Person/multi-person-openpose.cpp
@@ -320,7 +320,7 @@ int main(int argc,char** argv) {
 		inputFile = std::string(argv[1]);
 	}
 
-	cv::Mat input = cv::imread(inputFile,CV_LOAD_IMAGE_COLOR);
+	cv::Mat input = cv::imread(inputFile, cv::IMREAD_COLOR);
 
  	std::chrono::time_point<std::chrono::system_clock> startTP = std::chrono::system_clock::now();
 


### PR DESCRIPTION
`CV_LOAD_IMAGE_COLOR`  (like any other opencv1.0 c-api constant) is no more available in current opencv4