### PR TITLE
Upgrade feature-based image alignment for OpenCV 4 and 5

### DIFF
--- a/ImageAlignment-FeatureBased/CMakeLists.txt
+++ b/ImageAlignment-FeatureBased/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(feature_based_image_alignment LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# The first lookup establishes the OpenCV major version using modules whose
+# names are unchanged. OpenCV 5 renamed features2d to features and moved
+# findHomography from calib3d to geometry, so request those components only
+# after the version is known.
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs imgproc)
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR
+    "This example supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}")
+endif()
+
+if(OpenCV_VERSION VERSION_GREATER_EQUAL 5)
+  find_package(OpenCV REQUIRED COMPONENTS core features geometry imgcodecs imgproc)
+else()
+  find_package(OpenCV REQUIRED COMPONENTS calib3d core features2d imgcodecs imgproc)
+endif()
+
+add_executable(image_alignment align.cpp)
+target_include_directories(
+  image_alignment SYSTEM PRIVATE
+  ${OpenCV_INCLUDE_DIRS}
+)
+target_link_libraries(image_alignment PRIVATE ${OpenCV_LIBS})
+target_compile_definitions(
+  image_alignment PRIVATE
+  IMAGE_ALIGNMENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+if(MSVC)
+  target_compile_options(image_alignment PRIVATE /W4 /WX)
+else()
+  target_compile_options(image_alignment PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+include(CTest)
+if(BUILD_TESTING)
+  add_test(
+    NAME image_alignment_regression
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DEXECUTABLE=$<TARGET_FILE:image_alignment>
+      -DPROJECT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+      -DTEST_ROOT=${CMAKE_CURRENT_BINARY_DIR}/test-output
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_cpp_cli.cmake
+  )
+  set_tests_properties(
+    image_alignment_regression PROPERTIES
+    PASS_REGULAR_EXPRESSION "Alignment validation passed"
+  )
+endif()

--- a/ImageAlignment-FeatureBased/README.md
+++ b/ImageAlignment-FeatureBased/README.md
@@ -6,6 +6,131 @@ This repository contains code for the blog post [Feature Based Image Alignment u
 
 [<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://www.dropbox.com/scl/fo/7actm7m3yu4rg01mhve9b/h?dl=1&rlkey=7irdzdwlwniboxv6n0nyh4puh)
 
+## OpenCV compatibility
+
+The Python and C++ examples are tested with exact OpenCV 4.14.0 and OpenCV
+5.0.0 releases. They require Python 3.9 or newer for Python, and CMake 3.16 or
+newer plus C++17 for C++. ORB is part of the main OpenCV distribution, so
+`opencv_contrib` is not required.
+
+OpenCV 5 renamed the C++ `features2d` module to `features` and moved
+`findHomography` from `calib3d` to `geometry`. The source selects the appropriate
+headers and CMake components for each supported major version. The Python API
+names are unchanged.
+
+## Python
+
+From this directory, create an environment and install the supported dependency
+ranges:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+Run the bundled example headlessly and validate the result:
+
+```bash
+python align.py --output-dir output --no-display --validate
+```
+
+The default input images are resolved relative to `align.py`, so the command can
+also be run from another working directory by using the script's absolute path.
+`--output-dir` is resolved from the caller's working directory.
+
+Use different images with:
+
+```bash
+python align.py \
+  --input /path/to/image.jpg \
+  --reference /path/to/reference.jpg \
+  --output-dir output \
+  --no-display \
+  --validate
+```
+
+Run all Python regressions:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## C++
+
+Configure with the OpenCV installation to test. Standard Unix installations
+typically place `OpenCVConfig.cmake` under `lib/cmake/opencv4` for OpenCV 4 and
+`lib/cmake/opencv5` for OpenCV 5.
+
+```bash
+cmake -S . -B build \
+  -DOpenCV_DIR=/path/to/opencv-5.0.0/lib/cmake/opencv5 \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+Run and test the executable:
+
+```bash
+./build/image_alignment --output-dir output --no-display --validate
+ctest --test-dir build --output-on-failure
+```
+
+As in the Python example, CMake embeds the project source directory for the
+default bundled inputs, and explicit `--input` and `--reference` paths override
+them.
+
+## Command-line options
+
+Both implementations accept the same options:
+
+| Option | Meaning |
+| --- | --- |
+| `--input PATH` | Image that will be aligned; defaults to `scanned-form.jpg`. |
+| `--reference PATH` | Reference image; defaults to `form.jpg`. |
+| `--output-dir PATH` | Directory for `aligned.jpg` and `matches.jpg`; defaults to the current directory. |
+| `--no-display` | Explicitly select the headless workflow. The example does not open GUI windows. |
+| `--validate` | Check output dimensions, readability, and alignment quality. |
+
+## Regression contract
+
+For the bundled images, ORB finds 500 keypoints in each image and 500 raw
+matches. The nominal best 15% ends at a tied Hamming distance, so the
+implementations retain all matches at that distance: 78 matches with 51 RANSAC
+inliers. This avoids selecting an arbitrary tied match based on collection
+ordering.
+
+Validation requires:
+
+- `aligned.jpg` to be 1000 by 1293 pixels and `matches.jpg` to be 2000 by 1333
+  pixels;
+- both files to be readable and nonempty;
+- the aligned image's mean absolute error against the reference to be at least
+  60% lower than the resized unaligned input; and
+- the explicit `Alignment validation passed` marker.
+
+OpenCV 5 changed homography refinement and perspective-warp interpolation.
+Small homography and pixel differences between 4.14 and 5.0 are therefore
+expected; the tests compare stable counts, dimensions, inliers, and alignment
+quality instead of encoded JPEG bytes.
+
+## Project layout
+
+```text
+ImageAlignment-FeatureBased/
+├── CMakeLists.txt
+├── README.md
+├── align.cpp
+├── align.py
+├── form.jpg
+├── requirements.txt
+├── scanned-form.jpg
+└── tests/
+    ├── check_cpp_cli.cmake
+    └── test_alignment.py
+```
+
 ---
 
 <p align="center">

--- a/ImageAlignment-FeatureBased/align.cpp
+++ b/ImageAlignment-FeatureBased/align.cpp
@@ -1,90 +1,325 @@
-#include <opencv2/opencv.hpp>
-#include "opencv2/xfeatures2d.hpp"
-#include "opencv2/features2d.hpp"
+#include <opencv2/core.hpp>
+#include <opencv2/core/version.hpp>
+#if CV_VERSION_MAJOR >= 5
+#include <opencv2/features.hpp>
+#include <opencv2/geometry.hpp>
+#else
+#include <opencv2/calib3d.hpp>
+#include <opencv2/features2d.hpp>
+#endif
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
 
-using namespace std;
-using namespace cv;
-using namespace cv::xfeatures2d;
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
 
-const int MAX_FEATURES = 500;
-const float GOOD_MATCH_PERCENT = 0.15f;
+#ifndef IMAGE_ALIGNMENT_SOURCE_DIR
+#define IMAGE_ALIGNMENT_SOURCE_DIR "."
+#endif
 
+namespace {
 
-void alignImages(Mat &im1, Mat &im2, Mat &im1Reg, Mat &h)
-{
-  // Convert images to grayscale
-  Mat im1Gray, im2Gray;
-  cvtColor(im1, im1Gray, cv::COLOR_BGR2GRAY);
-  cvtColor(im2, im2Gray, cv::COLOR_BGR2GRAY);
+constexpr int kMaxFeatures = 500;
+constexpr float kGoodMatchPercent = 0.15F;
+constexpr std::size_t kMinHomographyMatches = 4;
 
-  // Variables to store keypoints and descriptors
-  std::vector<KeyPoint> keypoints1, keypoints2;
-  Mat descriptors1, descriptors2;
+struct AlignmentStats {
+  std::size_t inputKeypoints;
+  std::size_t referenceKeypoints;
+  std::size_t totalMatches;
+  std::size_t retainedMatches;
+  int inlierMatches;
+};
 
-  // Detect ORB features and compute descriptors.
-  Ptr<Feature2D> orb = ORB::create(MAX_FEATURES);
-  orb->detectAndCompute(im1Gray, Mat(), keypoints1, descriptors1);
-  orb->detectAndCompute(im2Gray, Mat(), keypoints2, descriptors2);
-
-  // Match features.
-  std::vector<DMatch> matches;
-  Ptr<DescriptorMatcher> matcher = DescriptorMatcher::create("BruteForce-Hamming");
-  matcher->match(descriptors1, descriptors2, matches, Mat());
-
-  // Sort matches by score
-  std::sort(matches.begin(), matches.end());
-
-  // Remove not so good matches
-  const int numGoodMatches = matches.size() * GOOD_MATCH_PERCENT;
-  matches.erase(matches.begin()+numGoodMatches, matches.end());
-
-  // Draw top matches
-  Mat imMatches;
-  drawMatches(im1, keypoints1, im2, keypoints2, matches, imMatches);
-  imwrite("matches.jpg", imMatches);
-
-  // Extract location of good matches
-  std::vector<Point2f> points1, points2;
-
-  for( size_t i = 0; i < matches.size(); i++ )
-  {
-    points1.push_back( keypoints1[ matches[i].queryIdx ].pt );
-    points2.push_back( keypoints2[ matches[i].trainIdx ].pt );
+void writeImage(const std::string& filename, const cv::Mat& image) {
+  const std::filesystem::path outputPath(filename);
+  if (outputPath.has_parent_path()) {
+    std::filesystem::create_directories(outputPath.parent_path());
   }
-
-  // Find homography
-  h = findHomography( points1, points2, RANSAC );
-
-  // Use homography to warp image
-  warpPerspective(im1, im1Reg, h, im2.size());
+  if (!cv::imwrite(filename, image)) {
+    throw std::runtime_error("Could not write image: " + filename);
+  }
 }
 
+AlignmentStats alignImagesImpl(const cv::Mat& image, const cv::Mat& reference,
+                               cv::Mat& aligned, cv::Mat& homography,
+                               const std::string& matchesFilename) {
+  if (image.empty()) {
+    throw std::invalid_argument("The image to align is empty");
+  }
+  if (reference.empty()) {
+    throw std::invalid_argument("The reference image is empty");
+  }
 
-int main(int argc, char **argv)
-{
-  // Read reference image
-  string refFilename("form.jpg"); 
-  cout << "Reading reference image : " << refFilename << endl; 
-  Mat imReference = imread(refFilename);
+  cv::Mat imageGray;
+  cv::Mat referenceGray;
+  cv::cvtColor(image, imageGray, cv::COLOR_BGR2GRAY);
+  cv::cvtColor(reference, referenceGray, cv::COLOR_BGR2GRAY);
 
-  // Read image to be aligned
-  string imFilename("scanned-form.jpg");
-  cout << "Reading image to align : " << imFilename << endl; 
-  Mat im = imread(imFilename);
+  std::vector<cv::KeyPoint> keypoints1;
+  std::vector<cv::KeyPoint> keypoints2;
+  cv::Mat descriptors1;
+  cv::Mat descriptors2;
 
-  // Registered image will be resotred in imReg. 
-  // The estimated homography will be stored in h. 
-  Mat imReg, h;
+  const cv::Ptr<cv::Feature2D> orb = cv::ORB::create(kMaxFeatures);
+  orb->detectAndCompute(imageGray, cv::noArray(), keypoints1, descriptors1);
+  orb->detectAndCompute(referenceGray, cv::noArray(), keypoints2, descriptors2);
 
-  // Align images
-  cout << "Aligning images ..." << endl; 
-  alignImages(im, imReference, imReg, h);
+  if (descriptors1.empty() || descriptors2.empty()) {
+    throw std::runtime_error("ORB could not find features in both images");
+  }
 
-  // Write aligned image to disk. 
-  string outFilename("aligned.jpg");
-  cout << "Saving aligned image : " << outFilename << endl; 
-  imwrite(outFilename, imReg);
+  std::vector<cv::DMatch> matches;
+  const cv::Ptr<cv::BFMatcher> matcher =
+      cv::BFMatcher::create(cv::NORM_HAMMING, false);
+  matcher->match(descriptors1, descriptors2, matches);
 
-  // Print estimated homography
-  cout << "Estimated homography : \n" << h << endl; 
+  if (matches.size() < kMinHomographyMatches) {
+    throw std::runtime_error("At least four feature matches are required");
+  }
+
+  const auto matchSortKey = [&keypoints1, &keypoints2](const cv::DMatch& match) {
+    const cv::Point2f point1 = keypoints1[match.queryIdx].pt;
+    const cv::Point2f point2 = keypoints2[match.trainIdx].pt;
+    return std::make_tuple(match.distance, point1.y, point1.x, point2.y,
+                           point2.x, match.queryIdx, match.trainIdx,
+                           match.imgIdx);
+  };
+  std::sort(matches.begin(), matches.end(),
+            [&matchSortKey](const cv::DMatch& left, const cv::DMatch& right) {
+              return matchSortKey(left) < matchSortKey(right);
+            });
+
+  const std::size_t totalMatchCount = matches.size();
+  const auto nominalMatchCount =
+      static_cast<std::size_t>(matches.size() * kGoodMatchPercent);
+  const auto minimumMatchCount =
+      std::max(kMinHomographyMatches, nominalMatchCount);
+  const float cutoffDistance = matches[minimumMatchCount - 1].distance;
+  const auto retainedEnd =
+      std::find_if(matches.begin(), matches.end(),
+                   [cutoffDistance](const cv::DMatch& match) {
+                     return match.distance > cutoffDistance;
+                   });
+  matches.erase(retainedEnd, matches.end());
+
+  if (!matchesFilename.empty()) {
+    cv::Mat matchesImage;
+    cv::drawMatches(image, keypoints1, reference, keypoints2, matches,
+                    matchesImage, cv::Scalar(0, 255, 0),
+                    cv::Scalar(255, 0, 0), std::vector<char>(),
+                    cv::DrawMatchesFlags::DEFAULT);
+    writeImage(matchesFilename, matchesImage);
+  }
+
+  std::vector<cv::Point2f> points1;
+  std::vector<cv::Point2f> points2;
+  points1.reserve(matches.size());
+  points2.reserve(matches.size());
+  for (const auto& match : matches) {
+    points1.push_back(keypoints1[match.queryIdx].pt);
+    points2.push_back(keypoints2[match.trainIdx].pt);
+  }
+
+  cv::Mat inlierMask;
+  homography =
+      cv::findHomography(points1, points2, cv::RANSAC, 3.0, inlierMask);
+  if (homography.empty() || !cv::checkRange(homography)) {
+    throw std::runtime_error("Could not estimate a valid homography");
+  }
+  if (inlierMask.empty()) {
+    throw std::runtime_error("Could not determine homography inliers");
+  }
+
+  cv::warpPerspective(image, aligned, homography, reference.size());
+  return AlignmentStats{
+      keypoints1.size(),
+      keypoints2.size(),
+      totalMatchCount,
+      matches.size(),
+      cv::countNonZero(inlierMask),
+  };
+}
+
+cv::Mat readImage(const std::string& filename, const std::string& description) {
+  cv::Mat image = cv::imread(filename, cv::IMREAD_COLOR);
+  if (image.empty()) {
+    throw std::runtime_error("Could not read " + description + ": " + filename);
+  }
+  return image;
+}
+
+double meanAbsoluteError(const cv::Mat& first, const cv::Mat& second) {
+  if (first.size() != second.size() || first.type() != second.type()) {
+    throw std::invalid_argument("Images must have the same size and type");
+  }
+
+  cv::Mat difference;
+  cv::absdiff(first, second, difference);
+  const cv::Scalar channelMeans = cv::mean(difference);
+  double total = 0.0;
+  for (int channel = 0; channel < difference.channels(); ++channel) {
+    total += channelMeans[channel];
+  }
+  return total / difference.channels();
+}
+
+void validateAlignment(const cv::Mat& image, const cv::Mat& reference,
+                       const cv::Mat& aligned) {
+  if (aligned.size() != reference.size() ||
+      aligned.type() != reference.type()) {
+    throw std::runtime_error(
+        "Aligned image dimensions or type do not match the reference");
+  }
+
+  cv::Mat resizedInput;
+  cv::resize(image, resizedInput, reference.size());
+  const double before = meanAbsoluteError(resizedInput, reference);
+  const double after = meanAbsoluteError(aligned, reference);
+
+  std::cout << "Alignment MAE before: " << before << '\n';
+  std::cout << "Alignment MAE after: " << after << '\n';
+  if (!std::isfinite(before) || !std::isfinite(after) || before <= 0.0 ||
+      after >= before * 0.4) {
+    throw std::runtime_error(
+        "Alignment did not improve mean absolute error by the required amount");
+  }
+}
+
+void validateWrittenOutputs(const std::string& alignedFilename,
+                            const std::string& matchesFilename,
+                            const cv::Size& alignedSize,
+                            const cv::Size& matchesSize) {
+  const cv::Mat aligned =
+      readImage(alignedFilename, "written aligned image");
+  const cv::Mat matches =
+      readImage(matchesFilename, "written feature matches image");
+  if (aligned.size() != alignedSize) {
+    throw std::runtime_error(
+        "Written aligned image dimensions do not match the reference");
+  }
+  if (matches.size() != matchesSize) {
+    throw std::runtime_error(
+        "Written feature matches dimensions are not as expected");
+  }
+}
+
+struct Arguments {
+  std::string inputFilename =
+      (std::filesystem::path(IMAGE_ALIGNMENT_SOURCE_DIR) / "scanned-form.jpg")
+          .string();
+  std::string referenceFilename =
+      (std::filesystem::path(IMAGE_ALIGNMENT_SOURCE_DIR) / "form.jpg").string();
+  std::filesystem::path outputDirectory = ".";
+  bool validate = false;
+  bool showHelp = false;
+};
+
+Arguments parseArguments(int argc, char** argv) {
+  Arguments arguments;
+  for (int argument = 1; argument < argc; ++argument) {
+    const std::string option(argv[argument]);
+    const auto requireValue = [&]() -> std::string {
+      if (argument + 1 >= argc) {
+        throw std::invalid_argument("Missing value for " + option);
+      }
+      return argv[++argument];
+    };
+
+    if (option == "--input") {
+      arguments.inputFilename = requireValue();
+    } else if (option == "--reference") {
+      arguments.referenceFilename = requireValue();
+    } else if (option == "--output-dir") {
+      arguments.outputDirectory = requireValue();
+    } else if (option == "--validate") {
+      arguments.validate = true;
+    } else if (option == "--no-display") {
+      // This example has no GUI; accept the shared headless-example option.
+    } else if (option == "--help" || option == "-h") {
+      arguments.showHelp = true;
+    } else {
+      throw std::invalid_argument("Unknown argument: " + option);
+    }
+  }
+  return arguments;
+}
+
+void printUsage(const char* programName) {
+  std::cout
+      << "Usage: " << programName
+      << " [--input PATH] [--reference PATH] [--output-dir PATH]\n"
+         "       [--no-display] [--validate]\n";
+}
+
+}  // namespace
+
+// Preserve the original tutorial function signature for readers who copied it
+// into another C++ program. The command-line example below uses the extended
+// implementation so callers can choose the matches output path.
+void alignImages(cv::Mat& image, cv::Mat& reference, cv::Mat& aligned,
+                 cv::Mat& homography) {
+  static_cast<void>(
+      alignImagesImpl(image, reference, aligned, homography, "matches.jpg"));
+}
+
+int main(int argc, char** argv) {
+  try {
+    const Arguments arguments = parseArguments(argc, argv);
+    if (arguments.showHelp) {
+      printUsage(argv[0]);
+      return 0;
+    }
+
+    const std::string outputFilename =
+        (arguments.outputDirectory / "aligned.jpg").string();
+    const std::string matchesFilename =
+        (arguments.outputDirectory / "matches.jpg").string();
+    std::cout << "OpenCV version: " << CV_VERSION << '\n';
+    std::cout << "Reading reference image: " << arguments.referenceFilename
+              << '\n';
+    const cv::Mat reference =
+        readImage(arguments.referenceFilename, "reference image");
+    std::cout << "Reading image to align: " << arguments.inputFilename << '\n';
+    const cv::Mat image =
+        readImage(arguments.inputFilename, "input image");
+
+    cv::Mat aligned;
+    cv::Mat homography;
+    std::cout << "Aligning images ...\n";
+    const AlignmentStats stats = alignImagesImpl(
+        image, reference, aligned, homography, matchesFilename);
+    std::cout << "Detected keypoints: input=" << stats.inputKeypoints
+              << ", reference=" << stats.referenceKeypoints << '\n';
+    std::cout << "Feature matches: total=" << stats.totalMatches
+              << ", retained=" << stats.retainedMatches
+              << ", inliers=" << stats.inlierMatches << '\n';
+    if (arguments.validate) {
+      validateAlignment(image, reference, aligned);
+    }
+    writeImage(outputFilename, aligned);
+    if (arguments.validate) {
+      const cv::Size matchesSize(
+          image.cols + reference.cols,
+          std::max(image.rows, reference.rows));
+      validateWrittenOutputs(outputFilename, matchesFilename, reference.size(),
+                             matchesSize);
+      std::cout << "Alignment validation passed\n";
+    }
+
+    std::cout << "Saved aligned image: " << outputFilename << '\n';
+    std::cout << "Saved feature matches: " << matchesFilename << '\n';
+    std::cout << "Estimated homography:\n" << homography << '\n';
+  } catch (const std::exception& error) {
+    std::cerr << "Error: " << error.what() << '\n';
+    return 1;
+  }
+
+  return 0;
 }

--- a/ImageAlignment-FeatureBased/align.py
+++ b/ImageAlignment-FeatureBased/align.py
@@ -1,78 +1,260 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
 import cv2
 import numpy as np
 
 
 MAX_MATCHES = 500
 GOOD_MATCH_PERCENT = 0.15
+MIN_HOMOGRAPHY_MATCHES = 4
 
 
-def alignImages(im1, im2):
-
-  # Convert images to grayscale
-  im1Gray = cv2.cvtColor(im1, cv2.COLOR_BGR2GRAY)
-  im2Gray = cv2.cvtColor(im2, cv2.COLOR_BGR2GRAY)
-  
-  # Detect ORB features and compute descriptors.
-  orb = cv2.ORB_create(MAX_MATCHES)
-  keypoints1, descriptors1 = orb.detectAndCompute(im1Gray, None)
-  keypoints2, descriptors2 = orb.detectAndCompute(im2Gray, None)
-  
-  # Match features.
-  matcher = cv2.DescriptorMatcher_create(cv2.DESCRIPTOR_MATCHER_BRUTEFORCE_HAMMING)
-  matches = list(matcher.match(descriptors1, descriptors2, None))
-  
-  # Sort matches by score
-  matches.sort(key=lambda x: x.distance, reverse=False)
-
-  # Remove not so good matches
-  numGoodMatches = int(len(matches) * GOOD_MATCH_PERCENT)
-  matches = matches[:numGoodMatches]
-
-  # Draw top matches
-  imMatches = cv2.drawMatches(im1, keypoints1, im2, keypoints2, matches, None)
-  cv2.imwrite("matches.jpg", imMatches)
-  
-  # Extract location of good matches
-  points1 = np.zeros((len(matches), 2), dtype=np.float32)
-  points2 = np.zeros((len(matches), 2), dtype=np.float32)
-
-  for i, match in enumerate(matches):
-    points1[i, :] = keypoints1[match.queryIdx].pt
-    points2[i, :] = keypoints2[match.trainIdx].pt
-  
-  # Find homography
-  h, mask = cv2.findHomography(points1, points2, cv2.RANSAC)
-
-  # Use homography
-  height, width, channels = im2.shape
-  im1Reg = cv2.warpPerspective(im1, h, (width, height))
-  
-  return im1Reg, h
+class AlignmentStats(NamedTuple):
+    input_keypoints: int
+    reference_keypoints: int
+    total_matches: int
+    retained_matches: int
+    inlier_matches: int
 
 
-if __name__ == '__main__':
-  
-  # Read reference image
-  refFilename = "form.jpg"
-  print("Reading reference image : ", refFilename)
-  imReference = cv2.imread(refFilename, cv2.IMREAD_COLOR)
+def _write_image(filename, image):
+    filename = Path(filename)
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    if not cv2.imwrite(str(filename), image):
+        raise OSError(f"Could not write image: {filename}")
 
-  # Read image to be aligned
-  imFilename = "scanned-form.jpg"
-  print("Reading image to align : ", imFilename);  
-  im = cv2.imread(imFilename, cv2.IMREAD_COLOR)
-  
-  print("Aligning images ...")
-  # Registered image will be resotred in imReg. 
-  # The estimated homography will be stored in h. 
-  imReg, h = alignImages(im, imReference)
-  
-  # Write aligned image to disk. 
-  outFilename = "aligned.jpg"
-  print("Saving aligned image : ", outFilename); 
-  cv2.imwrite(outFilename, imReg)
 
-  # Print estimated homography
-  print("Estimated homography : \n",  h)
-  
+def _match_sort_key(match, keypoints1, keypoints2):
+    point1 = keypoints1[match.queryIdx].pt
+    point2 = keypoints2[match.trainIdx].pt
+    return (
+        float(match.distance),
+        float(point1[1]),
+        float(point1[0]),
+        float(point2[1]),
+        float(point2[0]),
+        int(match.queryIdx),
+        int(match.trainIdx),
+        int(match.imgIdx),
+    )
+
+
+def _align_images_impl(image, reference, matches_filename=None):
+    if image is None or image.size == 0:
+        raise ValueError("The image to align is empty")
+    if reference is None or reference.size == 0:
+        raise ValueError("The reference image is empty")
+
+    image_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    reference_gray = cv2.cvtColor(reference, cv2.COLOR_BGR2GRAY)
+
+    orb = cv2.ORB_create(MAX_MATCHES)
+    keypoints1, descriptors1 = orb.detectAndCompute(image_gray, None)
+    keypoints2, descriptors2 = orb.detectAndCompute(reference_gray, None)
+
+    if descriptors1 is None or descriptors2 is None:
+        raise ValueError("ORB could not find features in both images")
+
+    matcher = cv2.BFMatcher_create(cv2.NORM_HAMMING, False)
+    matches = list(matcher.match(descriptors1, descriptors2))
+
+    if len(matches) < MIN_HOMOGRAPHY_MATCHES:
+        raise ValueError(
+            f"At least {MIN_HOMOGRAPHY_MATCHES} feature matches are required; "
+            f"found {len(matches)}"
+        )
+
+    matches.sort(key=lambda match: _match_sort_key(match, keypoints1, keypoints2))
+    nominal_match_count = max(
+        MIN_HOMOGRAPHY_MATCHES,
+        int(len(matches) * GOOD_MATCH_PERCENT),
+    )
+    cutoff_distance = matches[nominal_match_count - 1].distance
+    good_matches = [
+        match for match in matches if match.distance <= cutoff_distance
+    ]
+
+    if matches_filename is not None:
+        matches_image = cv2.drawMatches(
+            image,
+            keypoints1,
+            reference,
+            keypoints2,
+            good_matches,
+            None,
+            matchColor=(0, 255, 0),
+            singlePointColor=(255, 0, 0),
+            flags=cv2.DrawMatchesFlags_DEFAULT,
+        )
+        _write_image(matches_filename, matches_image)
+
+    points1 = np.float32([keypoints1[match.queryIdx].pt for match in good_matches])
+    points2 = np.float32([keypoints2[match.trainIdx].pt for match in good_matches])
+
+    homography, inlier_mask = cv2.findHomography(points1, points2, cv2.RANSAC)
+    if homography is None or not np.isfinite(homography).all():
+        raise ValueError("Could not estimate a valid homography")
+    if inlier_mask is None:
+        raise ValueError("Could not determine homography inliers")
+
+    height, width = reference.shape[:2]
+    aligned = cv2.warpPerspective(image, homography, (width, height))
+    stats = AlignmentStats(
+        input_keypoints=len(keypoints1),
+        reference_keypoints=len(keypoints2),
+        total_matches=len(matches),
+        retained_matches=len(good_matches),
+        inlier_matches=int(np.count_nonzero(inlier_mask)),
+    )
+    return aligned, homography, stats
+
+
+def align_images(image, reference, matches_filename=None):
+    """Align ``image`` to ``reference`` and return the image and homography."""
+    aligned, homography, _ = _align_images_impl(
+        image,
+        reference,
+        matches_filename,
+    )
+    return aligned, homography
+
+
+def alignImages(image, reference):
+    """Backward-compatible wrapper used by the original LearnOpenCV article."""
+    return align_images(image, reference, "matches.jpg")
+
+
+def _read_image(filename, description):
+    image = cv2.imread(str(filename), cv2.IMREAD_COLOR)
+    if image is None:
+        raise FileNotFoundError(f"Could not read {description}: {filename}")
+    return image
+
+
+def validate_alignment(image, reference, aligned):
+    if aligned.shape != reference.shape:
+        raise ValueError("Aligned image dimensions do not match the reference")
+
+    resized_input = cv2.resize(image, (reference.shape[1], reference.shape[0]))
+    before = float(np.mean(cv2.absdiff(resized_input, reference)))
+    after = float(np.mean(cv2.absdiff(aligned, reference)))
+    print(f"Alignment MAE before: {before:.6f}")
+    print(f"Alignment MAE after: {after:.6f}")
+    if (
+        not np.isfinite((before, after)).all()
+        or before <= 0
+        or after >= before * 0.4
+    ):
+        raise ValueError("Alignment did not improve mean absolute error by at least 60%")
+
+
+def validate_written_outputs(
+    aligned_path,
+    matches_path,
+    aligned_shape,
+    matches_shape,
+):
+    aligned = _read_image(aligned_path, "written aligned image")
+    matches = _read_image(matches_path, "written feature matches image")
+    if aligned.shape != aligned_shape:
+        raise ValueError(
+            "Written aligned image dimensions do not match the reference"
+        )
+    if matches.shape != matches_shape:
+        raise ValueError(
+            "Written feature matches dimensions are not as expected"
+        )
+
+
+def parse_args(argv=None):
+    project_dir = Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser(
+        description="Feature-based image alignment with OpenCV"
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=project_dir / "scanned-form.jpg",
+        help="image to align",
+    )
+    parser.add_argument(
+        "--reference",
+        type=Path,
+        default=project_dir / "form.jpg",
+        help="reference image",
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument(
+        "--no-display",
+        action="store_true",
+        help="accepted for headless workflows",
+    )
+    parser.add_argument("--validate", action="store_true")
+    return parser.parse_args(argv)
+
+
+def run(args):
+    output_dir = args.output_dir.resolve()
+    aligned_path = output_dir / "aligned.jpg"
+    matches_path = output_dir / "matches.jpg"
+    print(f"OpenCV version: {cv2.__version__}")
+    print(f"Reading reference image: {args.reference}")
+    reference = _read_image(args.reference, "reference image")
+    print(f"Reading image to align: {args.input}")
+    image = _read_image(args.input, "input image")
+
+    print("Aligning images ...")
+    aligned, homography, stats = _align_images_impl(
+        image,
+        reference,
+        matches_path,
+    )
+    print(
+        "Detected keypoints: "
+        f"input={stats.input_keypoints}, reference={stats.reference_keypoints}"
+    )
+    print(
+        "Feature matches: "
+        f"total={stats.total_matches}, retained={stats.retained_matches}, "
+        f"inliers={stats.inlier_matches}"
+    )
+    if args.validate:
+        validate_alignment(image, reference, aligned)
+    _write_image(aligned_path, aligned)
+    if args.validate:
+        matches_shape = (
+            max(image.shape[0], reference.shape[0]),
+            image.shape[1] + reference.shape[1],
+            3,
+        )
+        validate_written_outputs(
+            aligned_path,
+            matches_path,
+            reference.shape,
+            matches_shape,
+        )
+
+    print(f"Saved aligned image: {aligned_path}")
+    print(f"Saved feature matches: {matches_path}")
+    print("Estimated homography:\n", homography)
+    if args.validate:
+        print("Alignment validation passed")
+    return aligned, homography
+
+
+def main(argv=None):
+    try:
+        run(parse_args(argv))
+    except (OSError, ValueError, cv2.error) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ImageAlignment-FeatureBased/requirements.txt
+++ b/ImageAlignment-FeatureBased/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.23,<3
+opencv-python>=4.8,<6

--- a/ImageAlignment-FeatureBased/tests/check_cpp_cli.cmake
+++ b/ImageAlignment-FeatureBased/tests/check_cpp_cli.cmake
@@ -1,0 +1,108 @@
+foreach(required_variable EXECUTABLE PROJECT_DIR TEST_ROOT)
+  if(NOT DEFINED ${required_variable})
+    message(FATAL_ERROR "${required_variable} was not provided")
+  endif()
+endforeach()
+
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY "${TEST_ROOT}/unrelated-cwd")
+
+function(run_success label output_directory)
+  execute_process(
+    COMMAND
+      "${EXECUTABLE}"
+      ${ARGN}
+      --output-dir "${output_directory}"
+      --no-display
+      --validate
+    WORKING_DIRECTORY "${TEST_ROOT}/unrelated-cwd"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE stdout
+    ERROR_VARIABLE stderr
+  )
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR
+      "${label} failed with exit ${result}\nstdout:\n${stdout}\nstderr:\n${stderr}"
+    )
+  endif()
+
+  string(FIND "${stdout}" "Alignment validation passed" validation_position)
+  if(validation_position EQUAL -1)
+    message(FATAL_ERROR "${label} did not print the validation marker")
+  endif()
+  string(FIND
+    "${stdout}"
+    "Feature matches: total=500, retained=78, inliers=51"
+    metrics_position
+  )
+  if(metrics_position EQUAL -1)
+    message(FATAL_ERROR
+      "${label} did not report the expected feature-match metrics\n${stdout}"
+    )
+  endif()
+
+  file(GLOB output_entries
+    RELATIVE "${output_directory}"
+    "${output_directory}/*"
+  )
+  list(SORT output_entries)
+  set(expected_entries aligned.jpg matches.jpg)
+  if(NOT "${output_entries}" STREQUAL "${expected_entries}")
+    message(FATAL_ERROR
+      "${label} output manifest was '${output_entries}', expected '${expected_entries}'"
+    )
+  endif()
+
+  foreach(output_file IN LISTS expected_entries)
+    file(SIZE "${output_directory}/${output_file}" output_size)
+    if(output_size EQUAL 0)
+      message(FATAL_ERROR "${label} wrote an empty ${output_file}")
+    endif()
+  endforeach()
+
+  message("${stdout}")
+endfunction()
+
+function(run_failure label expected_error)
+  execute_process(
+    COMMAND "${EXECUTABLE}" ${ARGN}
+    WORKING_DIRECTORY "${TEST_ROOT}/unrelated-cwd"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE stdout
+    ERROR_VARIABLE stderr
+  )
+  if(NOT result EQUAL 1)
+    message(FATAL_ERROR
+      "${label} returned '${result}', expected a clean exit status of 1"
+    )
+  endif()
+  string(FIND "${stderr}" "${expected_error}" error_position)
+  if(error_position EQUAL -1)
+    message(FATAL_ERROR
+      "${label} did not report '${expected_error}'\nstdout:\n${stdout}\nstderr:\n${stderr}"
+    )
+  endif()
+endfunction()
+
+run_success(default_inputs "${TEST_ROOT}/default")
+run_success(
+  explicit_inputs
+  "${TEST_ROOT}/nested/explicit"
+  --input "${PROJECT_DIR}/scanned-form.jpg"
+  --reference "${PROJECT_DIR}/form.jpg"
+)
+
+run_failure(
+  missing_input
+  "Could not read input image"
+  --input "${TEST_ROOT}/missing-input.jpg"
+  --output-dir "${TEST_ROOT}/failure-output"
+)
+run_failure(
+  missing_reference
+  "Could not read reference image"
+  --reference "${TEST_ROOT}/missing-reference.jpg"
+  --output-dir "${TEST_ROOT}/failure-output"
+)
+run_failure(unknown_argument "Unknown argument" --unknown)
+run_failure(missing_option_value "Missing value for --input" --input)

--- a/ImageAlignment-FeatureBased/tests/test_alignment.py
+++ b/ImageAlignment-FeatureBased/tests/test_alignment.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_DIR / "align.py"
+sys.path.insert(0, str(PROJECT_DIR))
+
+from align import _align_images_impl, align_images, alignImages  # noqa: E402
+
+
+EXPECTED_STATS = (500, 500, 500, 78, 51)
+EXPECTED_OUTPUTS = {"aligned.jpg", "matches.jpg"}
+
+
+class FeatureAlignmentTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.image = cv2.imread(
+            str(PROJECT_DIR / "scanned-form.jpg"),
+            cv2.IMREAD_COLOR,
+        )
+        cls.reference = cv2.imread(
+            str(PROJECT_DIR / "form.jpg"),
+            cv2.IMREAD_COLOR,
+        )
+        if cls.image is None or cls.reference is None:
+            raise RuntimeError("Could not load the bundled alignment fixtures")
+
+    def _run_cli(self, working_directory, *arguments):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *map(str, arguments)],
+            cwd=working_directory,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def _assert_successful_outputs(self, result, output_directory):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Alignment validation passed", result.stdout)
+        self.assertIn(
+            "Feature matches: total=500, retained=78, inliers=51",
+            result.stdout,
+        )
+        self.assertEqual(
+            {path.name for path in output_directory.iterdir()},
+            EXPECTED_OUTPUTS,
+        )
+
+        aligned = cv2.imread(
+            str(output_directory / "aligned.jpg"),
+            cv2.IMREAD_COLOR,
+        )
+        matches = cv2.imread(
+            str(output_directory / "matches.jpg"),
+            cv2.IMREAD_COLOR,
+        )
+        self.assertIsNotNone(aligned)
+        self.assertIsNotNone(matches)
+        self.assertEqual(aligned.shape, self.reference.shape)
+        self.assertEqual(
+            matches.shape,
+            (
+                max(self.image.shape[0], self.reference.shape[0]),
+                self.image.shape[1] + self.reference.shape[1],
+                3,
+            ),
+        )
+
+    def test_align_images_fixture_contract(self):
+        aligned, homography, stats = _align_images_impl(
+            self.image,
+            self.reference,
+        )
+        resized_input = cv2.resize(
+            self.image,
+            (self.reference.shape[1], self.reference.shape[0]),
+        )
+        before = float(np.mean(cv2.absdiff(resized_input, self.reference)))
+        after = float(np.mean(cv2.absdiff(aligned, self.reference)))
+
+        self.assertEqual(tuple(stats), EXPECTED_STATS)
+        self.assertEqual(aligned.shape, self.reference.shape)
+        self.assertEqual(homography.shape, (3, 3))
+        self.assertTrue(np.isfinite(homography).all())
+        self.assertNotEqual(float(np.linalg.det(homography)), 0.0)
+        self.assertGreater(after / before, 0.23)
+        self.assertLess(after / before, 0.30)
+
+    def test_alignment_is_repeatable(self):
+        _, first = align_images(self.image, self.reference)
+        _, second = align_images(self.image, self.reference)
+        corners = np.float32(
+            [
+                [0, 0],
+                [self.image.shape[1] - 1, 0],
+                [self.image.shape[1] - 1, self.image.shape[0] - 1],
+                [0, self.image.shape[0] - 1],
+            ]
+        ).reshape(-1, 1, 2)
+        first_projection = cv2.perspectiveTransform(corners, first)
+        second_projection = cv2.perspectiveTransform(corners, second)
+        np.testing.assert_allclose(
+            first_projection,
+            second_projection,
+            rtol=0,
+            atol=1e-6,
+        )
+
+    def test_legacy_alignImages_wrapper(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            original_directory = Path.cwd()
+            os.chdir(temporary_directory)
+            try:
+                aligned, homography = alignImages(self.image, self.reference)
+            finally:
+                os.chdir(original_directory)
+
+            matches_path = Path(temporary_directory) / "matches.jpg"
+            self.assertTrue(matches_path.is_file())
+            self.assertGreater(matches_path.stat().st_size, 0)
+            self.assertEqual(aligned.shape, self.reference.shape)
+            self.assertEqual(homography.shape, (3, 3))
+
+    def test_featureless_images_fail_cleanly(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
+        with self.assertRaisesRegex(ValueError, "features"):
+            align_images(blank, blank)
+
+    def test_cli_defaults_from_unrelated_working_directory(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            working_directory = temporary_path / "unrelated"
+            output_directory = temporary_path / "nested" / "default-output"
+            working_directory.mkdir()
+            result = self._run_cli(
+                working_directory,
+                "--output-dir",
+                output_directory,
+                "--no-display",
+                "--validate",
+            )
+            self._assert_successful_outputs(result, output_directory)
+
+    def test_cli_explicit_inputs_and_nested_output_directory(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            working_directory = temporary_path / "unrelated"
+            output_directory = temporary_path / "nested" / "explicit-output"
+            working_directory.mkdir()
+            result = self._run_cli(
+                working_directory,
+                "--input",
+                PROJECT_DIR / "scanned-form.jpg",
+                "--reference",
+                PROJECT_DIR / "form.jpg",
+                "--output-dir",
+                output_directory,
+                "--no-display",
+                "--validate",
+            )
+            self._assert_successful_outputs(result, output_directory)
+
+    def test_cli_missing_inputs_fail_cleanly(self):
+        cases = (
+            (
+                "--input",
+                "missing-input.jpg",
+                "Could not read input image",
+            ),
+            (
+                "--reference",
+                "missing-reference.jpg",
+                "Could not read reference image",
+            ),
+        )
+        for option, filename, expected_error in cases:
+            with self.subTest(option=option):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    temporary_path = Path(temporary_directory)
+                    output_directory = temporary_path / "output"
+                    result = self._run_cli(
+                        temporary_path,
+                        option,
+                        temporary_path / filename,
+                        "--output-dir",
+                        output_directory,
+                        "--no-display",
+                        "--validate",
+                    )
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn(expected_error, result.stderr)
+                    self.assertNotIn("Traceback", result.stderr)
+                    self.assertFalse(output_directory.exists())
+
+    def test_cli_unknown_argument(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = self._run_cli(
+                temporary_directory,
+                "--unknown",
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("unrecognized arguments: --unknown", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 
 | Blog Post | Code|
 | ------------- |:-------------|
+| [Feature-Based Image Alignment with OpenCV 4 and 5 (C++ and Python)](https://learnopencv.com/image-alignment-feature-based-using-opencv-c-python/) | [Code](https://github.com/spmallick/learnopencv/tree/master/ImageAlignment-FeatureBased) |
 | [Contour Detection using OpenCV (Python/C++)](https://learnopencv.com/contour-detection-using-opencv-python-c/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Contour-Detection-using-OpenCV) |
 | [Install OpenCV 5 on Linux](https://learnopencv.com/install-opencv-5-linux/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Install-OpenCV-5-on-Linux) |
 | [Decoding Virat Kohli's Flick Shot: AI-Based 3D Motion Reconstruction](https://learnopencv.com/decoding-virat-kohlis-flick-shot-ai-based-3d-motion-reconstruction/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Decoding-Virats-Flick-Shot) |
@@ -438,7 +439,6 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 |[How to convert your OpenCV C++ code into a Python module](https://www.learnopencv.com/how-to-convert-your-opencv-c-code-into-a-python-module/)|[Code](https://github.com/spmallick/learnopencv/tree/master/pymodule)|
 |[CV4Faces : Best Project Award 2018](https://www.learnopencv.com/cv4faces-best-project-award-2018/)| |
 |[Facemark : Facial Landmark Detection using OpenCV](https://www.learnopencv.com/facemark-facial-landmark-detection-using-opencv/)|[Code](https://github.com/spmallick/learnopencv/tree/master/FacialLandmarkDetection)|
-|[Image Alignment (Feature Based) using OpenCV (C++/Python)](https://www.learnopencv.com/image-alignment-feature-based-using-opencv-c-python/)| [Code](https://github.com/spmallick/learnopencv/tree/master/ImageAlignment-FeatureBased)|
 |[Barcode and QR code Scanner using ZBar and OpenCV](https://www.learnopencv.com/barcode-and-qr-code-scanner-using-zbar-and-opencv/)| [Code](https://github.com/spmallick/learnopencv/tree/master/barcode-QRcodeScanner)|
 |[Keras Tutorial : Fine-tuning using pre-trained models](https://www.learnopencv.com/keras-tutorial-fine-tuning-using-pre-trained-models/)| [Code](https://github.com/spmallick/learnopencv/tree/master/Keras-Fine-Tuning)|
 |[OpenCV Transparent API](https://www.learnopencv.com/opencv-transparent-api/)| |


### PR DESCRIPTION
## What changed

- Modernize `ImageAlignment-FeatureBased` for OpenCV 4.8 through OpenCV 5.
- Add CMake/C++17 compatibility, a Python CLI, headless validation, deterministic tie-aware match retention, and safety checks.
- Add Python and C++ regression tests.
- Move the refreshed LearnOpenCV article to the top of the main README without duplicating its existing entry.

## Validation

- Python regression suite: 8/8 passed with OpenCV 4.14.0 and OpenCV 5.0.0.
- C++ CTest suite: 1/1 passed with OpenCV 4.14.0 and OpenCV 5.0.0.
- The updated example tree matches the previously reviewed commit exactly.
- `git diff --check` passed.