### PR TITLE
Add torchmetrics version in requirements

### DIFF
--- a/Human-Action-Recognition-Using-Detectron2-And-Lstm/requirements.txt
+++ b/Human-Action-Recognition-Using-Detectron2-And-Lstm/requirements.txt
@@ -9,4 +9,5 @@ torch==1.8.1
 torchvision==0.9.1
 pyyaml==5.1
 Werkzeug==0.15.6
+torchmetrics==0.6.0
 torchtext


### PR DESCRIPTION
Fixed in requirements because torchmetrics and torchvision versions are not compatible.