### PR TITLE
Fixes #265 (for opencv version 3.4.x)

### DIFF
--- a/InstallScripts/README.md
+++ b/InstallScripts/README.md
@@ -1,32 +1,32 @@
 1. OpenCV Installation on Windows
 - [Install OpenCV 4.0 on Windows](https://www.learnopencv.com/install-opencv-4-on-windows/) - [Code](https://github.com/spmallick/learnopencv/tree/master/InstallScripts/Windows-4)
-- [Install OpenCV 3.4.4 on Windows](https://www.learnopencv.com/install-opencv-3-4-4-on-windows/) - [Code](https://github.com/spmallick/learnopencv/tree/master/InstallScripts/Windows-3)
+- [Install OpenCV 3.4.x on Windows](https://www.learnopencv.com/install-opencv-3-4-4-on-windows/) - [Code](https://github.com/spmallick/learnopencv/tree/master/InstallScripts/Windows-3)
 
 2. OpenCV Installation on Ubuntu 16.04
 - [Install OpenCV 4.0 on Ubuntu 16.04](https://www.learnopencv.com/install-opencv-4-on-ubuntu-16-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-on-Ubuntu-16-04.sh)
-- [Install OpenCV 3.4.4 on Ubuntu 16.04](https://www.learnopencv.com/install-opencv-3-4-4-ubuntu-16-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-Ubuntu-16-04.sh)
+- [Install OpenCV 3.4.x on Ubuntu 16.04](https://www.learnopencv.com/install-opencv-3-4-4-ubuntu-16-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-Ubuntu-16-04.sh)
 
 3. OpenCV Installation on Ubuntu 18.04
 - [Install OpenCV 4.0 on Ubuntu 18.04](https://www.learnopencv.com/install-opencv-4-on-ubuntu-18-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-on-Ubuntu-18-04.sh)
-- [Install OpenCV 3.4.4 on Ubuntu 18.04](https://www.learnopencv.com/install-opencv-3-4-4-on-ubuntu-18-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh)
+- [Install OpenCV 3.4.x on Ubuntu 18.04](https://www.learnopencv.com/install-opencv-3-4-4-on-ubuntu-18-04/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh)
 
 4. OpenCV Installation on Red Hat
 - [Install OpenCV 4 on Red Hat (C++ and Python)](https://www.learnopencv.com/install-opencv-4-on-red-hat/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-on-red-hat.sh)
-- [Install OpenCV 3.4.4 on Red Hat (C++ and Python)](https://www.learnopencv.com/install-opencv-3-4-4-on-red-hat/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-red-hat.sh)
+- [Install OpenCV 3.4.x on Red Hat (C++ and Python)](https://www.learnopencv.com/install-opencv-3-4-4-on-red-hat/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-red-hat.sh)
 
 5. OpenCV Installation on CentOS
 
-- [Install OpenCV 3.4.4 on CentOS 7 (C++ and Python)](https://www.learnopencv.com/install-opencv-3-4-4-on-centos-7/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-centos.sh)
+- [Install OpenCV 3.4.x on CentOS 7 (C++ and Python)](https://www.learnopencv.com/install-opencv-3-4-4-on-centos-7/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-on-centos.sh)
 - [Install OpenCV 4 on CentOS 7 (C++ and Python)](https://www.learnopencv.com/install-opencv-4-on-centos-7/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-on-centos.sh)
 
 6. OpenCV Installation on macOS
 - [Install OpenCV 4.0 on macOS](https://www.learnopencv.com/install-opencv-4-on-macos/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-macos.sh)
-- [Install OpenCV 3.4.4 on macOS](https://www.learnopencv.com/install-opencv-3-4-4-on-macos/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-macos.sh)
+- [Install OpenCV 3.4.x on macOS](https://www.learnopencv.com/install-opencv-3-4-4-on-macos/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-macos.sh)
 - [Install OpenCV using brew](https://www.learnopencv.com/install-opencv3-on-macos/)
 
 7. OpenCV Installation on Raspberry Pi
 - [Install OpenCV 4.0 on Raspberry Pi](https://www.learnopencv.com/install-opencv-4-on-raspberry-pi/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-4-raspberry-pi.sh)
-- [Install OpenCV 3.4.4 on Raspberry Pi](https://www.learnopencv.com/install-opencv-3-4-4-on-raspberry-pi/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-raspberry-pi.sh)
+- [Install OpenCV 3.4.x on Raspberry Pi](https://www.learnopencv.com/install-opencv-3-4-4-on-raspberry-pi/) - [Code](https://github.com/spmallick/learnopencv/blob/master/InstallScripts/installOpenCV-3-raspberry-pi.sh)
 
 8. OpenCV Docker Image
 - [OpenCV 3.4.3, OpenCV 3.4.4 and OpenCV 4.0 Docker Image](https://www.learnopencv.com/install-opencv-docker-image-ubuntu-macos-windows/)

--- a/InstallScripts/installOpenCV-3-macos.sh
+++ b/InstallScripts/installOpenCV-3-macos.sh
@@ -41,10 +41,10 @@ source /usr/local/bin/virtualenvwrapper.sh
 
 #=================================================================
 
-echo "Installing OpenCV - 3.4.4"
+echo "Installing OpenCV - 3.4.x"
  
 #Specify OpenCV version
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv/build
@@ -68,12 +68,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
 
 cd opencv

--- a/InstallScripts/installOpenCV-3-on-Ubuntu-16-04.sh
+++ b/InstallScripts/installOpenCV-3-on-Ubuntu-16-04.sh
@@ -3,7 +3,7 @@
 echo "OpenCV installation by learnOpenCV.com"
  
 #Specify OpenCV version
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv/build
@@ -71,12 +71,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout $cvVersion
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout $cvVersion
+git checkout "$cvVersion"
 cd ..
 
 cd opencv

--- a/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh
+++ b/InstallScripts/installOpenCV-3-on-Ubuntu-18-04.sh
@@ -3,7 +3,7 @@
 echo "OpenCV installation by learnOpenCV.com"
  
 #Specify OpenCV version
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv/build
@@ -74,12 +74,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
 
 

--- a/InstallScripts/installOpenCV-3-on-centos.sh
+++ b/InstallScripts/installOpenCV-3-on-centos.sh
@@ -2,10 +2,10 @@
 
 echo "OpenCV installation by learnOpenCV.com"
 
-echo "Installing OpenCV - 3.4.4"
+echo "Installing OpenCV - 3.4"
  
 #Specify OpenCV version
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv
@@ -68,12 +68,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
 
 cd opencv

--- a/InstallScripts/installOpenCV-3-on-red-hat.sh
+++ b/InstallScripts/installOpenCV-3-on-red-hat.sh
@@ -2,10 +2,10 @@
 
 echo "OpenCV installation by learnOpenCV.com"
 
-echo "Installing OpenCV - 3.4.4"
+echo "Installing OpenCV - 3.4"
  
 #Specify OpenCV version
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv
@@ -66,12 +66,12 @@ deactivate
 
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
  
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 cd ..
 
 cd opencv

--- a/InstallScripts/installOpenCV-3-raspberry-pi.sh
+++ b/InstallScripts/installOpenCV-3-raspberry-pi.sh
@@ -17,7 +17,7 @@ sudo apt-get -y autoremove
 # Step 0: Take inputs
 echo "OpenCV installation by learnOpenCV.com"
 
-cvVersion="3.4.4"
+cvVersion="3.4"
 
 # Clean build directories
 rm -rf opencv/build
@@ -111,13 +111,13 @@ echo "Complete"
 echo "Downloading opencv and opencv_contrib"
 git clone https://github.com/opencv/opencv.git
 cd opencv
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 
 git clone https://github.com/opencv/opencv_contrib.git
 cd opencv_contrib
-git checkout 3.4
+git checkout "$cvVersion"
 
 cd ..
 echo "================================"


### PR DESCRIPTION
This fixes #265 (for opencv 3 versions).
- README.md is adjusted (now mentions "3.4.x")
- installation scripts use "$cvVersion"  (which is set to 3.4)