### PR TITLE
Host Contour tutorial bundle on GitHub Releases

### DIFF
--- a/Contour-Detection-using-OpenCV/README.md
+++ b/Contour-Detection-using-OpenCV/README.md
@@ -2,7 +2,7 @@
 
 **This repository contains code for [Contour Detection using OpenCV](https://learnopencv.com/contour-detection-using-opencv-python-c/) blogpost**.
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://www.dropbox.com/sh/lylz9lzqzs2nt2q/AAC5SfEV7_ex0imh1uip9-U6a?dl=1)
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://github.com/spmallick/learnopencv/releases/download/contour-detection-opencv-2026.07.22/Contour-Detection-using-OpenCV-2026.07.22.zip)
 
 ## Directory Structure
 


### PR DESCRIPTION
## What changed

- Replace the stale Dropbox download in `Contour-Detection-using-OpenCV/README.md` with a deterministic, versioned GitHub Release asset URL.
- Keep the download scoped to the single Contour tutorial folder rather than the monorepo source archive.

## Why

The README and WordPress metadata currently point to separate, stale Dropbox bundles. A tagged GitHub Release asset ties the downloadable tutorial to the tested repository source and gives both locations one canonical URL.

## Validation

- `git diff --check`
- Python regression suite: 3/3 passed with OpenCV 4.14.0
- Python regression suite: 3/3 passed with OpenCV 5.0.0
- C++ CMake/CTest: 3/3 passed with OpenCV 4.14.0
- C++ CMake/CTest: 3/3 passed with OpenCV 5.0.0

After merge, the release will be tagged from the merge commit and the exact project subtree will be uploaded as `Contour-Detection-using-OpenCV-2026.07.22.zip` with a SHA-256 checksum.