### PR TITLE
Extended gitignore for python and C++ artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,26 @@
 .DS_Store
+
+# C++
+.clangd
+build
+compile_commands.json
+
+# Python
+__pycache__/
+
+# Jupyter notebook
+.ipynb_checkpoints
+
+# venv
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json


### PR DESCRIPTION
Adding the python cache dir, virtual envs and C++ clangd cache and build artifacts to gitignore will make it easier to play with tutorials in this repo and to rebase upstream content when new tutorials are released. 