### PR TITLE
Exception ERROR in ColorSpaces: interactiveColorDetect.cpp

### DIFF
--- a/ColorSpaces/interactiveColorDetect.cpp
+++ b/ColorSpaces/interactiveColorDetect.cpp
@@ -9,7 +9,7 @@ Mat img, placeholder;
 // Callback function for any event on he mouse
 void onMouse( int event, int x, int y, int flags, void* userdata )
 {   
-    if( event == EVENT_MOUSEMOVE )
+    if( event == EVENT_MOUSEMOVE and (x<img.rows and y<img.cols))
 	{
 
      	Vec3b bgrPixel(img.at<Vec3b>(y, x));


### PR DESCRIPTION
Current code throw an exception error when cursor is moved in the "placeholder" area. It can be fixed by updating the if condition on line 12:

FROM:
LINE 12: `if( event == EVENT_MOUSEMOVE)`

TO: 
LINE 12: `if( event == EVENT_MOUSEMOVE and (x<img.rows and y<img.cols))`