### PR TITLE
Link FPS standalone GitHub Release

### DIFF
--- a/FPS/README.md
+++ b/FPS/README.md
@@ -11,6 +11,24 @@ The compatibility target is:
 
 The examples use APIs shared by OpenCV 4.x and 5.x, and CMake rejects major versions other than 4 and 5. The automated acceptance matrix is run against the exact OpenCV 4.14.0 and 5.0.0 releases.
 
+## Download the standalone project
+
+Download the immutable, versioned [FPS.zip](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip) bundle and its [SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip.sha256). The ZIP contains exactly one top-level `FPS/` directory with the eight files shown in the directory layout below.
+
+On macOS or Linux, download and verify both files before extracting the project:
+
+```bash
+curl --fail --location --remote-name \
+  https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip
+curl --fail --location --remote-name \
+  https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip.sha256
+shasum -a 256 -c FPS.zip.sha256
+unzip FPS.zip
+cd FPS
+```
+
+The expected SHA-256 digest for `FPS.zip` is `12e1e6fd48c4fdc00907c970d73616d1cbc1ef85fb9a353843299ebbab311bbf`.
+
 ## What the example measures
 
 The examples report two different values:


### PR DESCRIPTION
## What changed

- Add immutable download links for the versioned `FPS.zip` bundle and its SHA-256 checksum.
- Document download, checksum verification, extraction, and working-directory commands.
- Record the verified archive digest and the exact one-root, eight-file payload.

## Why

The upgraded FPS project did not yet have a maintained standalone download. The previous legacy Dropbox bundle was stale and did not contain the complete OpenCV 4.14/5 project.

## Impact

Readers can download the exact tested project from a versioned GitHub Release instead of cloning the monorepo. The tutorial commands, directory tree, and BigVision footer are otherwise unchanged.

## Validation

- Published release: `fps-opencv-2026.07.23`
- Public ZIP and checksum downloaded without GitHub credentials.
- Both public assets matched the locally verified files byte-for-byte.
- Public checksum and ZIP integrity checks passed.
- README links, digest, and eight-file directory tree match the published archive.
- `git diff --check` passed.
- BigVision footer remained byte-for-byte identical.
