### PR TITLE
Fix error in R-CNN example due to the new version update of OpenCV

### DIFF
--- a/Mask-RCNN/mask_rcnn.py
+++ b/Mask-RCNN/mask_rcnn.py
@@ -51,7 +51,7 @@ def drawBox(frame, classId, conf, left, top, right, bottom, classMask):
 
     # Draw the contours on the image
     mask = mask.astype(np.uint8)
-    im2, contours, hierarchy = cv.findContours(mask,cv.RETR_TREE,cv.CHAIN_APPROX_SIMPLE)
+    contours, hierarchy = cv.findContours(mask,cv.RETR_TREE,cv.CHAIN_APPROX_SIMPLE)
     cv.drawContours(frame[top:bottom+1, left:right+1], contours, -1, color, 3, cv.LINE_8, hierarchy, 100)
 
 # For each frame, extract the bounding box and mask for each detected object


### PR DESCRIPTION
The `cv2.findContours` function only returns 2 arguments instead of one in newer versions of OpenCV. For that reason, it will most likely throw an error when using a more recent OpenCV version. For reference see [here](https://github.com/facebookresearch/maskrcnn-benchmark/issues/339).