### PR TITLE
Upgrade Find Contours examples for OpenCV 4 and 5

### DIFF
--- a/Contour-Detection-using-OpenCV/README.md
+++ b/Contour-Detection-using-OpenCV/README.md
@@ -9,7 +9,7 @@
 **All the code files and folders follow the following structure.**
 
 ```
-├── CPP
+├── cpp
 │   ├── channel_experiments
 │   │   ├── channel_experiments.cpp
 │   │   └── CMakeLists.txt
@@ -28,51 +28,107 @@
 │   │   └── channel_experiments.py
 │   ├── contour_approximations
 │   │   └── contour_approx.py
-│   └── contour_extraction
-│       └── contour_extraction.py
+│   ├── contour_extraction
+│   │   └── contour_extraction.py
+│   ├── tests
+│   │   └── test_examples.py
+│   └── requirements.txt
 └── README.md
 ```
 
 
 
+## Requirements
+
+The examples support OpenCV 4.x and OpenCV 5.x. Python requires Python 3.9 or
+newer. The C++ examples use C++17 and CMake 3.16 or newer.
+
 ## Instructions
 
 ### Python
 
-To run the code in Python, please go into the `python` folder and execute the Python scripts in each of the respective sub-folders.
+Install a supported OpenCV version and run each example from the repository
+directory. Input paths are resolved from the script location, so the commands
+also work from another current directory.
+
+```shell
+python3 -m pip install -r python/requirements.txt
+python3 python/channel_experiments/channel_experiments.py
+python3 python/contour_approximations/contour_approx.py
+python3 python/contour_extraction/contour_extraction.py
+```
+
+Every Python example accepts `--no-display` for headless environments,
+`--output-dir PATH`, and `--validate` for regression checks. Run the complete
+Python regression suite with:
+
+```shell
+python3 -m unittest discover -s python/tests -v
+```
+
+Use `--input PATH` to override the image for the channel and retrieval-mode
+examples. The approximation example accepts `--image1 PATH --image2 PATH`.
 
 ### C++
 
-To run the code in C++, please go into the `cpp` folder, then go into each of the respective sub-folders and follow the steps below:
+Configure, build, and test each C++ example independently. For example:
 
-```
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release
-cd ..
-./build/channel_experiments
-```
-
-```
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release
-cd ..
-./build/contour_approximations
+```shell
+cmake -S cpp/channel_experiments -B cpp/channel_experiments/build \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build cpp/channel_experiments/build --config Release
+ctest --test-dir cpp/channel_experiments/build --output-on-failure
+./cpp/channel_experiments/build/channel_experiments
 ```
 
-```
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release
-cd ..
-./build/contour_extraction
+Replace `channel_experiments` with `contour_approximations` or
+`contour_extraction` for the other examples. The executables support the same
+`--no-display`, `--output-dir`, and `--validate` options as their Python
+counterparts.
+
+To select a particular OpenCV installation, pass its package directory while
+configuring:
+
+```shell
+cmake -S cpp/contour_extraction -B cpp/contour_extraction/build \
+  -DOpenCV_DIR=/path/to/opencv/lib/cmake/opencv5
 ```
 
+### `findContours` performance in OpenCV 4.14 and 5
 
+OpenCV 4.14 introduced the parallel TRUCO implementation that is also used by
+OpenCV 5. It is selected for an 8-bit single-channel input with `RETR_LIST`
+when hierarchy output is not requested. The four-argument C++ overload makes
+that explicit:
+
+```cpp
+std::vector<std::vector<cv::Point>> contours;
+cv::findContours(binary, contours, cv::RETR_LIST,
+                 cv::CHAIN_APPROX_SIMPLE);
+```
+
+Passing `cv::noArray()` as the hierarchy output to the hierarchy-accepting
+overload also leaves hierarchy unrequested and can select the same fast path.
+
+The tutorial examples intentionally request hierarchy or use another retrieval
+mode while explaining contour relationships, so changing those calls would
+change their documented behavior. The current Python binding also returns
+hierarchy and does not expose the no-hierarchy fast path.
+
+In Release builds on an Apple M5 Pro, the no-hierarchy overload was about
+1.3–1.6 times as fast as the hierarchy-producing overload on the two tutorial
+images. OpenCV 4.14 and 5 had essentially the same fast-path performance because
+both contain TRUCO. On a 6-core/12-thread Intel Core i7-6850K Linux machine, the
+same comparison was about 2.7–3.0 times with the default 12-thread pthreads
+backend and 1.38–1.50 times in a single-thread sensitivity run. This spread is
+why the result must be treated as platform- and workload-specific; benchmark the
+exact call on your deployment hardware. See the
+[current `findContours` API documentation](https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html)
+for the activation conditions, and the
+[TRUCO implementation pull request](https://github.com/opencv/opencv/pull/28773)
+for its development history and original benchmark discussion. The benchmark
+fixtures produced the same contour sets, but outer-vector ordering is not an API
+guarantee; sort or match contours explicitly when order matters.
 
 ---
 

--- a/Contour-Detection-using-OpenCV/cpp/channel_experiments/CMakeLists.txt
+++ b/Contour-Detection-using-OpenCV/cpp/channel_experiments/CMakeLists.txt
@@ -1,20 +1,30 @@
-cmake_minimum_required(VERSION 3.0.0)
-project(channel_experiments VERSION 0.1.0)
+cmake_minimum_required(VERSION 3.16)
+project(channel_experiments LANGUAGES CXX)
 
-include(CTest)
-enable_testing()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(OpenCV REQUIRED)
-find_package(Threads REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc)
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR "This example supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}")
+endif()
 
 add_executable(channel_experiments channel_experiments.cpp)
+target_include_directories(channel_experiments PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(channel_experiments PRIVATE ${OpenCV_LIBS})
+target_compile_definitions(
+  channel_experiments PRIVATE TUTORIAL_INPUT_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../input"
+)
 
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX__STANDARD_REQUIRED ON)
-
-include_directories(${OpenCV_INCLUDE_DIRS})
-target_link_libraries(channel_experiments ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+include(CTest)
+if(BUILD_TESTING)
+  add_test(
+    NAME channel_experiments_regression
+    COMMAND channel_experiments --no-display --validate
+            --output-dir "${CMAKE_CURRENT_BINARY_DIR}/test-output"
+  )
+  set_tests_properties(
+    channel_experiments_regression PROPERTIES PASS_REGULAR_EXPRESSION "Validation passed"
+  )
+endif()

--- a/Contour-Detection-using-OpenCV/cpp/channel_experiments/channel_experiments.cpp
+++ b/Contour-Detection-using-OpenCV/cpp/channel_experiments/channel_experiments.cpp
@@ -1,50 +1,106 @@
-#include<opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <array>
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
-using namespace std;
-using namespace cv;
+#ifndef TUTORIAL_INPUT_DIR
+#define TUTORIAL_INPUT_DIR "../../input"
+#endif
 
-int main() {
-    // read the image
-    Mat image = imread("../../input/image_1.jpg");
+namespace fs = std::filesystem;
 
-    // B, G, R channel splitting
-    Mat channels[3];
-    split(image, channels);
+struct Options {
+    fs::path input = fs::path(TUTORIAL_INPUT_DIR) / "image_1.jpg";
+    fs::path output_dir = fs::current_path();
+    bool display = true;
+    bool validate = false;
+};
 
-    // detect contours using blue channel and without thresholding
-    vector<vector<Point>> contours1;
-    vector<Vec4i> hierarchy1;
-    findContours(channels[0], contours1, hierarchy1, RETR_TREE, CHAIN_APPROX_NONE);
-    // draw contours on the original image
-    Mat image_contour_blue = image.clone();
-    drawContours(image_contour_blue, contours1, -1, Scalar(0, 255, 0), 2);
-    imshow("Contour detection using blue channels only", image_contour_blue);
-    waitKey(0);
-    imwrite("blue_channel.jpg", image_contour_blue);
-    destroyAllWindows();
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string argument = argv[i];
+        if ((argument == "--input" || argument == "--output-dir") && i + 1 >= argc) {
+            throw std::invalid_argument(argument + " requires a path");
+        }
+        if (argument == "--input") {
+            options.input = argv[++i];
+        } else if (argument == "--output-dir") {
+            options.output_dir = argv[++i];
+        } else if (argument == "--no-display") {
+            options.display = false;
+        } else if (argument == "--validate") {
+            options.validate = true;
+        } else {
+            throw std::invalid_argument("Unknown argument: " + argument);
+        }
+    }
+    return options;
+}
 
-    // detect contours using green channel and without thresholding
-    vector<vector<Point>> contours2;
-    vector<Vec4i> hierarchy2;
-    findContours(channels[1], contours2, hierarchy2, RETR_TREE, CHAIN_APPROX_NONE);
-    // draw contours on the original image
-    Mat image_contour_green = image.clone();
-    drawContours(image_contour_green, contours2, -1, Scalar(0, 255, 0), 2);
-    imshow("Contour detection using green channels only", image_contour_green);
-    waitKey(0);
-    imwrite("green_channel.jpg", image_contour_green);
-    destroyAllWindows();
+void show_image(const std::string& title, const cv::Mat& image, bool display) {
+    if (display) {
+        cv::imshow(title, image);
+        cv::waitKey(0);
+        cv::destroyAllWindows();
+    }
+}
 
-    // detect contours using red channel and without thresholding
-    vector<vector<Point>> contours3;
-    vector<Vec4i> hierarchy3;
-    findContours(channels[2], contours3, hierarchy3, RETR_TREE, CHAIN_APPROX_NONE);
-    // draw contours on the original image
-    Mat image_contour_red = image.clone();
-    drawContours(image_contour_red, contours3, -1, Scalar(0, 255, 0), 2);
-    imshow("Contour detection using red channels only", image_contour_red);
-    waitKey(0);
-    imwrite("red_channel.jpg", image_contour_red);
-    destroyAllWindows();
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        const cv::Mat image = cv::imread(options.input.string());
+        if (image.empty()) {
+            throw std::runtime_error("Could not read input image: " + options.input.string());
+        }
+        fs::create_directories(options.output_dir);
+
+        std::vector<cv::Mat> channels;
+        cv::split(image, channels);
+        const std::array<std::string, 3> names{"blue", "green", "red"};
+        std::array<std::size_t, 3> counts{};
+
+        for (std::size_t index = 0; index < names.size(); ++index) {
+            std::vector<std::vector<cv::Point>> contours;
+            std::vector<cv::Vec4i> hierarchy;
+            cv::findContours(
+                channels[index].clone(), contours, hierarchy, cv::RETR_TREE,
+                cv::CHAIN_APPROX_NONE
+            );
+
+            cv::Mat rendered = image.clone();
+            cv::drawContours(
+                rendered, contours, -1, cv::Scalar(0, 255, 0), 2, cv::LINE_AA
+            );
+            show_image("Contours from the " + names[index] + " channel", rendered,
+                       options.display);
+
+            const fs::path output = options.output_dir / (names[index] + "_channel.jpg");
+            if (!cv::imwrite(output.string(), rendered)) {
+                throw std::runtime_error("Could not write output image: " + output.string());
+            }
+            counts[index] = contours.size();
+            std::cout << names[index] << ": contours=" << contours.size() << '\n';
+        }
+
+        if (options.validate) {
+            if (!(counts[0] > 0 && counts[0] < counts[1] && counts[1] < counts[2])) {
+                throw std::runtime_error(
+                    "Expected the bundled image to produce 0 < blue < green < red contours"
+                );
+            }
+            std::cout << "Validation passed\n";
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return 1;
+    }
 }

--- a/Contour-Detection-using-OpenCV/cpp/contour_approximations/CMakeLists.txt
+++ b/Contour-Detection-using-OpenCV/cpp/contour_approximations/CMakeLists.txt
@@ -1,21 +1,30 @@
-cmake_minimum_required(VERSION 3.0.0)
-project(contour_approximations VERSION 0.1.0)
+cmake_minimum_required(VERSION 3.16)
+project(contour_approximations LANGUAGES CXX)
 
-include(CTest)
-enable_testing()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-
-find_package(OpenCV REQUIRED)
-find_package(Threads REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc)
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR "This example supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}")
+endif()
 
 add_executable(contour_approximations contour_approx.cpp)
+target_include_directories(contour_approximations PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(contour_approximations PRIVATE ${OpenCV_LIBS})
+target_compile_definitions(
+  contour_approximations PRIVATE TUTORIAL_INPUT_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../input"
+)
 
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX__STANDARD_REQUIRED ON)
-
-include_directories(${OpenCV_INCLUDE_DIRS})
-target_link_libraries(contour_approximations ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+include(CTest)
+if(BUILD_TESTING)
+  add_test(
+    NAME contour_approximations_regression
+    COMMAND contour_approximations --no-display --validate
+            --output-dir "${CMAKE_CURRENT_BINARY_DIR}/test-output"
+  )
+  set_tests_properties(
+    contour_approximations_regression PROPERTIES PASS_REGULAR_EXPRESSION "Validation passed"
+  )
+endif()

--- a/Contour-Detection-using-OpenCV/cpp/contour_approximations/contour_approx.cpp
+++ b/Contour-Detection-using-OpenCV/cpp/contour_approximations/contour_approx.cpp
@@ -1,73 +1,165 @@
-#include<opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
-using namespace std;
-using namespace cv;
+#ifndef TUTORIAL_INPUT_DIR
+#define TUTORIAL_INPUT_DIR "../../input"
+#endif
 
-int main() {
-    // read the image
-    Mat image = imread("../../input/image_1.jpg");
-    // convert the image to grayscale format
-    Mat img_gray;
-    cvtColor(image, img_gray, COLOR_BGR2GRAY);
-    // apply binary thresholding
-    Mat thresh;
-    threshold(img_gray, thresh, 150, 255, THRESH_BINARY);
-    imshow("Binary mage", thresh);
-    waitKey(0);
-    imwrite("image_thres1.jpg", thresh);
-    destroyAllWindows();
+namespace fs = std::filesystem;
 
-    // detect the contours on the binary image using cv2.CHAIN_APPROX_NONE
-    vector<vector<Point>> contours;
-    vector<Vec4i> hierarchy;
-    findContours(thresh, contours, hierarchy, RETR_TREE, CHAIN_APPROX_NONE);
-    // draw contours on the original image
-    Mat image_copy = image.clone();
-    drawContours(image_copy, contours, -1, Scalar(0, 255, 0), 2);
-    imshow("None approximation", image_copy);
-    waitKey(0);
-    imwrite("contours_none_image1.jpg", image_copy);
-    destroyAllWindows();
+struct Options {
+    fs::path image1 = fs::path(TUTORIAL_INPUT_DIR) / "image_1.jpg";
+    fs::path image2 = fs::path(TUTORIAL_INPUT_DIR) / "image_2.jpg";
+    fs::path output_dir = fs::current_path();
+    bool display = true;
+    bool validate = false;
+};
 
-
-    // Now let's try with CHAIN_APPROX_SIMPLE`
-    // detect the contours on the binary image using cv2.CHAIN_APPROX_NONE
-    vector<vector<Point>> contours1;
-    vector<Vec4i> hierarchy1;
-    findContours(thresh, contours1, hierarchy1, RETR_TREE, CHAIN_APPROX_SIMPLE);
-    // draw contours on the original image
-    Mat image_copy1 = image.clone();
-    drawContours(image_copy1, contours1, -1, Scalar(0, 255, 0), 2);
-    imshow("Simple approximation", image_copy1);
-    waitKey(0);
-    imwrite("contours_simple_image1.jpg", image_copy1);
-    destroyAllWindows();
-
-    // using a proper image for visualizing CHAIN_APPROX_SIMPLE
-    Mat image1 = imread("../../input/image_2.jpg");
-    Mat img_gray1;
-    cvtColor(image1, img_gray1, COLOR_BGR2GRAY);
-    Mat thresh1;
-    threshold(img_gray1, thresh1, 150, 255, THRESH_BINARY);
-    vector<vector<Point>> contours2;
-    vector<Vec4i> hierarchy2;
-    findContours(thresh1, contours2, hierarchy2, RETR_TREE, CHAIN_APPROX_NONE);
-    Mat image_copy2 = image1.clone();
-    drawContours(image_copy2, contours2, -1, Scalar(0, 255, 0), 2);
-    imshow("None approximation", image_copy2);
-    waitKey(0);
-    imwrite("contours_none_image1.jpg", image_copy2);
-    destroyAllWindows();
-    Mat image_copy3 = image1.clone();
-    for(int i=0; i<contours2.size(); i=i+1){
-        for (int j=0; j<contours2[i].size(); j=j+1){
-            circle(image_copy3, (contours2[i][0], contours2[i][1]), 2, 
-            Scalar(0, 255, 0), 2);
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string argument = argv[i];
+        if ((argument == "--image1" || argument == "--image2" ||
+             argument == "--output-dir") && i + 1 >= argc) {
+            throw std::invalid_argument(argument + " requires a path");
+        }
+        if (argument == "--image1") {
+            options.image1 = argv[++i];
+        } else if (argument == "--image2") {
+            options.image2 = argv[++i];
+        } else if (argument == "--output-dir") {
+            options.output_dir = argv[++i];
+        } else if (argument == "--no-display") {
+            options.display = false;
+        } else if (argument == "--validate") {
+            options.validate = true;
+        } else {
+            throw std::invalid_argument("Unknown argument: " + argument);
         }
     }
-    imshow("CHAIN_APPROX_SIMPLE Point only", image_copy3);
-    waitKey(0);
-    imwrite("contour_point_simple.jpg", image_copy3);
-    destroyAllWindows();
+    return options;
+}
+
+cv::Mat read_image(const fs::path& path) {
+    cv::Mat image = cv::imread(path.string());
+    if (image.empty()) {
+        throw std::runtime_error("Could not read input image: " + path.string());
+    }
+    return image;
+}
+
+void show_image(const std::string& title, const cv::Mat& image, bool display) {
+    if (display) {
+        cv::imshow(title, image);
+        cv::waitKey(0);
+        cv::destroyAllWindows();
+    }
+}
+
+void write_image(const fs::path& path, const cv::Mat& image) {
+    if (!cv::imwrite(path.string(), image)) {
+        throw std::runtime_error("Could not write output image: " + path.string());
+    }
+}
+
+std::vector<std::vector<cv::Point>> find_binary_contours(
+    const cv::Mat& image, int method, cv::Mat* threshold_output = nullptr
+) {
+    cv::Mat gray;
+    cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
+    cv::Mat threshold_image;
+    cv::threshold(gray, threshold_image, 150, 255, cv::THRESH_BINARY);
+    std::vector<std::vector<cv::Point>> contours;
+    std::vector<cv::Vec4i> hierarchy;
+    cv::findContours(threshold_image.clone(), contours, hierarchy, cv::RETR_TREE, method);
+    if (threshold_output != nullptr) {
+        *threshold_output = threshold_image;
+    }
+    return contours;
+}
+
+std::size_t point_count(const std::vector<std::vector<cv::Point>>& contours) {
+    std::size_t total = 0;
+    for (const auto& contour : contours) {
+        total += contour.size();
+    }
+    return total;
+}
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        fs::create_directories(options.output_dir);
+
+        const cv::Mat image1 = read_image(options.image1);
+        cv::Mat threshold_image;
+        const auto contours_none =
+            find_binary_contours(image1, cv::CHAIN_APPROX_NONE, &threshold_image);
+        const auto contours_simple = find_binary_contours(image1, cv::CHAIN_APPROX_SIMPLE);
+
+        show_image("Binary image", threshold_image, options.display);
+        write_image(options.output_dir / "image_thres1.jpg", threshold_image);
+
+        cv::Mat none_rendered = image1.clone();
+        cv::drawContours(
+            none_rendered, contours_none, -1, cv::Scalar(0, 255, 0), 2, cv::LINE_AA
+        );
+        show_image("None approximation", none_rendered, options.display);
+        write_image(options.output_dir / "contours_none_image1.jpg", none_rendered);
+
+        cv::Mat simple_rendered = image1.clone();
+        cv::drawContours(
+            simple_rendered, contours_simple, -1, cv::Scalar(0, 255, 0), 2, cv::LINE_AA
+        );
+        show_image("Simple approximation", simple_rendered, options.display);
+        write_image(options.output_dir / "contours_simple_image1.jpg", simple_rendered);
+
+        const cv::Mat image2 = read_image(options.image2);
+        const auto image2_contours = find_binary_contours(image2, cv::CHAIN_APPROX_SIMPLE);
+        cv::Mat image2_rendered = image2.clone();
+        cv::drawContours(
+            image2_rendered, image2_contours, -1, cv::Scalar(0, 255, 0), 2,
+            cv::LINE_AA
+        );
+        show_image("SIMPLE approximation contours", image2_rendered, options.display);
+        write_image(options.output_dir / "contours_simple_image2.jpg", image2_rendered);
+
+        cv::Mat points_only = image2.clone();
+        for (const auto& contour : image2_contours) {
+            for (const cv::Point& point : contour) {
+                cv::circle(points_only, point, 2, cv::Scalar(0, 255, 0), 2, cv::LINE_AA);
+            }
+        }
+        show_image("CHAIN_APPROX_SIMPLE points", points_only, options.display);
+        write_image(options.output_dir / "contour_point_simple.jpg", points_only);
+
+        const std::size_t none_points = point_count(contours_none);
+        const std::size_t simple_points = point_count(contours_simple);
+        std::cout << "none_contours=" << contours_none.size()
+                  << ", none_points=" << none_points
+                  << ", simple_contours=" << contours_simple.size()
+                  << ", simple_points=" << simple_points
+                  << ", image2_simple_contours=" << image2_contours.size()
+                  << ", image2_simple_points=" << point_count(image2_contours) << '\n';
+
+        if (options.validate) {
+            if (contours_none.size() != contours_simple.size() ||
+                simple_points >= none_points || image2_contours.empty()) {
+                throw std::runtime_error("Contour approximation validation failed");
+            }
+            std::cout << "Validation passed\n";
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return 1;
+    }
 }

--- a/Contour-Detection-using-OpenCV/cpp/contour_extraction/CMakeLists.txt
+++ b/Contour-Detection-using-OpenCV/cpp/contour_extraction/CMakeLists.txt
@@ -1,20 +1,30 @@
-cmake_minimum_required(VERSION 3.0.0)
-project(contour_extraction VERSION 0.1.0)
+cmake_minimum_required(VERSION 3.16)
+project(contour_extraction LANGUAGES CXX)
 
-include(CTest)
-enable_testing()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(OpenCV REQUIRED)
-find_package(Threads REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc)
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR "This example supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}")
+endif()
 
 add_executable(contour_extraction contour_extraction.cpp)
+target_include_directories(contour_extraction PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(contour_extraction PRIVATE ${OpenCV_LIBS})
+target_compile_definitions(
+  contour_extraction PRIVATE TUTORIAL_INPUT_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../input"
+)
 
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX__STANDARD_REQUIRED ON)
-
-include_directories(${OpenCV_INCLUDE_DIRS})
-target_link_libraries(contour_extraction ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+include(CTest)
+if(BUILD_TESTING)
+  add_test(
+    NAME contour_extraction_regression
+    COMMAND contour_extraction --no-display --validate
+            --output-dir "${CMAKE_CURRENT_BINARY_DIR}/test-output"
+  )
+  set_tests_properties(
+    contour_extraction_regression PROPERTIES PASS_REGULAR_EXPRESSION "Validation passed"
+  )
+endif()

--- a/Contour-Detection-using-OpenCV/cpp/contour_extraction/contour_extraction.cpp
+++ b/Contour-Detection-using-OpenCV/cpp/contour_extraction/contour_extraction.cpp
@@ -1,57 +1,118 @@
-#include<opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <array>
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
-using namespace std;
-using namespace cv;
+#ifndef TUTORIAL_INPUT_DIR
+#define TUTORIAL_INPUT_DIR "../../input"
+#endif
 
-int main() {
-    /*
-    Contour detection and drawing using different extraction modes to complement 
-    the understanding of hierarchies
-    */
-    Mat image2 = imread("../../input/custom_colors.jpg");
-    Mat img_gray2;
-    cvtColor(image2, img_gray2, COLOR_BGR2GRAY);
-    Mat thresh2;
-    threshold(img_gray2, thresh2, 150, 255, THRESH_BINARY);
+namespace fs = std::filesystem;
 
-    vector<vector<Point>> contours3;
-    vector<Vec4i> hierarchy3;
-    findContours(thresh2, contours3, hierarchy3, RETR_LIST, CHAIN_APPROX_NONE);
-    Mat image_copy4 = image2.clone();
-    drawContours(image_copy4, contours3, -1, Scalar(0, 255, 0), 2);
-    imshow("LIST", image_copy4);
-    waitKey(0);
-    imwrite("contours_retr_list.jpg", image_copy4);
-    destroyAllWindows();
+struct Options {
+    fs::path input = fs::path(TUTORIAL_INPUT_DIR) / "custom_colors.jpg";
+    fs::path output_dir = fs::current_path();
+    bool display = true;
+    bool validate = false;
+};
 
-    vector<vector<Point>> contours4;
-    vector<Vec4i> hierarchy4;
-    findContours(thresh2, contours4, hierarchy4, RETR_EXTERNAL, CHAIN_APPROX_NONE);
-    Mat image_copy5 = image2.clone();
-    drawContours(image_copy5, contours4, -1, Scalar(0, 255, 0), 2);
-    imshow("EXTERNAL", image_copy5);
-    waitKey(0);
-    imwrite("contours_retr_external.jpg", image_copy4);
-    destroyAllWindows();
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string argument = argv[i];
+        if ((argument == "--input" || argument == "--output-dir") && i + 1 >= argc) {
+            throw std::invalid_argument(argument + " requires a path");
+        }
+        if (argument == "--input") {
+            options.input = argv[++i];
+        } else if (argument == "--output-dir") {
+            options.output_dir = argv[++i];
+        } else if (argument == "--no-display") {
+            options.display = false;
+        } else if (argument == "--validate") {
+            options.validate = true;
+        } else {
+            throw std::invalid_argument("Unknown argument: " + argument);
+        }
+    }
+    return options;
+}
 
-    vector<vector<Point>> contours5;
-    vector<Vec4i> hierarchy5;
-    findContours(thresh2, contours5, hierarchy5, RETR_CCOMP, CHAIN_APPROX_NONE);
-    Mat image_copy6 = image2.clone();
-    drawContours(image_copy6, contours5, -1, Scalar(0, 255, 0), 2);
-    imshow("EXTERNAL", image_copy6);
-    waitKey(0);
-    imwrite("contours_retr_ccomp.jpg", image_copy6);
-    destroyAllWindows();
+void show_image(const std::string& title, const cv::Mat& image, bool display) {
+    if (display) {
+        cv::imshow(title, image);
+        cv::waitKey(0);
+        cv::destroyAllWindows();
+    }
+}
 
-    vector<vector<Point>> contours6;
-    vector<Vec4i> hierarchy6;
-    findContours(thresh2, contours6, hierarchy6, RETR_TREE, CHAIN_APPROX_NONE);
-    Mat image_copy7 = image2.clone();
-    drawContours(image_copy7, contours6, -1, Scalar(0, 255, 0), 2);
-    imshow("EXTERNAL", image_copy7);
-    waitKey(0);
-    imwrite("contours_retr_tree.jpg", image_copy7);
-    destroyAllWindows();
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        const cv::Mat image = cv::imread(options.input.string());
+        if (image.empty()) {
+            throw std::runtime_error("Could not read input image: " + options.input.string());
+        }
+        fs::create_directories(options.output_dir);
+
+        cv::Mat gray;
+        cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
+        cv::Mat threshold_image;
+        cv::threshold(gray, threshold_image, 150, 255, cv::THRESH_BINARY);
+
+        struct RetrievalMode {
+            const char* name;
+            int value;
+        };
+        const std::array<RetrievalMode, 4> modes{{
+            {"list", cv::RETR_LIST},
+            {"external", cv::RETR_EXTERNAL},
+            {"ccomp", cv::RETR_CCOMP},
+            {"tree", cv::RETR_TREE},
+        }};
+        std::array<std::size_t, 4> counts{};
+
+        for (std::size_t index = 0; index < modes.size(); ++index) {
+            std::vector<std::vector<cv::Point>> contours;
+            std::vector<cv::Vec4i> hierarchy;
+            cv::findContours(
+                threshold_image.clone(), contours, hierarchy, modes[index].value,
+                cv::CHAIN_APPROX_NONE
+            );
+
+            cv::Mat rendered = image.clone();
+            cv::drawContours(
+                rendered, contours, -1, cv::Scalar(0, 255, 0), 2, cv::LINE_AA
+            );
+            show_image(modes[index].name, rendered, options.display);
+
+            const fs::path output =
+                options.output_dir / (std::string("contours_retr_") + modes[index].name + ".jpg");
+            if (!cv::imwrite(output.string(), rendered)) {
+                throw std::runtime_error("Could not write output image: " + output.string());
+            }
+            counts[index] = contours.size();
+            std::cout << modes[index].name << ": contours=" << contours.size()
+                      << ", hierarchy=" << hierarchy.size() << '\n';
+        }
+
+        if (options.validate) {
+            if (counts[0] == 0 || counts[1] == 0 || counts[2] == 0 || counts[3] == 0 ||
+                counts[1] > counts[0] || counts[2] != counts[3]) {
+                throw std::runtime_error("Contour retrieval-mode validation failed");
+            }
+            std::cout << "Validation passed\n";
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return 1;
+    }
 }

--- a/Contour-Detection-using-OpenCV/python/channel_experiments/channel_experiments.py
+++ b/Contour-Detection-using-OpenCV/python/channel_experiments/channel_experiments.py
@@ -1,53 +1,73 @@
-"""
-This Python script shows why we need to convert the image to grayscale 
-and why other single channel values like R, G, and B, do not work well for
-contour detection.
-"""
+"""Show why raw B, G, and R channels are poor contour inputs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
 
 import cv2
 
-# read the image
-image = cv2.imread('../../input/image_1.jpg')
 
-# B, G, R channel splitting
-blue, green, red = cv2.split(image)
+DEFAULT_INPUT = Path(__file__).resolve().parents[2] / "input" / "image_1.jpg"
 
-# detect contours using blue channel and without thresholding
-contours1, hierarchy1 = cv2.findContours(image=blue, mode=cv2.RETR_TREE, 
-                                       method=cv2.CHAIN_APPROX_NONE)
 
-# draw contours on the original image
-image_contour_blue = image.copy()
-cv2.drawContours(image=image_contour_blue, contours=contours1, contourIdx=-1, 
-                 color=(0, 255, 0), thickness=2, lineType=cv2.LINE_AA)
-# see the results
-cv2.imshow('Contour detection using blue channels only', image_contour_blue)
-cv2.waitKey(0)
-cv2.imwrite('blue_channel.jpg', image_contour_blue)
-cv2.destroyAllWindows()
+def show_image(title: str, image, display: bool) -> None:
+    if display:
+        cv2.imshow(title, image)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
 
-# detect contours using green channel and without thresholding
-contours2, hierarchy2 = cv2.findContours(image=green, mode=cv2.RETR_TREE, 
-                                       method=cv2.CHAIN_APPROX_NONE)
-# draw contours on the original image
-image_contour_green = image.copy()
-cv2.drawContours(image=image_contour_green, contours=contours2, contourIdx=-1, 
-                 color=(0, 255, 0), thickness=2, lineType=cv2.LINE_AA)
-# see the results
-cv2.imshow('Contour detection using green channels only', image_contour_green)
-cv2.waitKey(0)
-cv2.imwrite('green_channel.jpg', image_contour_green)
-cv2.destroyAllWindows()
 
-# detect contours using red channel and without thresholding
-contours3, hierarchy3 = cv2.findContours(image=red, mode=cv2.RETR_TREE, 
-                                       method=cv2.CHAIN_APPROX_NONE)
-# draw contours on the original image
-image_contour_red = image.copy()
-cv2.drawContours(image=image_contour_red, contours=contours3, contourIdx=-1, 
-                 color=(0, 255, 0), thickness=2, lineType=cv2.LINE_AA)
-# see the results
-cv2.imshow('Contour detection using red channels only', image_contour_red)
-cv2.waitKey(0)
-cv2.imwrite('red_channel.jpg', image_contour_red)
-cv2.destroyAllWindows()
+def run(input_path: Path, output_dir: Path, display: bool = True) -> dict[str, int]:
+    image = cv2.imread(str(input_path))
+    if image is None:
+        raise FileNotFoundError(f"Could not read input image: {input_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, int] = {}
+
+    # OpenCV stores color images in B, G, R order.
+    for name, channel in zip(("blue", "green", "red"), cv2.split(image)):
+        contours, _ = cv2.findContours(
+            channel.copy(), cv2.RETR_TREE, cv2.CHAIN_APPROX_NONE
+        )
+        rendered = image.copy()
+        cv2.drawContours(rendered, contours, -1, (0, 255, 0), 2, cv2.LINE_AA)
+
+        show_image(f"Contours from the {name} channel", rendered, display)
+        output_path = output_dir / f"{name}_channel.jpg"
+        if not cv2.imwrite(str(output_path), rendered):
+            raise OSError(f"Could not write output image: {output_path}")
+
+        counts[name] = len(contours)
+        print(f"{name}: contours={len(contours)}")
+
+    return counts
+
+
+def validate(counts: dict[str, int]) -> None:
+    if not all(count > 0 for count in counts.values()):
+        raise RuntimeError("Every color channel should produce at least one contour")
+    if not counts["blue"] < counts["green"] < counts["red"]:
+        raise RuntimeError(
+            "Expected the bundled image to produce blue < green < red contour counts"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--no-display", action="store_true", help="Skip GUI windows")
+    parser.add_argument(
+        "--validate", action="store_true", help="Validate bundled-image invariants"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    result = run(args.input, args.output_dir, display=not args.no_display)
+    if args.validate:
+        validate(result)
+        print("Validation passed")

--- a/Contour-Detection-using-OpenCV/python/contour_approximations/contour_approx.py
+++ b/Contour-Detection-using-OpenCV/python/contour_approximations/contour_approx.py
@@ -1,65 +1,120 @@
+"""Compare CHAIN_APPROX_NONE and CHAIN_APPROX_SIMPLE."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
 import cv2
 
-# read the image
-image = cv2.imread('../../input/image_1.jpg')
-# convert the image to grayscale format
-img_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-# apply binary thresholding
-ret, thresh = cv2.threshold(img_gray, 150, 255, cv2.THRESH_BINARY)
-# visualize the binary image
-cv2.imshow('Binary image', thresh)
-cv2.waitKey(0)
-cv2.imwrite('image_thres1.jpg', thresh)
-cv2.destroyAllWindows()
 
-# detect the contours on the binary image using cv2.CHAIN_APPROX_NONE
-contours, hierarchy = cv2.findContours(image=thresh, mode=cv2.RETR_TREE, 
-                                       method=cv2.CHAIN_APPROX_NONE)
-# draw contours on the original image
-image_copy = image.copy()
-cv2.drawContours(image=image_copy, contours=contours, contourIdx=-1, 
-                 color=(0, 255, 0), thickness=2, lineType=cv2.LINE_AA)
-# see the results
-cv2.imshow('None approximation', image_copy)
-cv2.waitKey(0)
-cv2.imwrite('contours_none_image1.jpg', image_copy)
-cv2.destroyAllWindows()
+INPUT_DIR = Path(__file__).resolve().parents[2] / "input"
 
-"""
-Now let's try with `cv2.CHAIN_APPROX_SIMPLE`
-"""
-# detect the contours on the binary image using cv2.ChAIN_APPROX_SIMPLE
-contours1, hierarchy1 = cv2.findContours(thresh, cv2.RETR_TREE, 
-                                                cv2.CHAIN_APPROX_SIMPLE)
-# draw contours on the original image for `CHAIN_APPROX_SIMPLE`
-image_copy1 = image.copy()
-cv2.drawContours(image_copy1, contours1, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-# see the results
-cv2.imshow('Simple approximation', image_copy1)
-cv2.waitKey(0)
-cv2.imwrite('contours_simple_image1.jpg', image_copy1)
-cv2.destroyAllWindows()
 
-# to actually visualize the effect of `CHAIN_APPROX_SIMPLE`, we need a proper image
-image1 = cv2.imread('../../input/image_2.jpg')
-img_gray1 = cv2.cvtColor(image1, cv2.COLOR_BGR2GRAY)
-ret, thresh1 = cv2.threshold(img_gray1, 150, 255, cv2.THRESH_BINARY)
-contours2, hierarchy2 = cv2.findContours(thresh1, cv2.RETR_TREE, 
-                                                cv2.CHAIN_APPROX_SIMPLE)
-image_copy2 = image1.copy()
-cv2.drawContours(image_copy2, contours2, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-cv2.imshow('SIMPLE Approximation contours', image_copy2)
-cv2.waitKey(0)
-image_copy3 = image1.copy()
-for i, contour in enumerate(contours2): # loop over one contour area
-    for j, contour_point in enumerate(contour): # loop over the points 
-        # draw a circle on the current contour coordinate
-        cv2.circle(image_copy3, ((contour_point[0][0], contour_point[0][1])), 
-                   2, (0, 255, 0), 2, cv2.LINE_AA)
-# see the results
-cv2.imshow('CHAIN_APPROX_SIMPLE Point only', image_copy3)
-cv2.waitKey(0)
-cv2.imwrite('contour_point_simple.jpg', image_copy3)
-cv2.destroyAllWindows()
+def read_image(path: Path):
+    image = cv2.imread(str(path))
+    if image is None:
+        raise FileNotFoundError(f"Could not read input image: {path}")
+    return image
+
+
+def show_image(title: str, image, display: bool) -> None:
+    if display:
+        cv2.imshow(title, image)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+
+
+def write_image(path: Path, image) -> None:
+    if not cv2.imwrite(str(path), image):
+        raise OSError(f"Could not write output image: {path}")
+
+
+def find_binary_contours(image, method: int):
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    _, threshold_image = cv2.threshold(gray, 150, 255, cv2.THRESH_BINARY)
+    contours, hierarchy = cv2.findContours(
+        threshold_image.copy(), cv2.RETR_TREE, method
+    )
+    return threshold_image, contours, hierarchy
+
+
+def run(
+    image1_path: Path,
+    image2_path: Path,
+    output_dir: Path,
+    display: bool = True,
+) -> dict[str, int]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    image1 = read_image(image1_path)
+    threshold_image, contours_none, _ = find_binary_contours(
+        image1, cv2.CHAIN_APPROX_NONE
+    )
+    _, contours_simple, _ = find_binary_contours(image1, cv2.CHAIN_APPROX_SIMPLE)
+
+    show_image("Binary image", threshold_image, display)
+    write_image(output_dir / "image_thres1.jpg", threshold_image)
+
+    for name, contours in (("none", contours_none), ("simple", contours_simple)):
+        rendered = image1.copy()
+        cv2.drawContours(rendered, contours, -1, (0, 255, 0), 2, cv2.LINE_AA)
+        show_image(f"{name.title()} approximation", rendered, display)
+        write_image(output_dir / f"contours_{name}_image1.jpg", rendered)
+
+    image2 = read_image(image2_path)
+    _, contours_image2, _ = find_binary_contours(image2, cv2.CHAIN_APPROX_SIMPLE)
+    rendered = image2.copy()
+    cv2.drawContours(rendered, contours_image2, -1, (0, 255, 0), 2, cv2.LINE_AA)
+    show_image("SIMPLE approximation contours", rendered, display)
+    write_image(output_dir / "contours_simple_image2.jpg", rendered)
+
+    points_only = image2.copy()
+    for contour in contours_image2:
+        for contour_point in contour:
+            x, y = contour_point[0]
+            cv2.circle(points_only, (int(x), int(y)), 2, (0, 255, 0), 2, cv2.LINE_AA)
+    show_image("CHAIN_APPROX_SIMPLE points", points_only, display)
+    write_image(output_dir / "contour_point_simple.jpg", points_only)
+
+    metrics = {
+        "none_contours": len(contours_none),
+        "none_points": sum(len(contour) for contour in contours_none),
+        "simple_contours": len(contours_simple),
+        "simple_points": sum(len(contour) for contour in contours_simple),
+        "image2_simple_contours": len(contours_image2),
+        "image2_simple_points": sum(len(contour) for contour in contours_image2),
+    }
+    print(", ".join(f"{name}={value}" for name, value in metrics.items()))
+    return metrics
+
+
+def validate(metrics: dict[str, int]) -> None:
+    if metrics["none_contours"] != metrics["simple_contours"]:
+        raise RuntimeError("Approximation methods should find the same contours")
+    if metrics["simple_points"] >= metrics["none_points"]:
+        raise RuntimeError("CHAIN_APPROX_SIMPLE should retain fewer contour points")
+    if metrics["image2_simple_contours"] <= 0:
+        raise RuntimeError("The second bundled image should contain contours")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image1", type=Path, default=INPUT_DIR / "image_1.jpg")
+    parser.add_argument("--image2", type=Path, default=INPUT_DIR / "image_2.jpg")
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--no-display", action="store_true", help="Skip GUI windows")
+    parser.add_argument(
+        "--validate", action="store_true", help="Validate bundled-image invariants"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    result = run(
+        args.image1, args.image2, args.output_dir, display=not args.no_display
+    )
+    if args.validate:
+        validate(result)
+        print("Validation passed")

--- a/Contour-Detection-using-OpenCV/python/contour_extraction/contour_extraction.py
+++ b/Contour-Detection-using-OpenCV/python/contour_extraction/contour_extraction.py
@@ -1,57 +1,84 @@
+"""Compare contour retrieval modes using OpenCV 4 or OpenCV 5."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
 import cv2
 
-"""
-Contour detection and drawing using different extraction modes to complement 
-the understanding of hierarchies
-"""
-image2 = cv2.imread('../../input/custom_colors.jpg')
-img_gray2 = cv2.cvtColor(image2, cv2.COLOR_BGR2GRAY)
-ret, thresh2 = cv2.threshold(img_gray2, 150, 255, cv2.THRESH_BINARY)
 
-contours3, hierarchy3 = cv2.findContours(thresh2, cv2.RETR_LIST, 
-                                       cv2.CHAIN_APPROX_NONE)
-image_copy4 = image2.copy()
-cv2.drawContours(image_copy4, contours3, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-# see the results
-cv2.imshow('LIST', image_copy4)
-print(f"LIST: {hierarchy3}")
-cv2.waitKey(0)
-cv2.imwrite('contours_retr_list.jpg', image_copy4)
-cv2.destroyAllWindows()
+DEFAULT_INPUT = Path(__file__).resolve().parents[2] / "input" / "custom_colors.jpg"
+MODES = {
+    "list": cv2.RETR_LIST,
+    "external": cv2.RETR_EXTERNAL,
+    "ccomp": cv2.RETR_CCOMP,
+    "tree": cv2.RETR_TREE,
+}
 
-contours4, hierarchy4 = cv2.findContours(thresh2, cv2.RETR_EXTERNAL, 
-                                       cv2.CHAIN_APPROX_NONE)
-image_copy5 = image2.copy()
-cv2.drawContours(image_copy5, contours4, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-# see the results
-cv2.imshow('EXTERNAL', image_copy5)
-print(f"EXTERNAL: {hierarchy4}")
-cv2.waitKey(0)
-cv2.imwrite('contours_retr_external.jpg', image_copy5)
-cv2.destroyAllWindows()
 
-contours5, hierarchy5 = cv2.findContours(thresh2, cv2.RETR_CCOMP, 
-                                       cv2.CHAIN_APPROX_NONE)
-image_copy6 = image2.copy()
-cv2.drawContours(image_copy6, contours5, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-# see the results
-cv2.imshow('CCOMP', image_copy6)
-print(f"CCOMP: {hierarchy5}")
-cv2.waitKey(0)
-cv2.imwrite('contours_retr_ccomp.jpg', image_copy6)
-cv2.destroyAllWindows()
+def show_image(title: str, image, display: bool) -> None:
+    """Display an image when running interactively."""
+    if display:
+        cv2.imshow(title, image)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
 
-contours6, hierarchy6 = cv2.findContours(thresh2, cv2.RETR_TREE, 
-                                       cv2.CHAIN_APPROX_NONE)
-image_copy7 = image2.copy()
-cv2.drawContours(image_copy7, contours6, -1, (0, 255, 0), 2, 
-                 cv2.LINE_AA)
-# see the results
-cv2.imshow('TREE', image_copy7)
-print(f"TREE: {hierarchy6}")
-cv2.waitKey(0)
-cv2.imwrite('contours_retr_tree.jpg', image_copy7)
-cv2.destroyAllWindows()
+
+def run(input_path: Path, output_dir: Path, display: bool = True) -> dict[str, int]:
+    """Run the retrieval-mode experiment and return contour counts."""
+    image = cv2.imread(str(input_path))
+    if image is None:
+        raise FileNotFoundError(f"Could not read input image: {input_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    _, threshold_image = cv2.threshold(gray, 150, 255, cv2.THRESH_BINARY)
+
+    counts: dict[str, int] = {}
+    for name, mode in MODES.items():
+        contours, hierarchy = cv2.findContours(
+            threshold_image.copy(), mode, cv2.CHAIN_APPROX_NONE
+        )
+        rendered = image.copy()
+        cv2.drawContours(rendered, contours, -1, (0, 255, 0), 2, cv2.LINE_AA)
+
+        show_image(name.upper(), rendered, display)
+        output_path = output_dir / f"contours_retr_{name}.jpg"
+        if not cv2.imwrite(str(output_path), rendered):
+            raise OSError(f"Could not write output image: {output_path}")
+
+        counts[name] = len(contours)
+        hierarchy_shape = None if hierarchy is None else hierarchy.shape
+        print(f"{name.upper()}: contours={len(contours)}, hierarchy={hierarchy_shape}")
+
+    return counts
+
+
+def validate(counts: dict[str, int]) -> None:
+    """Check relationships that should hold for the bundled tutorial image."""
+    if not all(count > 0 for count in counts.values()):
+        raise RuntimeError("Every retrieval mode should find at least one contour")
+    if counts["external"] > counts["list"]:
+        raise RuntimeError("RETR_EXTERNAL cannot return more contours than RETR_LIST")
+    if counts["ccomp"] != counts["tree"]:
+        raise RuntimeError("The bundled image should have equal CCOMP and TREE counts")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--no-display", action="store_true", help="Skip GUI windows")
+    parser.add_argument(
+        "--validate", action="store_true", help="Validate bundled-image invariants"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    result = run(args.input, args.output_dir, display=not args.no_display)
+    if args.validate:
+        validate(result)
+        print("Validation passed")

--- a/Contour-Detection-using-OpenCV/python/requirements.txt
+++ b/Contour-Detection-using-OpenCV/python/requirements.txt
@@ -1,1 +1,2 @@
-opencv-python==4.5.1.48
+numpy>=1.23,<3
+opencv-python>=4.8,<6

--- a/Contour-Detection-using-OpenCV/python/tests/test_examples.py
+++ b/Contour-Detection-using-OpenCV/python/tests/test_examples.py
@@ -1,0 +1,85 @@
+"""Headless regression tests for the contour-detection tutorial scripts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2
+
+
+PYTHON_DIR = Path(__file__).resolve().parents[1]
+
+
+class ContourExamplesTest(unittest.TestCase):
+    def run_example(self, relative_script: str, expected_outputs: set[str]) -> str:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_dir = Path(temporary_directory)
+            command = [
+                sys.executable,
+                str(PYTHON_DIR / relative_script),
+                "--no-display",
+                "--validate",
+                "--output-dir",
+                str(output_dir),
+            ]
+            result = subprocess.run(
+                command,
+                cwd=Path(temporary_directory),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("Validation passed", result.stdout)
+            self.assertEqual(expected_outputs, {path.name for path in output_dir.glob("*.jpg")})
+            for output_name in expected_outputs:
+                image = cv2.imread(str(output_dir / output_name))
+                self.assertIsNotNone(image, output_name)
+                self.assertGreater(image.size, 0, output_name)
+            return result.stdout
+
+    def test_channel_experiments(self) -> None:
+        output = self.run_example(
+            "channel_experiments/channel_experiments.py",
+            {"blue_channel.jpg", "green_channel.jpg", "red_channel.jpg"},
+        )
+        self.assertIn("blue: contours=1", output)
+        self.assertIn("green: contours=151", output)
+        self.assertIn("red: contours=1321", output)
+
+    def test_contour_approximations(self) -> None:
+        output = self.run_example(
+            "contour_approximations/contour_approx.py",
+            {
+                "image_thres1.jpg",
+                "contours_none_image1.jpg",
+                "contours_simple_image1.jpg",
+                "contours_simple_image2.jpg",
+                "contour_point_simple.jpg",
+            },
+        )
+        self.assertIn("none_contours=85", output)
+        self.assertIn("simple_contours=85", output)
+        self.assertIn("image2_simple_contours=379", output)
+
+    def test_contour_extraction(self) -> None:
+        output = self.run_example(
+            "contour_extraction/contour_extraction.py",
+            {
+                "contours_retr_list.jpg",
+                "contours_retr_external.jpg",
+                "contours_retr_ccomp.jpg",
+                "contours_retr_tree.jpg",
+            },
+        )
+        self.assertIn("LIST: contours=5", output)
+        self.assertIn("EXTERNAL: contours=3", output)
+        self.assertIn("CCOMP: contours=5", output)
+        self.assertIn("TREE: contours=5", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- modernize the Python and C++ Find Contours examples for OpenCV 4.14 and 5.0
- add headless validation/output controls, C++17 CMake targets, and Python regression tests
- document the OpenCV 5 TRUCO fast path and its platform-specific performance caveat

## Validation

- Python unit tests: 6/6 on exact OpenCV 4.14.0 and 6/6 on exact OpenCV 5.0.0
- Python CLI examples: 6/6 on each version; all 12 generated JPEGs are byte-identical across versions
- C++: six fresh Release builds, CTest 6/6, `-Werror` with zero warnings, and exact 4.14/5.0 linkage
- C++ outputs: all 12 generated JPEGs are byte-identical across versions
- post-review contour extraction rerun on both versions with nonzero LIST, EXTERNAL, CCOMP, and TREE counts
- README hierarchy-unrequested and `cv::noArray()` signatures compiled and ran on both versions
