### PR TITLE
Addition of "estimateAffine2D" for finding transformation matrix in OpenCV version greater than 3.0

### DIFF
--- a/VideoStabilization/video_stabilization.py
+++ b/VideoStabilization/video_stabilization.py
@@ -91,7 +91,11 @@ for i in range(n_frames-2):
   curr_pts = curr_pts[idx]
 
   #Find transformation matrix
-  m = cv2.estimateRigidTransform(prev_pts, curr_pts, fullAffine=False) #will only work with OpenCV-3 or less
+  if float((cv2.__version__)[0:3])<=3.0:
+     m = cv2.estimateRigidTransform(prev_pts, curr_pts, fullAffine=False) #will only work with OpenCV-3 or less
+   
+  else:
+    m,_ = cv2.estimateAffine2D(prev_pts, curr_pts)# will work with OpenCV>3.0
    
   # Extract traslation
   dx = m[0,2]


### PR DESCRIPTION
For OpenCV version greater than 3.0 assigned "estimateAffine2D" function for finding transformation matrix. Initially "estimateRigidTransform" was used which only works in OpenCV-3 or less.