### PR TITLE
Updated install scripts for raspberry pi, closes #258

### DIFF
--- a/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh
+++ b/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh
@@ -74,12 +74,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
 
 

--- a/InstallScripts/installOpenCV-3-raspberry-pi.sh
+++ b/InstallScripts/installOpenCV-3-raspberry-pi.sh
@@ -111,13 +111,13 @@ echo "Complete"
 echo "Downloading opencv and opencv_contrib"
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 echo "================================"

--- a/InstallScripts/installOpenCV-4-on-Ubuntu-18-04.sh
+++ b/InstallScripts/installOpenCV-4-on-Ubuntu-18-04.sh
@@ -74,12 +74,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout $cvVersion
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout $cvVersion
+git checkout "$cvVersion"
 cd ..
 
 cd opencv


### PR DESCRIPTION
In the git checkout part of these install scripts, use "$cvVersion" instead of 3.4 / "master" for checking out the desired git branch.