### PR TITLE
Update image_classification_using_transfer_learning_in_pytorch.ipynb

### DIFF
--- a/Image-Classification-in-PyTorch/image_classification_using_transfer_learning_in_pytorch.ipynb
+++ b/Image-Classification-in-PyTorch/image_classification_using_transfer_learning_in_pytorch.ipynb
@@ -83,7 +83,7 @@
     "bs = 32\n",
     "\n",
     "# Number of classes\n",
-    "num_classes = len(os.listdir(valid_directory))-1  #10#2#257\n",
+    "num_classes = len(os.listdir(valid_directory))  #10#2#257\n",
     "print(num_classes)\n",
     "\n",
     "# Load Data from folders\n",


### PR DESCRIPTION
Num classes should not be entries -1

Otherwise last layer does not match input labels and you will get this error

```Epoch: 1/30
/pytorch/aten/src/THCUNN/ClassNLLCriterion.cu:108: cunn_ClassNLLCriterion_updateOutput_kernel: block: [0,0,0], thread: [7,0,0] Assertion `t >= 0 && t < n_classes` failed.```