### PR TITLE
Updated the way multiple images are loaded

### DIFF
--- a/ExposureFusion/exposureFusion.py
+++ b/ExposureFusion/exposureFusion.py
@@ -1,32 +1,16 @@
 import cv2
 import numpy as np
 import sys
+import os
 
-
-def readImagesAndTimes():
+def readImagesAndTimes(dir_path):
   
-  filenames = [
-               "images/memorial0061.jpg",
-               "images/memorial0062.jpg",
-               "images/memorial0063.jpg",
-               "images/memorial0064.jpg",
-               "images/memorial0065.jpg",
-               "images/memorial0066.jpg",
-               "images/memorial0067.jpg",
-               "images/memorial0068.jpg",
-               "images/memorial0069.jpg",
-               "images/memorial0070.jpg",
-               "images/memorial0071.jpg",
-               "images/memorial0072.jpg",
-               "images/memorial0073.jpg",
-               "images/memorial0074.jpg",
-               "images/memorial0075.jpg",
-               "images/memorial0076.jpg"
-               ]
-
+  #load images with os
+  filenames = [os.path.join(dir_path, f) for f in os.listdir(dir_path) if f.endswith('.jpg')]
   images = []
   for filename in filenames:
     im = cv2.imread(filename)
+    im = cv2.resize(im, (500, 500))
     images.append(im)
   
   return images
@@ -35,6 +19,8 @@ if __name__ == '__main__':
   
   # Read images
   print("Reading images ... ")
+  
+  dir_path = '' #path to images
   
   if len(sys.argv) > 1:
     # Read images from the command line
@@ -45,7 +31,7 @@ if __name__ == '__main__':
     needsAlignment = False
   else :
     # Read example images
-    images = readImagesAndTimes()
+    images = readImagesAndTimes(dir_path=dir_path)
     needsAlignment = False
   
   # Align input images

--- a/hdr/hdr.py
+++ b/hdr/hdr.py
@@ -1,26 +1,25 @@
 import cv2
 import numpy as np
+import os
 
-
-def readImagesAndTimes():
+def readImagesAndTimes(dir_path):
   
-  times = np.array([ 1/30.0, 0.25, 2.5, 15.0 ], dtype=np.float32)
-  
-  filenames = ["img_0.033.jpg", "img_0.25.jpg", "img_2.5.jpg", "img_15.jpg"]
-
+  #load images with os
+  filenames = [os.path.join(dir_path, f) for f in os.listdir(dir_path) if f.endswith('.jpg')]
   images = []
   for filename in filenames:
     im = cv2.imread(filename)
+    im = cv2.resize(im, (500, 500))
     images.append(im)
   
-  return images, times
+  return images
 
 if __name__ == '__main__':
   # Read images and exposure times
   print("Reading images ... ")
 
-  images, times = readImagesAndTimes()
-  
+  dir_path = '' #path to images
+  images, times = readImagesAndTimes(dir_path=dir_path)
   
   # Align input images
   print("Aligning images ... ")


### PR DESCRIPTION
Made changes for loading multiple images in 2 files.
Previously all image names had to be provided, with this commit user has to just provide the directory path, considering the directory only contains required images. 

Previously : 
![image](https://user-images.githubusercontent.com/82194525/233416362-aa90865a-4a04-4b44-a187-b129faa2a4c3.png)


Changes :
![image](https://user-images.githubusercontent.com/82194525/233416155-50c2566d-c1f2-47a3-a50b-422b053f4e4f.png)
