### PR TITLE
Clarify Contour example working directory

### DIFF
--- a/Contour-Detection-using-OpenCV/README.md
+++ b/Contour-Detection-using-OpenCV/README.md
@@ -47,9 +47,9 @@ newer. The C++ examples use C++17 and CMake 3.16 or newer.
 
 ### Python
 
-Install a supported OpenCV version and run each example from the repository
-directory. Input paths are resolved from the script location, so the commands
-also work from another current directory.
+Install a supported OpenCV version and run the commands below from the project
+directory. The examples resolve their bundled input images from the script
+location, so absolute script paths also work from another current directory.
 
 ```shell
 python3 -m pip install -r python/requirements.txt


### PR DESCRIPTION
## What changed

Clarify that the README's relative Python commands must be run from the project directory. Absolute script paths remain valid from another current directory because the examples resolve bundled inputs relative to their own files.

## Why

The release-candidate audit caught that the previous wording could send readers to a failing invocation from outside the extracted folder.

## Validation

- `git diff --check`
- Documentation-only follow-up to #1091
- The release candidate's Python and C++ regression suites already passed on OpenCV 4.14.0 and 5.0.0