### PR TITLE
Add YOLO26 Keypoint Estimation code and README

### DIFF
--- a/YOLO26_Keypoint_Estimation/YOLO26_Keypoint_Estimation.ipynb
+++ b/YOLO26_Keypoint_Estimation/YOLO26_Keypoint_Estimation.ipynb
@@ -1,0 +1,1025 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Klk0I4297PPo"
+      },
+      "source": [
+        "# YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/)\n",
+        "\n",
+        "In this notebook, we implement **keypoint (pose) estimation** using the **YOLO26** pose model from Ultralytics on images and videos.\n",
+        "\n",
+        "**YOLO26** introduces key improvements for pose estimation:\n",
+        "- **Residual Log-Likelihood Estimation (RLE)** for more accurate keypoint localization\n",
+        "- **End-to-end NMS-free inference**\n",
+        "- **MuSGD optimizer** for stable training\n",
+        "- Detects 17 anatomical landmarks (COCO format)\n",
+        "\n",
+        "---"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RCXNri_F7PPq"
+      },
+      "source": [
+        "## 1. Installation & Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "imwu6jUT7PPr"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install ultralytics -q"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "36e2RddH7PPs"
+      },
+      "outputs": [],
+      "source": [
+        "from ultralytics import YOLO\n",
+        "import cv2\n",
+        "import numpy as np\n",
+        "from IPython.display import HTML, display\n",
+        "from base64 import b64encode\n",
+        "from tqdm.auto import tqdm\n",
+        "import os\n",
+        "import shutil\n",
+        "import zipfile\n",
+        "import urllib.request\n",
+        "\n",
+        "# cv2_imshow is Colab-only; fall back to a plain display for other platforms\n",
+        "try:\n",
+        "    from google.colab.patches import cv2_imshow\n",
+        "except ImportError:\n",
+        "    def cv2_imshow(img):\n",
+        "        from IPython.display import Image\n",
+        "        _, buf = cv2.imencode('.png', img)\n",
+        "        display(Image(data=buf.tobytes()))\n",
+        "\n",
+        "print(\"All imports successful!\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BFq0212p7PPs"
+      },
+      "source": [
+        "---\n",
+        "## 2. Setup Workspace and Download Input Files\n",
+        "\n",
+        "All processing runs in a **local workspace folder** (`./yolo26_workspace/`) with an `inputs/` and `outputs/` structure. The sample images and videos are packaged as a single zip in a public **GitHub release**, so they download directly into `inputs/` with no authentication required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gDwZyRRB7PPs"
+      },
+      "outputs": [],
+      "source": [
+        "# Workspace\n",
+        "WORK_DIR     = os.path.abspath(\"./yolo26_workspace\")\n",
+        "INPUT_DIR    = os.path.join(WORK_DIR, \"inputs\")\n",
+        "OUTPUT_DIR   = os.path.join(WORK_DIR, \"outputs\")\n",
+        "VIDEO_OUTPUT = os.path.join(OUTPUT_DIR, \"videos\")\n",
+        "IMAGE_OUTPUT = os.path.join(OUTPUT_DIR, \"images\")\n",
+        "\n",
+        "for d in [INPUT_DIR, VIDEO_OUTPUT, IMAGE_OUTPUT]:\n",
+        "    os.makedirs(d, exist_ok=True)\n",
+        "\n",
+        "print(f\"📁 Workspace: {WORK_DIR}\")\n",
+        "print(f\"   inputs  : {INPUT_DIR}\")\n",
+        "print(f\"   outputs : {OUTPUT_DIR}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "zpayDdnQ7PPt"
+      },
+      "outputs": [],
+      "source": [
+        "# Public GitHub release zip — no login / no auth required\n",
+        "RELEASE_URL = \"https://github.com/spmallick/learnopencv/releases/download/YOLO26_Keypoint_Estimation/YOLO26_Keypoint_Estimation.zip\"\n",
+        "ZIP_PATH    = os.path.join(WORK_DIR, \"YOLO26_Keypoint_Estimation.zip\")\n",
+        "\n",
+        "MEDIA_EXT = ('.mp4', '.mov', '.avi', '.mkv',\n",
+        "             '.jpg', '.jpeg', '.png', '.bmp', '.webp')\n",
+        "\n",
+        "existing = [f for f in os.listdir(INPUT_DIR)\n",
+        "            if os.path.isfile(os.path.join(INPUT_DIR, f))\n",
+        "            and f.lower().endswith(MEDIA_EXT)]\n",
+        "\n",
+        "if existing:\n",
+        "    print(f\"✅ Using {len(existing)} media file(s) already in {INPUT_DIR}\")\n",
+        "else:\n",
+        "    # --- Download ---\n",
+        "    def _report(block_num, block_size, total_size):\n",
+        "        downloaded = block_num * block_size\n",
+        "        pct = min(downloaded * 100 / total_size, 100) if total_size > 0 else 0\n",
+        "        print(f\"\\r⬇️  Downloading release zip... {pct:5.1f}%  ({downloaded / (1024*1024):6.2f} MB)\",\n",
+        "              end='', flush=True)\n",
+        "\n",
+        "    print(f\"⬇️  Downloading from: {RELEASE_URL}\")\n",
+        "    urllib.request.urlretrieve(RELEASE_URL, ZIP_PATH, reporthook=_report)\n",
+        "    print()\n",
+        "\n",
+        "    # --- Extract to a temp sub-folder so we can safely flatten afterwards ---\n",
+        "    TEMP_EXTRACT = os.path.join(WORK_DIR, \"_zip_contents\")\n",
+        "    os.makedirs(TEMP_EXTRACT, exist_ok=True)\n",
+        "\n",
+        "    print(\"📦 Extracting zip...\")\n",
+        "    with zipfile.ZipFile(ZIP_PATH, 'r') as zf:\n",
+        "        zf.extractall(TEMP_EXTRACT)\n",
+        "\n",
+        "    # --- Walk the extracted tree and move every media file into INPUT_DIR ---\n",
+        "    moved = 0\n",
+        "    for root, dirs, files in os.walk(TEMP_EXTRACT):\n",
+        "        for fname in files:\n",
+        "            if fname.lower().endswith(MEDIA_EXT):\n",
+        "                src = os.path.join(root, fname)\n",
+        "                dst = os.path.join(INPUT_DIR, fname)\n",
+        "                if not os.path.exists(dst):\n",
+        "                    shutil.move(src, dst)\n",
+        "                    moved += 1\n",
+        "\n",
+        "    # --- Clean up ---\n",
+        "    shutil.rmtree(TEMP_EXTRACT, ignore_errors=True)\n",
+        "    os.remove(ZIP_PATH)\n",
+        "    print(f\"✅ Moved {moved} media file(s) into {INPUT_DIR}\")\n",
+        "\n",
+        "# List final inputs\n",
+        "files = sorted([f for f in os.listdir(INPUT_DIR)\n",
+        "                if os.path.isfile(os.path.join(INPUT_DIR, f))])\n",
+        "print(f\"\\n📦 {len(files)} file(s) in workspace:\")\n",
+        "for f in files:\n",
+        "    size_mb = os.path.getsize(os.path.join(INPUT_DIR, f)) / (1024 * 1024)\n",
+        "    print(f\"   - {f}  ({size_mb:.2f} MB)\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oL2NA0ac7PPt"
+      },
+      "source": [
+        "---\n",
+        "## 3. Choose & Load the YOLO26 Pose Model\n",
+        "\n",
+        "YOLO26 comes in **5 variants** ranging from a tiny 2.9M-parameter nano model to a 57.6M-parameter extra-large one. Pick the variant that matches your **speed vs accuracy** needs:\n",
+        "\n",
+        "| Model | Params (M) | FLOPs (B) | mAP₅₀₋₉₅ (Pose) | T4 GPU Speed (ms) | Best For |\n",
+        "|-------|-----------|-----------|----------------|-------------------|----------|\n",
+        "| **yolo26n-pose** | 2.9 | 7.5 | 57.2 | **1.8** ⚡ | Real-time on edge devices, webcams, mobile |\n",
+        "| **yolo26s-pose** | 10.4 | 23.9 | 63.0 | 2.7 | Balanced speed + accuracy on consumer GPU |\n",
+        "| **yolo26m-pose** | 21.5 | 73.1 | 68.8 | 5.0 | Higher accuracy with reasonable speed |\n",
+        "| **yolo26l-pose** | 25.9 | 91.3 | 70.4 | 6.5 | High accuracy for analysis pipelines |\n",
+        "| **yolo26x-pose** | 57.6 | 201.7 | **71.6** 🎯 | 12.2 | Maximum accuracy, offline batch processing |\n",
+        "\n",
+        "*Benchmarks on COCO val2017 at 640×640. Speed measured on NVIDIA T4 GPU with TensorRT10.*\n",
+        "\n",
+        "### How to choose:\n",
+        "- **Live demo / mobile / webcam?** → `yolo26n-pose` (fastest)\n",
+        "- **Blog tutorials / Colab T4?** → `yolo26n-pose` or `yolo26s-pose` (good balance)\n",
+        "- **Production pipeline?** → `yolo26m-pose` or `yolo26l-pose`\n",
+        "- **Research / batch analysis?** → `yolo26x-pose` (best accuracy)\n",
+        "\n",
+        "For this tutorial, we'll use `yolo26n-pose.pt` since it's fast on Colab's free T4 GPU. Change the model name below to try a different variant."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "B7kwADXc7PPu"
+      },
+      "outputs": [],
+      "source": [
+        "# Choose your model variant:\n",
+        "#   \"yolo26n-pose.pt\"   ← Nano   (fastest, smallest)\n",
+        "#   \"yolo26s-pose.pt\"   ← Small\n",
+        "#   \"yolo26m-pose.pt\"   ← Medium\n",
+        "#   \"yolo26l-pose.pt\"   ← Large\n",
+        "#   \"yolo26x-pose.pt\"   ← XLarge (most accurate, slowest)\n",
+        "\n",
+        "MODEL_NAME = \"yolo26n-pose.pt\"\n",
+        "\n",
+        "model = YOLO(MODEL_NAME)\n",
+        "print(f\"✅ Loaded {MODEL_NAME}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Jhc93Q2T7PPu"
+      },
+      "source": [
+        "---\n",
+        "## 4. Helper Functions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fZIWX_137PPu"
+      },
+      "outputs": [],
+      "source": [
+        "def display_video_inline(video_path, width=720, crf=18, preset='medium'):\n",
+        "    \"\"\"\n",
+        "    Display a video inline (H.264 compressed for fast loading).\n",
+        "    crf: 18 = visually lossless, 22 = high quality (default), 28 = medium, 35 = low.\n",
+        "    \"\"\"\n",
+        "    compressed_path = '/tmp/display_video.mp4'\n",
+        "    cmd = (\n",
+        "        f\"ffmpeg -y -i '{video_path}' \"\n",
+        "        f\"-vcodec libx264 -crf {crf} -preset {preset} \"\n",
+        "        f\"-pix_fmt yuv420p \"\n",
+        "        f\"-vf 'scale={width}:-2' -an \"\n",
+        "        f\"-movflags +faststart \"\n",
+        "        f\"-f mp4 {compressed_path} -loglevel quiet\"\n",
+        "    )\n",
+        "    os.system(cmd)\n",
+        "    with open(compressed_path, 'rb') as f:\n",
+        "        video_data = f.read()\n",
+        "    video_b64 = b64encode(video_data).decode()\n",
+        "    size_mb = len(video_data) / (1024 * 1024)\n",
+        "    print(f\"🎬 {os.path.basename(video_path)} — {size_mb:.2f} MB (crf={crf}, width={width})\")\n",
+        "    html = f'''\n",
+        "    <video width=\"{width}\" controls autoplay muted loop>\n",
+        "        <source src=\"data:video/mp4;base64,{video_b64}\" type=\"video/mp4\">\n",
+        "    </video>\n",
+        "    '''\n",
+        "    return HTML(html)\n",
+        "\n",
+        "\n",
+        "def display_image_inline(image, width=720, title=None):\n",
+        "    h, w = image.shape[:2]\n",
+        "    if w > width:\n",
+        "        scale = width / w\n",
+        "        image = cv2.resize(image, (width, int(h * scale)))\n",
+        "    if title:\n",
+        "        print(f\"🖼️ {title}\")\n",
+        "    cv2_imshow(image)\n",
+        "\n",
+        "\n",
+        "def run_keypoint_on_video(video_path, output_path, conf=0.5, plot_kwargs=None):\n",
+        "    \"\"\"Run YOLO26 keypoint estimation on a video frame by frame with a progress bar.\"\"\"\n",
+        "    if plot_kwargs is None:\n",
+        "        plot_kwargs = {'boxes': False, 'labels': False, 'conf': False}\n",
+        "    cap = cv2.VideoCapture(video_path)\n",
+        "    if not cap.isOpened():\n",
+        "        print(f\"❌ Could not open video: {video_path}\")\n",
+        "        return\n",
+        "    fps    = int(cap.get(cv2.CAP_PROP_FPS))\n",
+        "    width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))\n",
+        "    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
+        "    total  = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))\n",
+        "    print(f\"  Resolution: {width}x{height} @ {fps}fps | {total} frames\")\n",
+        "    fourcc = cv2.VideoWriter_fourcc(*\"mp4v\")\n",
+        "    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))\n",
+        "    pbar = tqdm(total=total, desc=f\"  {os.path.basename(video_path)}\",\n",
+        "                unit=\"frame\", dynamic_ncols=True, leave=True)\n",
+        "    while cap.isOpened():\n",
+        "        ret, frame = cap.read()\n",
+        "        if not ret:\n",
+        "            break\n",
+        "        results = model(frame, conf=conf, verbose=False)\n",
+        "        annotated = results[0].plot(**plot_kwargs)\n",
+        "        out.write(annotated)\n",
+        "        pbar.update(1)\n",
+        "    pbar.close()\n",
+        "    cap.release()\n",
+        "    out.release()\n",
+        "    print(f\"  ✅ Saved: {os.path.basename(output_path)}\")\n",
+        "\n",
+        "\n",
+        "print(\"✅ Helper functions ready\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Q3pbJE9G7PPu"
+      },
+      "source": [
+        "---\n",
+        "## 5. Keypoint Estimation on Images\n",
+        "\n",
+        "Let's run YOLO26 pose estimation on a variety of activities — yoga, martial arts, gym workouts, walking, gymnastics, group play, and sports action — to see how the model performs across different scenarios."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 5.1 Karate\n",
+        "\n",
+        "Karate is a martial art focused on quick, controlled striking movements such as kicks, punches, and blocks. Practitioners often hold extreme stances with one leg fully raised — a great test for pose estimation under dynamic body configurations."
+      ],
+      "metadata": {
+        "id": "udB8rtbXHeea"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "image_name = \"karate.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot()  # default — boxes + labels + confidence\n",
+        "\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"output_with_box_{image_name}\")\n",
+        "cv2.imwrite(output_path, annotated)\n",
+        "display_image_inline(annotated, width=700, title=f\"YOLO26 Pose on {image_name}\")\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ],
+      "metadata": {
+        "id": "cqlZHPRiHfbe"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Beyond visualization, you can extract raw keypoint coordinates and confidence scores for downstream tasks like joint angle calculation, action classification, or fitness rep counting."
+      ],
+      "metadata": {
+        "id": "eShBnX1XHYci"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "KEYPOINT_NAMES = [\n",
+        "    \"Nose\", \"Left Eye\", \"Right Eye\", \"Left Ear\", \"Right Ear\",\n",
+        "    \"Left Shoulder\", \"Right Shoulder\", \"Left Elbow\", \"Right Elbow\",\n",
+        "    \"Left Wrist\", \"Right Wrist\", \"Left Hip\", \"Right Hip\",\n",
+        "    \"Left Knee\", \"Right Knee\", \"Left Ankle\", \"Right Ankle\"\n",
+        "]\n",
+        "\n",
+        "image_name = \"karate.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "for result in results:\n",
+        "    if result.keypoints is not None:\n",
+        "        for person_idx, kps in enumerate(result.keypoints.xy):\n",
+        "            print(f\"\\n--- Person {person_idx + 1} ---\")\n",
+        "            for i, (x, y) in enumerate(kps):\n",
+        "                if x > 0 and y > 0:\n",
+        "                    conf_score = result.keypoints.conf[person_idx][i].item()\n",
+        "                    print(f\"  {KEYPOINT_NAMES[i]:20s}: ({x:.1f}, {y:.1f})  conf={conf_score:.3f}\")"
+      ],
+      "metadata": {
+        "id": "qDmZ9-HkHjXa"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lpHJ-R367PPv"
+      },
+      "source": [
+        "### 5.2 Yoga\n",
+        "\n",
+        "Yoga is a mind-body practice involving controlled breathing and complex postures that demand exceptional flexibility, balance, and body awareness. Unusual joint configurations — inverted poses, twists, and balancing on a single limb — make it a challenging test for any pose estimator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ocaZ-o-W7PPv"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Yoga.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "original = cv2.imread(input_path)\n",
+        "results = model(original, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=False, labels=False, conf=False)\n",
+        "\n",
+        "h, w = original.shape[:2]\n",
+        "display_h = 500\n",
+        "scale = display_h / h\n",
+        "display_w = int(w * scale)\n",
+        "\n",
+        "original_resized  = cv2.resize(original,  (display_w, display_h))\n",
+        "annotated_resized = cv2.resize(annotated, (display_w, display_h))\n",
+        "\n",
+        "cv2.putText(original_resized,  \"Original Image\",         (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "cv2.putText(annotated_resized, \"YOLO26 Pose Estimation\", (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "\n",
+        "comparison = np.hstack([original_resized, annotated_resized])\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"comparison_{image_name}\")\n",
+        "cv2.imwrite(output_path, comparison)\n",
+        "display_image_inline(comparison, width=1200, title=image_name)\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RiERTgeS7PPv"
+      },
+      "source": [
+        "### 5.3 Acro Yoga\n",
+        "\n",
+        "Acro Yoga combines yoga and acrobatics with two or more partners performing balance-based poses. Multiple persons in close contact, overlapping limbs, and unusual orientations make it one of the toughest scenarios for pose estimation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XZWk5TPj7PPv"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Acro Yoga.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(\n",
+        "    boxes=False, labels=False, conf=False,\n",
+        "    line_width=3, kpt_radius=6,\n",
+        ")\n",
+        "\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"output_styled_{image_name}\")\n",
+        "cv2.imwrite(output_path, annotated)\n",
+        "display_image_inline(annotated, width=700, title=f\"YOLO26 Pose on {image_name}\")\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jHzBOiN57PPv"
+      },
+      "source": [
+        "### 5.4 Gym Workout\n",
+        "\n",
+        "Gym workouts involve repetitive movements like squats, presses, and lifts. Pose estimation here has practical value — it can be used to check exercise form, count reps, or detect imbalance between left and right sides."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "oaJZrHKC7PPw"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Gym.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "original = cv2.imread(input_path)\n",
+        "results = model(original, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=False, labels=False, conf=False)\n",
+        "\n",
+        "h, w = original.shape[:2]\n",
+        "display_h = 500\n",
+        "scale = display_h / h\n",
+        "display_w = int(w * scale)\n",
+        "\n",
+        "original_resized  = cv2.resize(original,  (display_w, display_h))\n",
+        "annotated_resized = cv2.resize(annotated, (display_w, display_h))\n",
+        "\n",
+        "cv2.putText(original_resized,  \"Original Image\",         (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "cv2.putText(annotated_resized, \"YOLO26 Pose Estimation\", (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "\n",
+        "comparison = np.hstack([original_resized, annotated_resized])\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"comparison_{image_name}\")\n",
+        "cv2.imwrite(output_path, comparison)\n",
+        "display_image_inline(comparison, width=1200, title=image_name)\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TJyGLhTr7PPw"
+      },
+      "source": [
+        "### 5.5 Walking\n",
+        "\n",
+        "Walking is the most basic human motion — a continuous gait cycle of alternating leg swings and arm counter-swings. While it looks simple, it serves as a baseline test: if pose estimation cannot reliably track walking, it cannot track anything more complex."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ZsrzFXS_7PPw"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Walk.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=False, labels=False, conf=False)\n",
+        "\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"output_{image_name}\")\n",
+        "cv2.imwrite(output_path, annotated)\n",
+        "display_image_inline(annotated, width=700, title=f\"YOLO26 Pose on {image_name}\")\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5h_YKE7a7PPw"
+      },
+      "source": [
+        "### 5.6 Gymnastics\n",
+        "\n",
+        "Gymnastics features some of the most extreme human body configurations — inverted bodies, mid-air rotations, and full-body extensions on apparatus like the rings or bars. The body orientation can be entirely flipped or twisted, often confusing keypoint estimators trained on standard upright poses."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nluPGGAK7PPw"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Gymnastics.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "original = cv2.imread(input_path)\n",
+        "results = model(original, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=False, labels=False, conf=False, line_width=3, kpt_radius=6)\n",
+        "\n",
+        "h, w = original.shape[:2]\n",
+        "display_h = 500\n",
+        "scale = display_h / h\n",
+        "display_w = int(w * scale)\n",
+        "\n",
+        "original_resized  = cv2.resize(original,  (display_w, display_h))\n",
+        "annotated_resized = cv2.resize(annotated, (display_w, display_h))\n",
+        "\n",
+        "cv2.putText(original_resized,  \"Original Image\",         (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "cv2.putText(annotated_resized, \"YOLO26 Pose Estimation\", (15, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.1, (0, 255, 0), 3)\n",
+        "\n",
+        "comparison = np.hstack([original_resized, annotated_resized])\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"comparison_{image_name}\")\n",
+        "cv2.imwrite(output_path, comparison)\n",
+        "display_image_inline(comparison, width=1200, title=image_name)\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zmK58Z6U7PPw"
+      },
+      "source": [
+        "### 5.7 Group Play\n",
+        "\n",
+        "Group play scenarios often involve multiple people interacting closely together — children playing, friends in a casual moment, or team activities. Detecting every person individually in such crowded scenes is a strong test of multi-person pose estimation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "TMlfsQ_Q7PPx"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Play.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=True, labels=False, conf=False)\n",
+        "\n",
+        "if results[0].keypoints is not None:\n",
+        "    n_people = len(results[0].keypoints.xy)\n",
+        "    print(f\"👥 Detected {n_people} person(s) in this frame\")\n",
+        "\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"output_{image_name}\")\n",
+        "cv2.imwrite(output_path, annotated)\n",
+        "display_image_inline(annotated, width=700, title=f\"YOLO26 Pose on {image_name}\")\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2BUCUWtq7PPx"
+      },
+      "source": [
+        "### 5.8 Sports Action\n",
+        "\n",
+        "Sports action shots capture fast-paced moments mid-action — a player throwing, jumping, or running. These shots often have motion blur, partial occlusions from equipment, and players in non-standard positions. A great real-world test of how robust pose estimation is for sports analytics applications."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PFDhW8r57PPx"
+      },
+      "outputs": [],
+      "source": [
+        "image_name = \"Game.jpg\"\n",
+        "input_path = os.path.join(INPUT_DIR, image_name)\n",
+        "\n",
+        "results = model(input_path, conf=0.5, verbose=False)\n",
+        "annotated = results[0].plot(boxes=False, labels=False, conf=False)\n",
+        "\n",
+        "output_path = os.path.join(IMAGE_OUTPUT, f\"output_{image_name}\")\n",
+        "cv2.imwrite(output_path, annotated)\n",
+        "display_image_inline(annotated, width=700, title=f\"YOLO26 Pose on {image_name}\")\n",
+        "print(f\"✅ Saved to: {output_path}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CyGfKafG7PPx"
+      },
+      "source": [
+        "---\n",
+        "## 6. Keypoint Estimation on Videos\n",
+        "\n",
+        "Static images are great, but pose estimation truly shines on video. Let's see how YOLO26 tracks the human skeleton through fast-paced movements like boxing, yoga, parkour, dance, and jumps."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2KgK0SpJ7PPx"
+      },
+      "source": [
+        "### 6.1 Boxing\n",
+        "\n",
+        "Boxing is a fast-paced combat sport with rapid arm movements, frequent occlusions when fists cross the body, and dynamic weight shifts. Tracking the punching arm consistently is a strong test of pose estimation under motion."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "axQMr5T67PPx"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Boxing.mp4\"\n",
+        "input_path  = os.path.join(INPUT_DIR, video_name)\n",
+        "output_path = os.path.join(VIDEO_OUTPUT, f\"output_{video_name}\")\n",
+        "\n",
+        "print(f\"--- Processing {video_name} ---\")\n",
+        "run_keypoint_on_video(input_path, output_path, conf=0.5,\n",
+        "                      plot_kwargs={'boxes': False, 'labels': False, 'conf': False})"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hdBxtYf27PPx"
+      },
+      "outputs": [],
+      "source": [
+        "display_video_inline(output_path, width=560)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vRuK4bBg7PPy"
+      },
+      "source": [
+        "### 6.2 Yoga\n",
+        "\n",
+        "Yoga in motion involves smooth transitions between asanas (poses). Each pose tests a different aspect of flexibility, balance, and stillness — all of which the model needs to track frame by frame."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nbUksCyv7PPy"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Yoga.mp4\"\n",
+        "input_path  = os.path.join(INPUT_DIR, video_name)\n",
+        "output_path = os.path.join(VIDEO_OUTPUT, f\"output_with_box_{video_name}\")\n",
+        "\n",
+        "print(f\"--- Processing {video_name} ---\")\n",
+        "run_keypoint_on_video(input_path, output_path, conf=0.5,\n",
+        "                      plot_kwargs={'boxes': True, 'labels': False, 'conf': False})"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "5k_-3Ouz7PPy"
+      },
+      "outputs": [],
+      "source": [
+        "display_video_inline(output_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "R-roLrNz7PPy"
+      },
+      "source": [
+        "### 6.3 Parkour\n",
+        "\n",
+        "Parkour involves explosive jumps, vaults, and flips through urban environments. The model has to track extreme body configurations — fully extended limbs, mid-air rotations, tucked positions — making this an extreme stress test for any pose estimator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "TwiLed2i7PPy"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Parkour.mp4\"\n",
+        "input_path  = os.path.join(INPUT_DIR, video_name)\n",
+        "output_path = os.path.join(VIDEO_OUTPUT, f\"output_styled_{video_name}\")\n",
+        "\n",
+        "print(f\"--- Processing {video_name} ---\")\n",
+        "run_keypoint_on_video(input_path, output_path, conf=0.5,\n",
+        "                      plot_kwargs={'boxes': False, 'labels': False, 'conf': False,\n",
+        "                                   'line_width': 4, 'kpt_radius': 7})"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "NhtIXFKf7PPy"
+      },
+      "outputs": [],
+      "source": [
+        "display_video_inline(output_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pNQJLhvH7PPy"
+      },
+      "source": [
+        "### 6.4 Dance\n",
+        "\n",
+        "Dance combines rhythm, style, and full-body coordination. Limbs swing in wide arcs and the body changes orientation rapidly — making it a natural fit for showing off pose estimation on creative human movement."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Koqjcubq7PPz"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Dance.mp4\"\n",
+        "input_path  = os.path.join(INPUT_DIR, video_name)\n",
+        "output_path = os.path.join(VIDEO_OUTPUT, f\"output_{video_name}\")\n",
+        "\n",
+        "cap = cv2.VideoCapture(input_path)\n",
+        "fps    = int(cap.get(cv2.CAP_PROP_FPS))\n",
+        "width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))\n",
+        "height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
+        "total  = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))\n",
+        "\n",
+        "print(f\"  Resolution: {width}x{height} @ {fps}fps | {total} frames\")\n",
+        "\n",
+        "# Output width is 2x original (two frames side by side)\n",
+        "fourcc = cv2.VideoWriter_fourcc(*\"mp4v\")\n",
+        "out = cv2.VideoWriter(output_path, fourcc, fps, (width * 2, height))\n",
+        "\n",
+        "pbar = tqdm(total=total, desc=f\"  {video_name}\",\n",
+        "            unit=\"frame\", dynamic_ncols=True, leave=True)\n",
+        "\n",
+        "while cap.isOpened():\n",
+        "    ret, frame = cap.read()\n",
+        "    if not ret:\n",
+        "        break\n",
+        "    results = model(frame, conf=0.5, verbose=False)\n",
+        "    annotated = results[0].plot(boxes=False, labels=False, conf=False)\n",
+        "\n",
+        "    original_labeled = frame.copy()\n",
+        "    cv2.putText(original_labeled, \"Original Video\", (15, 50),\n",
+        "                cv2.FONT_HERSHEY_SIMPLEX, 1.4, (0, 255, 0), 3, cv2.LINE_AA)\n",
+        "    cv2.putText(annotated, \"YOLO26 Pose Estimation\", (15, 50),\n",
+        "                cv2.FONT_HERSHEY_SIMPLEX, 1.4, (0, 255, 0), 3, cv2.LINE_AA)\n",
+        "\n",
+        "    combined = np.hstack([original_labeled, annotated])\n",
+        "    out.write(combined)\n",
+        "    pbar.update(1)\n",
+        "\n",
+        "pbar.close()\n",
+        "cap.release()\n",
+        "out.release()\n",
+        "print(f\"  ✅ Saved: {os.path.basename(output_path)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "R0GDkmV27PPz"
+      },
+      "outputs": [],
+      "source": [
+        "display_video_inline(output_path, width=960)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FtXlrw-n7PPz"
+      },
+      "source": [
+        "### 6.5 Jump\n",
+        "\n",
+        "Jumping captures the human body at moments of full extension — arms above the head, legs bent or straight, the body suspended in air with no ground contact. The body's center of gravity, posture, and limb positions all change rapidly through standing, takeoff, peak, and landing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "3pAuwci07PPz"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Jump.mp4\"\n",
+        "input_path  = os.path.join(INPUT_DIR, video_name)\n",
+        "output_path = os.path.join(VIDEO_OUTPUT, f\"output_{video_name}\")\n",
+        "\n",
+        "print(f\"--- Processing {video_name} ---\")\n",
+        "run_keypoint_on_video(input_path, output_path, conf=0.5,\n",
+        "                      plot_kwargs={'boxes': False, 'labels': False, 'conf': False})"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nHbXHOB77PPz"
+      },
+      "outputs": [],
+      "source": [
+        "display_video_inline(output_path)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rbKr-6je7PPz"
+      },
+      "source": [
+        "### 6.6 Choreography Progression\n",
+        "\n",
+        "A single frame doesn't tell the full story of a dance routine. By extracting four evenly-spaced keyframes across the video and arranging them in a 2×2 grid, we can see how the pose evolves over time — useful for choreography analysis or showing the temporal flow of a routine in a single image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "9O7IRQIM7PPz"
+      },
+      "outputs": [],
+      "source": [
+        "video_name = \"Dance 2.mp4\"\n",
+        "input_path = os.path.join(INPUT_DIR, video_name)\n",
+        "\n",
+        "cap = cv2.VideoCapture(input_path)\n",
+        "total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))\n",
+        "positions = [0.10, 0.35, 0.60, 0.85]\n",
+        "frames_annotated = []\n",
+        "\n",
+        "for pos in positions:\n",
+        "    cap.set(cv2.CAP_PROP_POS_FRAMES, int(total_frames * pos))\n",
+        "    ret, frame = cap.read()\n",
+        "    if not ret:\n",
+        "        continue\n",
+        "    results = model(frame, conf=0.5, verbose=False)\n",
+        "    annotated = results[0].plot(boxes=False, labels=False, conf=False, line_width=3, kpt_radius=5)\n",
+        "    cv2.putText(annotated, f\"t = {int(pos * 100)}%\", (15, 40),\n",
+        "                cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 255, 0), 3)\n",
+        "    frames_annotated.append(annotated)\n",
+        "\n",
+        "cap.release()\n",
+        "\n",
+        "if len(frames_annotated) == 4:\n",
+        "    h = 350\n",
+        "    resized = []\n",
+        "    for f in frames_annotated:\n",
+        "        fh, fw = f.shape[:2]\n",
+        "        scale = h / fh\n",
+        "        resized.append(cv2.resize(f, (int(fw * scale), h)))\n",
+        "    min_w = min(f.shape[1] for f in resized)\n",
+        "    resized = [f[:, :min_w] for f in resized]\n",
+        "    top    = np.hstack([resized[0], resized[1]])\n",
+        "    bottom = np.hstack([resized[2], resized[3]])\n",
+        "    grid   = np.vstack([top, bottom])\n",
+        "    grid_path = os.path.join(VIDEO_OUTPUT, f\"keyframes_{video_name.replace('.mp4', '.jpg')}\")\n",
+        "    cv2.imwrite(grid_path, grid)\n",
+        "    display_image_inline(grid, width=1200, title=f\"Pose progression in {video_name}\")\n",
+        "    print(f\"✅ Saved keyframe grid to: {grid_path}\")\n",
+        "else:\n",
+        "    print(f\"❌ Could only extract {len(frames_annotated)} frames\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "T2fFJD1k7PP0"
+      },
+      "source": [
+        "---\n",
+        "## 7. COCO Keypoint Reference\n",
+        "\n",
+        "| Index | Keypoint | Index | Keypoint |\n",
+        "|-------|----------|-------|----------|\n",
+        "| 0 | Nose | 9 | Left Wrist |\n",
+        "| 1 | Left Eye | 10 | Right Wrist |\n",
+        "| 2 | Right Eye | 11 | Left Hip |\n",
+        "| 3 | Left Ear | 12 | Right Hip |\n",
+        "| 4 | Right Ear | 13 | Left Knee |\n",
+        "| 5 | Left Shoulder | 14 | Right Knee |\n",
+        "| 6 | Right Shoulder | 15 | Left Ankle |\n",
+        "| 7 | Left Elbow | 16 | Right Ankle |\n",
+        "| 8 | Right Elbow | | |"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6WkjyfWa7PP0"
+      },
+      "source": [
+        "---\n",
+        "## Summary\n",
+        "\n",
+        "We implemented YOLO26 keypoint estimation on **8 images** and **6 videos** with multiple visualization styles.\n",
+        "\n",
+        "### What makes YOLO26 special?\n",
+        "- **RLE (Residual Log-Likelihood Estimation)** for accurate keypoint localization\n",
+        "- **End-to-end NMS-free inference** for faster deployment\n",
+        "- **Up to 43% faster CPU inference** vs predecessors\n",
+        "- **Non-human keypoint support** — works beyond human poses\n",
+        "\n",
+        "### References\n",
+        "- [Ultralytics YOLO26 Documentation](https://docs.ultralytics.com/models/yolo26/)\n",
+        "- [Pose Estimation Docs](https://docs.ultralytics.com/tasks/pose/)\n",
+        "- [YOLO26: An Analysis of NMS-Free End-to-End Framework for Real-Time Object Detection](https://arxiv.org/abs/2601.12882)\n",
+        "- [LearnOpenCV Blog](https://learnopencv.com/)"
+      ]
+    }
+  ]
+}

--- a/YOLO26_Keypoint_Estimation/readme.md
+++ b/YOLO26_Keypoint_Estimation/readme.md
@@ -1,0 +1,79 @@
+# YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics
+
+**This repository contains the code for [YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics](https://learnopencv.com/) blog post.**
+![YOLO26 Keypoint Estimation](https://learnopencv.com/wp-content/uploads/2026/04/yolo26-keypoint-hero.jpg)
+---
+
+## Overview
+
+This notebook demonstrates how to perform **real-time human pose estimation** using the **YOLO26** pose model from Ultralytics. YOLO26 builds on the YOLO family with several innovations targeted at keypoint estimation:
+
+- **Residual Log-Likelihood Estimation (RLE)** for more accurate keypoint localization
+- **End-to-end NMS-free inference** for predictable low-latency deployment
+- **MuSGD optimizer** (SGD + Muon) for more stable training
+- **Up to 43% faster CPU inference** compared to YOLO11
+- **17 COCO keypoints** detected out of the box, plus support for custom non-human keypoints
+
+## What's Covered
+
+The notebook walks through pose estimation on **8 images** and **6 videos** spanning a range of real-world activities:
+
+| Images | Videos |
+|---|---|
+| Yoga, Karate, Acro Yoga, Gym Workout, Walking, Gymnastics, Group Play, Sports Action | Boxing, Yoga, Parkour, Dance (side-by-side), Jump, Dance 2 (keyframe progression) |
+
+
+## Model Variants
+
+| Model | Params (M) | FLOPs (B) | mAP₅₀₋₉₅ (Pose) | T4 TensorRT (ms) |
+|---|---:|---:|---:|---:|
+| yolo26n-pose | 2.9 | 7.5 | 57.2 | 1.8 |
+| yolo26s-pose | 10.4 | 23.9 | 63.0 | 2.7 |
+| yolo26m-pose | 21.5 | 73.1 | 68.8 | 5.0 |
+| yolo26l-pose | 25.9 | 91.3 | 70.4 | 6.5 |
+| yolo26x-pose | 57.6 | 201.7 | 71.6 | 12.2 |
+
+*Benchmarks on COCO Keypoints val2017 at 640×640.*
+
+## How to Run
+
+### Option 1 — Google Colab (recommended)
+
+Click the **Open in Colab** badge above and run the cells top-to-bottom. Input images and videos are downloaded automatically from a public GitHub release, so no Google Drive or authentication is required.
+
+### Option 2 — Local Jupyter
+
+```bash
+git clone https://github.com/spmallick/learnopencv.git
+cd learnopencv/YOLO26_Keypoint_Estimation
+pip install ultralytics
+jupyter notebook YOLO26_Keypoint_Estimation.ipynb
+```
+
+## Input Files
+
+Sample inputs are distributed as a single zip in a public GitHub release:
+
+```
+https://github.com/spmallick/learnopencv/releases/download/YOLO26_Keypoint_Estimation/YOLO26_Keypoint_Estimation.zip
+```
+
+The notebook downloads and extracts it automatically into `./yolo26_workspace/inputs/`.
+
+---
+
+## AI Courses by OpenCV
+
+Want to become an expert in AI? [AI Courses by OpenCV](https://opencv.org/courses/) is a great place to start.
+
+<a href="https://opencv.org/courses/">
+<p align="center">
+<img src="https://learnopencv.com/wp-content/uploads/2023/01/AI-Courses-By-OpenCV-Github.png">
+</p>
+</a>
+
+## Connect with us
+
+- [Website](https://www.learnopencv.com/)
+- [YouTube](https://www.youtube.com/@LearnOpenCV)
+- [GitHub](https://github.com/spmallick/learnopencv)

--- a/YOLO26_Keypoint_Estimation/readme.md
+++ b/YOLO26_Keypoint_Estimation/readme.md
@@ -1,7 +1,8 @@
 # YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics
 
 **This repository contains the code for [YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics](https://learnopencv.com/) blog post.**
-![YOLO26 Keypoint Estimation](https://learnopencv.com/wp-content/uploads/2026/04/yolo26-keypoint-hero.jpg)
+
+![YOLO26 Keypoint Estimation](https://learnopencv.s3.us-west-2.amazonaws.com/wp-content/uploads/2026/04/16114728/play.png)
 ---
 
 ## Overview
@@ -39,7 +40,6 @@ The notebook walks through pose estimation on **8 images** and **6 videos** span
 
 ### Option 1 — Google Colab (recommended)
 
-Click the **Open in Colab** badge above and run the cells top-to-bottom. Input images and videos are downloaded automatically from a public GitHub release, so no Google Drive or authentication is required.
 
 ### Option 2 — Local Jupyter
 


### PR DESCRIPTION
## Summary

Adds the notebook and README for the blog post: **YOLO26 Keypoint Estimation: Real-Time Pose Estimation with Ultralytics**.

## What's added

- `YOLO26_Keypoint_Estimation/YOLO26_Keypoint_Estimation.ipynb` — end-to-end Colab notebook covering:
  - Installation & workspace setup
  - Downloading sample inputs from a public GitHub release (no Drive/auth required)
  - Model variant selection (nano → x-large)
  - Keypoint estimation on **8 images** (Yoga, Karate, Acro Yoga, Gym, Walking, Gymnastics, Group Play, Sports Action) with multiple visualization styles
  - Keypoint estimation on **6 videos** (Boxing, Yoga, Parkour, Dance side-by-side, Jump, Dance 2 keyframe grid)
  - Programmatic access to raw keypoint coordinates
  - COCO keypoint reference table
- `YOLO26_Keypoint_Estimation/README.md` — folder-level README with overview, model variants, benchmarks, and run instructions