### PR TITLE
Fix problem with OpenCV 4.1

### DIFF
--- a/Mask-RCNN/mask_rcnn.py
+++ b/Mask-RCNN/mask_rcnn.py
@@ -51,7 +51,7 @@ def drawBox(frame, classId, conf, left, top, right, bottom, classMask):
 
     # Draw the contours on the image
     mask = mask.astype(np.uint8)
-    im2, contours, hierarchy = cv.findContours(mask,cv.RETR_TREE,cv.CHAIN_APPROX_SIMPLE)
+    contours, hierarchy = cv.findContours(mask,cv.RETR_TREE,cv.CHAIN_APPROX_SIMPLE)
     cv.drawContours(frame[top:bottom+1, left:right+1], contours, -1, color, 3, cv.LINE_8, hierarchy, 100)
 
 # For each frame, extract the bounding box and mask for each detected object


### PR DESCRIPTION
It solves this problem:
```
python3 mask_rcnn.py --image=cars.jpg
Traceback (most recent call last):
  File "mask_rcnn.py", line 167, in <module>
    postprocess(boxes, masks)
  File "mask_rcnn.py", line 91, in postprocess
    drawBox(frame, classId, score, left, top, right, bottom, classMask)
  File "mask_rcnn.py", line 54, in drawBox
    im2, contours, hierarchy = cv.findContours(mask,cv.RETR_TREE,cv.CHAIN_APPROX_SIMPLE)
ValueError: not enough values to unpack (expected 3, got 2)
```