### PR TITLE
Add versioned VideoStabilization download

### DIFF
--- a/VideoStabilization/README.md
+++ b/VideoStabilization/README.md
@@ -6,6 +6,8 @@ tutorial. Both examples track point features between adjacent frames, estimate
 partial-affine camera motion, smooth the resulting trajectory, and write the
 original and stabilized views side by side.
 
+Download the immutable, versioned [VideoStabilization.zip](https://github.com/spmallick/learnopencv/releases/download/video-stabilization-opencv-2026.07.24/VideoStabilization.zip) bundle.
+
 ## Compatibility contract
 
 - OpenCV 4.14.0


### PR DESCRIPTION
Adds the immutable GitHub Release ZIP to the project README after public checksum and download verification. The change is confined to VideoStabilization/README.md, and the BigVision footer remains byte-identical.