### PR TITLE
Add Moondream Cloud API code and update README blog links

### DIFF
--- a/Moondream-Cloud-API/readme.md
+++ b/Moondream-Cloud-API/readme.md
@@ -1,8 +1,8 @@
 # Moondream Cloud API: One Image, Five Grounded Vision Skills
 
-**This folder contains the Jupyter Notebook for the LearnOpenCV blog post [How to Unlock 5 Vision Skills with the Moondream Cloud API](<BLOG_POST_URL>).**
+**This folder contains the Jupyter Notebook for the LearnOpenCV blog post [How to Unlock 5 Vision Skills with the Moondream Cloud API](https://learnopencv.com/moondream-cloud-api-one-image-five-grounded-vision-skills/).**
 
-[<img src="Moondream_Thumbnail.jpg" alt="Moondream Cloud API thumbnail" width="900">](<BLOG_POST_URL>)
+[<img src="Moondream_Thumbnail.jpg" alt="Moondream Cloud API thumbnail" width="900">](https://learnopencv.com/moondream-cloud-api-one-image-five-grounded-vision-skills/)
 
 In `Moondream3.ipynb`, we run all five Moondream Cloud skills on a single image of three children in costume:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Want to become an expert in AI? [AI Courses by OpenCV](https://opencv.org/course
 
 | Blog Post | Code|
 | ------------- |:-------------|
+| [How to Unlock 5 Vision Skills with the Moondream Cloud API](https://learnopencv.com/moondream-cloud-api-one-image-five-grounded-vision-skills/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Moondream-Cloud-API) |
+| [JEE Advanced 2026: We Tested AI on the Toughest Exam](https://learnopencv.com/jee-advanced-2026-we-tested-ai-on-the-toughest-exam/) | |
 | [How to Master Qwen3-VL Embedding and Reranker for Multimodal Search](https://learnopencv.com/how-to-master-qwen3-vl-embedding-and-reranker-for-multimodal-search/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Qwen3-VL-Embedding-Reranker) |
 | [How to Master YOLOE: Real-Time Open-Vocabulary Detection Made Easy](https://learnopencv.com/yoloe-tutorial-real-time-open-vocabulary-detection/) | [Code](https://github.com/spmallick/learnopencv/tree/master/YOLOE-Real-Time-Seeing-Anything) |
 | [Vision Banana: How Image Generators Are Becoming Powerful Vision Models](https://learnopencv.com/vision-banana-explained/) | |


### PR DESCRIPTION
This PR adds the code for the LearnOpenCV blog post **How to Unlock 5 Vision Skills with the Moondream Cloud API**, and updates the main README with the new blog and code links.

### Added
- `Moondream-Cloud-API/` — Jupyter notebook demonstrating all five Moondream Cloud skills (`caption`, `query`, `detect`, `point`, `segment`) on a single image, plus its README and thumbnail

### Updated README links
- **How to Unlock 5 Vision Skills with the Moondream Cloud API** — [Blog](https://learnopencv.com/moondream-cloud-api-one-image-five-grounded-vision-skills/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Moondream-Cloud-API)
- **JEE Advanced 2026: We Tested AI on the Toughest Exam** — [Blog](https://learnopencv.com/jee-advanced-2026-we-tested-ai-on-the-toughest-exam/) (no code)
