### PR TITLE
Add OpenCV 5 object tracker examples for Python and C++

### DIFF
--- a/Object-Tracking-OpenCV5/.gitignore
+++ b/Object-Tracking-OpenCV5/.gitignore
@@ -1,0 +1,2 @@
+models/
+__pycache__/

--- a/Object-Tracking-OpenCV5/.gitignore
+++ b/Object-Tracking-OpenCV5/.gitignore
@@ -1,2 +1,5 @@
 models/
 __pycache__/
+.venv/
+cpp/build*/
+outputs/

--- a/Object-Tracking-OpenCV5/README.md
+++ b/Object-Tracking-OpenCV5/README.md
@@ -1,0 +1,138 @@
+# OpenCV 5 Object Trackers: A Complete Guide (C++/Python)
+
+**This repository contains code for the [OpenCV 5 Object Trackers: A Complete Guide (C++/Python)](https://learnopencv.com/opencv5-object-trackers/) blogpost**.
+
+One command-line application — implemented twice, in Python and in C++ — runs every single-object tracker that ships with OpenCV 5:
+
+| Tracker | Type | Module | Model files |
+| --- | --- | --- | --- |
+| MIL | classical | main (`video`) | none |
+| KCF | classical | contrib (`tracking`) | none |
+| CSRT | classical | contrib (`tracking`) | none |
+| DaSiamRPN | deep learning | main (`video`) | 3 ONNX files |
+| NanoTrack v2 | deep learning | main (`video`) | 2 ONNX files |
+| VitTrack | deep learning | main (`video`) | 1 ONNX file |
+
+GOTURN is intentionally absent: OpenCV 5 removed its Caffe DNN importer, and with it the GOTURN tracker. The article covers the migration path.
+
+## Supported versions
+
+- OpenCV **4.9.0 – 5.x** (verified: Python on the **4.13.0.92** and **5.0.0.93** `opencv-contrib-python` wheels; C++ against an **OpenCV 5.0.0 + contrib** source build). The 4.9 floor exists because TrackerVit first shipped in OpenCV 4.9.0.
+- Python 3.9+ with `opencv-contrib-python>=4.9,<6` and `numpy>=1.23,<3`.
+- C++17, CMake 3.16+. KCF and CSRT require an OpenCV build that includes the opencv_contrib `tracking` module; without it the C++ example still builds and the two trackers report themselves unavailable.
+
+## Directory Structure
+
+```text
+Object-Tracking-OpenCV5/
+├── README.md
+├── download_models.py
+├── cpp/
+│   ├── CMakeLists.txt
+│   └── object_tracking.cpp
+└── python/
+    ├── requirements.txt
+    ├── object_tracking.py
+    └── tests/
+        └── test_object_tracking.py
+```
+
+The `models/` directory is created next to `download_models.py` on first download; model files are not committed to the repository.
+
+## Setup
+
+Download the ONNX models for the three deep-learning trackers (the classical trackers need no files):
+
+```shell
+python3 download_models.py
+```
+
+The script verifies SHA-256 checksums where the upstream host publishes stable files and prints the computed hash for every download.
+
+### Python
+
+```shell
+cd python
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### C++
+
+```shell
+cd cpp
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+To build against a specific OpenCV installation, point CMake at it:
+
+```shell
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+      -DOpenCV_DIR=/opt/opencv-5.0.0/lib/cmake/opencv5
+```
+
+## Run
+
+Both implementations expose the same controls. Inputs may be a video path or a numeric camera index; bundled assets are resolved relative to the source location, so any current working directory works.
+
+```shell
+# Python
+python3 python/object_tracking.py --list-trackers
+python3 python/object_tracking.py --tracker vittrack --input video.mp4
+python3 python/object_tracking.py --tracker csrt --input 0
+python3 python/object_tracking.py --tracker nanotrack --input video.mp4 \
+        --bbox 300,150,120,180 --output-dir outputs --no-display
+
+# C++
+./cpp/build/object_tracking --list
+./cpp/build/object_tracking --tracker=vittrack --input=video.mp4
+./cpp/build/object_tracking --tracker=mil --validate --no-display
+```
+
+Options common to both: `--bbox x,y,w,h` (initial box; drawn interactively when omitted), `--models-dir PATH`, `--output-dir PATH` (writes `tracked_<name>.avi` and `metrics_<name>.json`), `--max-frames N`, `--no-display` (headless; requires `--bbox` in normal mode), and `--validate`.
+
+`--validate` generates a deterministic synthetic clip (textured square on a noisy background, seeded), initializes the tracker from the ground-truth box of frame zero, and passes only when mean IoU ≥ 0.45 and at least 90% of frames stay above 0.30 IoU. It prints `VALIDATION PASSED` or `VALIDATION FAILED` and exits accordingly.
+
+## Tests
+
+```shell
+# Python: runs the real CLI in subprocesses, headless, from temp directories.
+python3 -m unittest discover -s python/tests -v
+
+# C++: one CTest regression per available tracker plus error-handling checks.
+cd cpp/build && ctest --output-on-failure
+```
+
+Trackers that are unavailable in the current build (no contrib) or whose models are not downloaded are skipped with an explicit reason. CTest registers the DNN-tracker tests only when the model files exist at configure time.
+
+## Compatibility notes
+
+- The same sources run unchanged on OpenCV 4.9+ and 5.x. On the reference synthetic clip, per-tracker mean IoU agreed to four decimal places between OpenCV 4.x and 5.0 in the Python matrix.
+- OpenCV 5's new DNN graph engine prints `setPreferableTarget` warnings when the DNN trackers load; they are harmless and do not affect results.
+- The C++ and Python synthetic clips share the same geometry, trajectory, and thresholds, but use different random generators, so their pixels (and exact IoU values) differ slightly across languages by design.
+- Performance is platform- and workload-specific; the FPS overlay measures tracker updates only.
+
+---
+
+<p align="center">
+  <a href="https://bigvision.ai/">
+    <img src="https://bigvision.ai/logos/logo.png" alt="BigVision.AI" width="300">
+  </a>
+</p>
+
+<h2 align="center">Build Production-Ready Computer Vision &amp; AI Solutions</h2>
+
+<p align="center">
+  LearnOpenCV is maintained by <a href="https://bigvision.ai/"><strong>BigVision.AI</strong></a>, a computer vision and AI consulting company. We help organizations design, build, optimize, and deploy production-ready AI solutions. Our team has deep expertise in computer vision, deep learning, multimodal AI, and edge deployment, with experience solving complex technical challenges across industries.
+</p>
+
+<p align="center">
+  Have a project in mind? Talk with our expert AI solution builders.
+</p>
+
+<p align="center">
+  <a href="https://bigvision.ai/expert-ai-solution-builders?utm_source=locv-github">
+    <img src="https://img.shields.io/badge/Get%20in%20Touch-087EA4?style=for-the-badge" alt="Get in Touch with BigVision.AI">
+  </a>
+</p>

--- a/Object-Tracking-OpenCV5/README.md
+++ b/Object-Tracking-OpenCV5/README.md
@@ -1,8 +1,10 @@
 # OpenCV 5 Object Trackers: A Complete Guide (C++/Python)
 
-**This repository contains code for the [OpenCV 5 Object Trackers: A Complete Guide (C++/Python)](https://learnopencv.com/opencv5-object-trackers/) blogpost**.
+This is the companion code for LearnOpenCV's **OpenCV 5 Object Trackers:
+A Complete Guide (C++/Python)**.
 
-One command-line application — implemented twice, in Python and in C++ — runs every single-object tracker that ships with OpenCV 5:
+One command-line application—implemented in both Python and C++—runs the six
+single-object trackers in OpenCV 5's modern, non-legacy `cv::Tracker` API:
 
 | Tracker | Type | Module | Model files |
 | --- | --- | --- | --- |
@@ -13,68 +15,100 @@ One command-line application — implemented twice, in Python and in C++ — run
 | NanoTrack v2 | deep learning | main (`video`) | 2 ONNX files |
 | VitTrack | deep learning | main (`video`) | 1 ONNX file |
 
-GOTURN is intentionally absent: OpenCV 5 removed its Caffe DNN importer, and with it the GOTURN tracker. The article covers the migration path.
+Older Boosting, MedianFlow, TLD, and MOSSE implementations remain under the
+separate `cv::legacy`/`cv2.legacy` API and are outside this example's scope.
+GOTURN is intentionally absent: OpenCV 5 removed its Caffe DNN importer, and
+with it the GOTURN tracker. The article covers the migration path.
 
-## Supported versions
+## Supported and tested versions
 
-- OpenCV **4.9.0 – 5.x** (verified: Python on the **4.13.0.92** and **5.0.0.93** `opencv-contrib-python` wheels; C++ against an **OpenCV 5.0.0 + contrib** source build). The 4.9 floor exists because TrackerVit first shipped in OpenCV 4.9.0.
-- Python 3.9+ with `opencv-contrib-python>=4.9,<6` and `numpy>=1.23,<3`.
-- C++17, CMake 3.16+. KCF and CSRT require an OpenCV build that includes the opencv_contrib `tracking` module; without it the C++ example still builds and the two trackers report themselves unavailable.
+- Acceptance-tested OpenCV versions: **4.14.0** and **5.0.0**, each with
+  `opencv_contrib`.
+- Python 3.9+ with NumPy 1.23–2.x. The dependency range is
+  `opencv-contrib-python>=4.9,<6` and `numpy>=1.23,<3`; TrackerVit establishes
+  the OpenCV 4.9 API floor, while 4.14.0 and 5.0.0 are the exact validation
+  targets.
+- C++17 and CMake 3.16+. OpenCV's `core`, `dnn`, `imgproc`, `videoio`,
+  `highgui`, and `video` modules are required. The contrib `tracking` module
+  enables KCF and CSRT; without it, the other four trackers still build and the
+  unavailable trackers are reported explicitly.
 
-## Directory Structure
+The full matrix was run on macOS arm64 with Python 3.14.3, CMake 3.29.3, and
+AppleClang 21.0.0. Python used source-built OpenCV 4.14.0 plus contrib and the
+`opencv-contrib-python` 5.0.0.93 wheel. C++ used fresh Release source builds for
+both exact OpenCV versions.
+
+## Directory structure
 
 ```text
 Object-Tracking-OpenCV5/
+├── .gitignore
 ├── README.md
 ├── download_models.py
 ├── cpp/
 │   ├── CMakeLists.txt
+│   ├── cmake/
+│   │   ├── RunExpectedFailure.cmake
+│   │   └── RunTrackerValidation.cmake
 │   └── object_tracking.cpp
 └── python/
-    ├── requirements.txt
     ├── object_tracking.py
+    ├── requirements.txt
     └── tests/
+        ├── test_download_models.py
         └── test_object_tracking.py
 ```
 
-The `models/` directory is created next to `download_models.py` on first download; model files are not committed to the repository.
+The generated `models/` directory is deliberately absent from the tracked
+tree. `download_models.py` creates it next to the script.
 
 ## Setup
 
-Download the ONNX models for the three deep-learning trackers (the classical trackers need no files):
+Start in the project root:
+
+```shell
+cd /path/to/learnopencv/Object-Tracking-OpenCV5
+```
+
+Download the six ONNX files used by the three deep-learning trackers:
 
 ```shell
 python3 download_models.py
 ```
 
-The script verifies SHA-256 checksums where the upstream host publishes stable files and prints the computed hash for every download.
+The downloader uses immutable upstream revisions, bounded streaming reads, and
+pinned byte sizes and SHA-256 checksums. It atomically replaces the destination
+only after verification. Use `--models-dir PATH` to choose another destination
+or `--force` to refresh already verified files.
 
 ### Python
 
 ```shell
-cd python
-python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -r python/requirements.txt
 ```
 
 ### C++
 
 ```shell
-cd cpp
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j
+cmake -S cpp -B cpp/build -DCMAKE_BUILD_TYPE=Release
+cmake --build cpp/build -j
 ```
 
-To build against a specific OpenCV installation, point CMake at it:
+Point `OpenCV_DIR` at the exact installation to select a version:
 
 ```shell
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+cmake -S cpp -B cpp/build-5.0.0 -DCMAKE_BUILD_TYPE=Release \
       -DOpenCV_DIR=/opt/opencv-5.0.0/lib/cmake/opencv5
+cmake --build cpp/build-5.0.0 -j
 ```
 
 ## Run
 
-Both implementations expose the same controls. Inputs may be a video path or a numeric camera index; bundled assets are resolved relative to the source location, so any current working directory works.
+Run these commands from the project root. Absolute script, executable, input,
+model, and output paths also work from an unrelated current directory. A
+numeric input selects a camera; any other input is treated as a video path.
 
 ```shell
 # Python
@@ -87,31 +121,74 @@ python3 python/object_tracking.py --tracker nanotrack --input video.mp4 \
 # C++
 ./cpp/build/object_tracking --list
 ./cpp/build/object_tracking --tracker=vittrack --input=video.mp4
-./cpp/build/object_tracking --tracker=mil --validate --no-display
+./cpp/build/object_tracking --tracker=mil --validate --no-display \
+        --output-dir=outputs
 ```
 
-Options common to both: `--bbox x,y,w,h` (initial box; drawn interactively when omitted), `--models-dir PATH`, `--output-dir PATH` (writes `tracked_<name>.avi` and `metrics_<name>.json`), `--max-frames N`, `--no-display` (headless; requires `--bbox` in normal mode), and `--validate`.
+Both implementations support the options below. Python accepts
+`--option value` or `--option=value`; C++ uses `--option=value`.
 
-`--validate` generates a deterministic synthetic clip (textured square on a noisy background, seeded), initializes the tracker from the ground-truth box of frame zero, and passes only when mean IoU ≥ 0.45 and at least 90% of frames stay above 0.30 IoU. It prints `VALIDATION PASSED` or `VALIDATION FAILED` and exits accordingly.
+- `--tracker`: `mil`, `kcf`, `csrt`, `dasiamrpn`, `nanotrack`, or `vittrack`.
+- `--input`: a video path or numeric camera index.
+- `--bbox x,y,w,h`: an initial rectangle; omit it for interactive selection.
+- `--models-dir PATH`: override the source-relative `models/` directory.
+- `--output-dir PATH`: write `tracked_<name>.avi` and
+  `metrics_<name>.json`.
+- `--max-frames N`: stop after at most `N` processed frames; zero means
+  continue until end-of-stream or an interactive stop.
+- `--no-display`: disable windows; normal mode then requires `--bbox`.
+- `--validate`: generate and track a deterministic synthetic clip.
 
-## Tests
+Python uses `--list-trackers`; C++ uses `--list`. Invalid options, malformed or
+out-of-frame boxes, missing inputs, and output failures return a clean nonzero
+exit.
+
+Validation generates an 80-frame, 640×360 clip containing a textured square on
+a seeded noisy background. It initializes from frame zero and passes only when
+the 79 subsequent updates have mean IoU ≥ 0.45 and at least 90% exceed 0.30
+IoU. It writes the synthetic clip, an 80-frame annotated clip, and metrics
+JSON, then prints `VALIDATION PASSED` or `VALIDATION FAILED`.
+
+## Test
 
 ```shell
-# Python: runs the real CLI in subprocesses, headless, from temp directories.
+# Python: 23 tests, including all six tracker entry points.
 python3 -m unittest discover -s python/tests -v
 
-# C++: one CTest regression per available tracker plus error-handling checks.
-cd cpp/build && ctest --output-on-failure
+# C++: 17 tests with contrib and all downloaded models.
+ctest --test-dir cpp/build --output-on-failure
 ```
 
-Trackers that are unavailable in the current build (no contrib) or whose models are not downloaded are skipped with an explicit reason. CTest registers the DNN-tracker tests only when the model files exist at configure time.
+The Python suite runs the real CLI headlessly from temporary working
+directories. Missing DNN model files are explicit skips, while missing APIs,
+corrupt models, and construction failures fail the suite. Each tracker test
+checks the exact artifact set, nonempty files, readable 640×360 videos, 80
+frames, metrics fields, thresholds, and zero lost frames.
+
+CTest uses portable CMake wrappers to check the pass marker, exact artifact
+manifest, nonempty files, readable 80-frame AVIs, metrics keys, frame/loss
+contract, and clean failures for malformed options, values, bounding boxes,
+missing input, and incomplete validation.
+Download models before configuring CMake because DNN tracker tests are
+registered only when their files exist at configure time.
+
+For the acceptance matrix, run both commands with exact OpenCV 4.14.0 and
+5.0.0 environments, use fresh CMake build directories, and also invoke every
+tracker's `--validate --no-display` entry point from an unrelated working
+directory.
 
 ## Compatibility notes
 
-- The same sources run unchanged on OpenCV 4.9+ and 5.x. On the reference synthetic clip, per-tracker mean IoU agreed to four decimal places between OpenCV 4.x and 5.0 in the Python matrix.
+- All six trackers passed the same thresholds on exact OpenCV 4.14.0 and 5.0.0
+  in Python and C++. Tracker scores can differ across OpenCV versions; passing
+  semantics and artifact contracts—not four-decimal score equality—are the
+  compatibility guarantee.
 - OpenCV 5's new DNN graph engine prints `setPreferableTarget` warnings when the DNN trackers load; they are harmless and do not affect results.
 - The C++ and Python synthetic clips share the same geometry, trajectory, and thresholds, but use different random generators, so their pixels (and exact IoU values) differ slightly across languages by design.
-- Performance is platform- and workload-specific; the FPS overlay measures tracker updates only.
+- Output videos preserve the input frame rate when the backend reports one and
+  otherwise use a 30 FPS fallback.
+- Performance is platform- and workload-specific; the FPS overlay measures
+  tracker updates only.
 
 ---
 

--- a/Object-Tracking-OpenCV5/cpp/CMakeLists.txt
+++ b/Object-Tracking-OpenCV5/cpp/CMakeLists.txt
@@ -1,0 +1,94 @@
+# Build configuration for the C++ tracking example.
+#
+# Supports OpenCV 4.x (4.8+) and OpenCV 5.x. Select a specific installation
+# with -DOpenCV_DIR=/path/to/opencv/lib/cmake/opencv5 (or .../opencv4).
+
+# 3.16 is the oldest CMake providing everything used below.
+cmake_minimum_required(VERSION 3.16)
+project(object_tracking LANGUAGES CXX)
+
+# OpenCV 5 requires C++17; we require it uniformly for both majors.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Request only the components this example actually uses. The contrib
+# "tracking" module (KCF, CSRT) is optional: the source detects its absence
+# through opencv_modules.hpp and compiles without those two trackers.
+find_package(OpenCV REQUIRED
+             COMPONENTS core imgproc videoio highgui video
+             OPTIONAL_COMPONENTS tracking)
+
+# Reject unsupported versions early with a clear message. 4.9 is the floor
+# because TrackerVit first shipped in OpenCV 4.9.0.
+if(OpenCV_VERSION VERSION_LESS 4.9 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR
+    "This example supports OpenCV 4.9+ and 5.x, not ${OpenCV_VERSION}")
+endif()
+
+add_executable(object_tracking object_tracking.cpp)
+
+# Target-scoped usage requirements only; no global include/link state.
+target_include_directories(object_tracking PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(object_tracking PRIVATE ${OpenCV_LIBS})
+
+# Bake the shared models directory (next to the project sources) into the
+# binary so it works from any current directory; --models-dir overrides it.
+target_compile_definitions(object_tracking PRIVATE
+  MODELS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../models")
+
+# Strict warnings; MSVC gets its closest equivalents.
+if(MSVC)
+  target_compile_options(object_tracking PRIVATE /W4 /WX)
+else()
+  target_compile_options(object_tracking PRIVATE
+    -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+# ---------------------------------------------------------------------------
+# CTest regressions: run the validation mode headlessly into a build-local
+# output directory and require the explicit success marker.
+# ---------------------------------------------------------------------------
+enable_testing()
+
+# Helper: register one validation test for a tracker name.
+function(add_tracker_test name)
+  add_test(NAME validate_${name}
+           COMMAND object_tracking --tracker=${name} --validate --no-display
+                   --output-dir=${CMAKE_CURRENT_BINARY_DIR}/test_out_${name})
+  set_tests_properties(validate_${name} PROPERTIES
+    PASS_REGULAR_EXPRESSION "VALIDATION PASSED")
+endfunction()
+
+# MIL ships with every supported OpenCV build: always test it.
+add_tracker_test(mil)
+
+# KCF and CSRT exist only when the contrib tracking module was found.
+if(TARGET opencv_tracking OR ";${OpenCV_LIBS};" MATCHES ";opencv_tracking;")
+  add_tracker_test(kcf)
+  add_tracker_test(csrt)
+endif()
+
+# DNN trackers are tested when their model files are present at configure
+# time (fetch them with: python3 ../download_models.py).
+set(_models_dir "${CMAKE_CURRENT_SOURCE_DIR}/../models")
+if(EXISTS "${_models_dir}/nanotrack_backbone_sim.onnx" AND
+   EXISTS "${_models_dir}/nanotrack_head_sim.onnx")
+  add_tracker_test(nanotrack)
+endif()
+if(EXISTS "${_models_dir}/object_tracking_vittrack_2023sep.onnx")
+  add_tracker_test(vittrack)
+endif()
+if(EXISTS "${_models_dir}/dasiamrpn_model.onnx" AND
+   EXISTS "${_models_dir}/dasiamrpn_kernel_cls1.onnx" AND
+   EXISTS "${_models_dir}/dasiamrpn_kernel_r1.onnx")
+  add_tracker_test(dasiamrpn)
+endif()
+
+# The error-handling contract is part of the example: a missing input file
+# must fail with a clean nonzero exit and a readable message.
+add_test(NAME missing_input_fails
+         COMMAND object_tracking --tracker=mil --input=no_such_file.mp4
+                 --bbox=10,10,40,40 --no-display)
+set_tests_properties(missing_input_fails PROPERTIES
+  PASS_REGULAR_EXPRESSION "Cannot open input")

--- a/Object-Tracking-OpenCV5/cpp/CMakeLists.txt
+++ b/Object-Tracking-OpenCV5/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build configuration for the C++ tracking example.
 #
-# Supports OpenCV 4.x (4.8+) and OpenCV 5.x. Select a specific installation
+# Supports OpenCV 4.x (4.9+) and OpenCV 5.x. Select a specific installation
 # with -DOpenCV_DIR=/path/to/opencv/lib/cmake/opencv5 (or .../opencv4).
 
 # 3.16 is the oldest CMake providing everything used below.
@@ -12,11 +12,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Request only the components this example actually uses. The contrib
-# "tracking" module (KCF, CSRT) is optional: the source detects its absence
-# through opencv_modules.hpp and compiles without those two trackers.
+# Request every component used by the tracker implementations. DNN is required
+# because the deep trackers load and execute ONNX networks even though this
+# source does not call cv::dnn APIs directly. The contrib "tracking" module
+# (KCF, CSRT) remains optional: the source detects its absence through
+# opencv_modules.hpp and compiles without those two trackers.
 find_package(OpenCV REQUIRED
-             COMPONENTS core imgproc videoio highgui video
+             COMPONENTS core dnn imgproc videoio highgui video
              OPTIONAL_COMPONENTS tracking)
 
 # Reject unsupported versions early with a clear message. 4.9 is the floor
@@ -46,18 +48,26 @@ else()
 endif()
 
 # ---------------------------------------------------------------------------
-# CTest regressions: run the validation mode headlessly into a build-local
-# output directory and require the explicit success marker.
+# CTest regressions use CMake wrappers rather than relying only on a process
+# exit code. Each wrapper checks the success marker, the exact output manifest,
+# nonempty artifacts, JSON fields, and the readability of both generated AVIs.
 # ---------------------------------------------------------------------------
 enable_testing()
 
 # Helper: register one validation test for a tracker name.
 function(add_tracker_test name)
   add_test(NAME validate_${name}
-           COMMAND object_tracking --tracker=${name} --validate --no-display
-                   --output-dir=${CMAKE_CURRENT_BINARY_DIR}/test_out_${name})
+    COMMAND ${CMAKE_COMMAND}
+      -DEXECUTABLE=$<TARGET_FILE:object_tracking>
+      -DTRACKER=${name}
+      -DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_out_${name}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/RunTrackerValidation.cmake)
   set_tests_properties(validate_${name} PROPERTIES
-    PASS_REGULAR_EXPRESSION "VALIDATION PASSED")
+    # DNN inference can become pathologically slow when multiple trackers
+    # compete for the same CPU. Keep validation deterministic even under
+    # ctest -j or CTEST_PARALLEL_LEVEL, while retaining a bounded timeout.
+    RUN_SERIAL TRUE
+    TIMEOUT 300)
 endfunction()
 
 # MIL ships with every supported OpenCV build: always test it.
@@ -85,10 +95,69 @@ if(EXISTS "${_models_dir}/dasiamrpn_model.onnx" AND
   add_tracker_test(dasiamrpn)
 endif()
 
-# The error-handling contract is part of the example: a missing input file
-# must fail with a clean nonzero exit and a readable message.
-add_test(NAME missing_input_fails
-         COMMAND object_tracking --tracker=mil --input=no_such_file.mp4
-                 --bbox=10,10,40,40 --no-display)
-set_tests_properties(missing_input_fails PROPERTIES
-  PASS_REGULAR_EXPRESSION "Cannot open input")
+# Helper: register a command expected to fail. The wrapper requires both a
+# normal numeric nonzero exit and the case-specific diagnostic text.
+function(add_failure_test name arguments expected_pattern)
+  add_test(NAME ${name}
+    COMMAND ${CMAKE_COMMAND}
+      -DEXECUTABLE=$<TARGET_FILE:object_tracking>
+      "-DTEST_ARGUMENTS=${arguments}"
+      "-DEXPECTED_PATTERN=${expected_pattern}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/RunExpectedFailure.cmake)
+endfunction()
+
+# Missing media, unknown options, and invalid typed values exercise distinct
+# clean-error paths before any validation-generated input is needed.
+add_failure_test(
+  missing_input_fails
+  "--tracker=mil|--input=no_such_file.mp4|--bbox=10,10,40,40|--no-display"
+  "error: Cannot open input")
+add_failure_test(
+  unknown_option_fails
+  "--not-an-option=1"
+  "Unknown option")
+add_failure_test(
+  invalid_max_frames_fails
+  "--max-frames=not-an-integer"
+  "can not convert")
+add_failure_test(
+  negative_max_frames_fails
+  "--max-frames=-1"
+  "--max-frames must be zero or positive")
+add_failure_test(
+  unknown_tracker_fails
+  "--tracker=goturn"
+  "unknown tracker name")
+add_failure_test(
+  output_path_fails
+  "--tracker=mil|--validate|--no-display|--output-dir=${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt"
+  "error:")
+add_failure_test(
+  truncated_validation_fails
+  "--tracker=mil|--validate|--no-display|--max-frames=2|--output-dir=${CMAKE_CURRENT_BINARY_DIR}/test_out_truncated"
+  "VALIDATION FAILED")
+
+# Bounding-box syntax and geometry checks need a real frame. Depend on the MIL
+# validation test, which deterministically creates this 640x360 input clip.
+set(_mil_test_clip
+    "${CMAKE_CURRENT_BINARY_DIR}/test_out_mil/synthetic_clip.avi")
+add_failure_test(
+  bbox_trailing_junk_fails
+  "--tracker=mil|--input=${_mil_test_clip}|--bbox=20,148,64,64junk|--no-display"
+  "expected exactly x,y,w,h integers")
+add_failure_test(
+  bbox_nonpositive_size_fails
+  "--tracker=mil|--input=${_mil_test_clip}|--bbox=20,148,0,64|--no-display"
+  "width and height must be positive")
+add_failure_test(
+  bbox_outside_frame_fails
+  "--tracker=mil|--input=${_mil_test_clip}|--bbox=620,340,40,40|--no-display"
+  "rectangle must lie inside the first frame")
+add_failure_test(
+  headless_without_bbox_fails
+  "--tracker=mil|--input=${_mil_test_clip}|--no-display"
+  "--bbox is required when --no-display is set")
+set_tests_properties(
+  bbox_trailing_junk_fails bbox_nonpositive_size_fails bbox_outside_frame_fails
+  headless_without_bbox_fails
+  PROPERTIES DEPENDS validate_mil)

--- a/Object-Tracking-OpenCV5/cpp/cmake/RunExpectedFailure.cmake
+++ b/Object-Tracking-OpenCV5/cpp/cmake/RunExpectedFailure.cmake
@@ -1,0 +1,40 @@
+# Verify that an intentionally invalid invocation fails cleanly and explains
+# the problem. This is stronger than CTest's WILL_FAIL property, which by itself
+# cannot distinguish a handled command error from a crash or signal.
+
+cmake_minimum_required(VERSION 3.16)
+
+foreach(_required_variable IN ITEMS EXECUTABLE TEST_ARGUMENTS EXPECTED_PATTERN)
+  if(NOT DEFINED ${_required_variable} OR "${${_required_variable}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_variable} must be provided")
+  endif()
+endforeach()
+
+# CMake lists use semicolons, while a vertical bar is safe in all arguments
+# registered by this project. Convert the transport representation back into
+# the executable's individual argv entries.
+string(REPLACE "|" ";" _arguments "${TEST_ARGUMENTS}")
+execute_process(
+  COMMAND "${EXECUTABLE}" ${_arguments}
+  RESULT_VARIABLE _result
+  OUTPUT_VARIABLE _stdout
+  ERROR_VARIABLE _stderr)
+set(_log "${_stdout}${_stderr}")
+
+# A numeric result demonstrates a normal process exit. Text such as "Subprocess
+# aborted" would indicate a signal or crash and must never count as clean.
+if(NOT "${_result}" MATCHES "^[0-9]+$")
+  message(FATAL_ERROR
+    "Invalid invocation did not exit cleanly (${_result}):\n${_log}")
+endif()
+if("${_result}" STREQUAL "0")
+  message(FATAL_ERROR
+    "Invalid invocation unexpectedly succeeded:\n${_log}")
+endif()
+if(NOT _log MATCHES "${EXPECTED_PATTERN}")
+  message(FATAL_ERROR
+    "Failure output omitted '${EXPECTED_PATTERN}':\n${_log}")
+endif()
+
+message(STATUS
+  "Clean failure exit ${_result} included '${EXPECTED_PATTERN}'")

--- a/Object-Tracking-OpenCV5/cpp/cmake/RunTrackerValidation.cmake
+++ b/Object-Tracking-OpenCV5/cpp/cmake/RunTrackerValidation.cmake
@@ -1,0 +1,191 @@
+# Run one tracker regression and independently verify its observable contract.
+# Keeping these checks in a CMake script makes them available anywhere CTest
+# runs, without requiring a particular shell, Python interpreter, or codec tool.
+
+cmake_minimum_required(VERSION 3.16)
+
+# Stop immediately when the test registration omitted a required value. A
+# configuration typo should not be mistaken for a tracker regression.
+foreach(_required_variable IN ITEMS EXECUTABLE TRACKER OUTPUT_DIR)
+  if(NOT DEFINED ${_required_variable} OR "${${_required_variable}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_variable} must be provided")
+  endif()
+endforeach()
+
+# Every run starts from an empty directory so stale files cannot satisfy the
+# artifact checks and unexpected new outputs are visible in the manifest.
+file(REMOVE_RECURSE "${OUTPUT_DIR}")
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+execute_process(
+  COMMAND "${EXECUTABLE}"
+          "--tracker=${TRACKER}"
+          --validate
+          --no-display
+          "--output-dir=${OUTPUT_DIR}"
+  RESULT_VARIABLE _validation_result
+  OUTPUT_VARIABLE _validation_stdout
+  ERROR_VARIABLE _validation_stderr)
+set(_validation_log "${_validation_stdout}${_validation_stderr}")
+
+# A successful process must also print the tutorial's explicit validation
+# marker; checking both prevents a swallowed failure or accidental early exit.
+if(NOT "${_validation_result}" STREQUAL "0")
+  message(FATAL_ERROR
+    "${TRACKER} validation exited ${_validation_result}:\n${_validation_log}")
+endif()
+if(NOT _validation_log MATCHES "VALIDATION PASSED")
+  message(FATAL_ERROR
+    "${TRACKER} validation omitted VALIDATION PASSED:\n${_validation_log}")
+endif()
+
+# Validation promises exactly these three files. Sort both lists before
+# comparing so the check is independent of filesystem enumeration order.
+set(_expected_artifacts
+    "metrics_${TRACKER}.json"
+    "synthetic_clip.avi"
+    "tracked_${TRACKER}.avi")
+list(SORT _expected_artifacts)
+file(GLOB _actual_artifacts
+     LIST_DIRECTORIES false
+     RELATIVE "${OUTPUT_DIR}"
+     "${OUTPUT_DIR}/*")
+list(SORT _actual_artifacts)
+if(NOT "${_actual_artifacts}" STREQUAL "${_expected_artifacts}")
+  message(FATAL_ERROR
+    "${TRACKER} artifacts differ.\n"
+    "Expected: ${_expected_artifacts}\n"
+    "Actual:   ${_actual_artifacts}")
+endif()
+
+# Empty media or JSON files are never useful even if their names are correct.
+foreach(_artifact IN LISTS _expected_artifacts)
+  set(_artifact_path "${OUTPUT_DIR}/${_artifact}")
+  file(SIZE "${_artifact_path}" _artifact_size)
+  if(_artifact_size EQUAL 0)
+    message(FATAL_ERROR "${_artifact_path} is empty")
+  endif()
+endforeach()
+
+# Require every documented metrics field. Quoted-key matching avoids accepting
+# a field name merely because the same text appeared inside a string value.
+set(_metrics_path "${OUTPUT_DIR}/metrics_${TRACKER}.json")
+file(READ "${_metrics_path}" _metrics_json)
+foreach(_metrics_key IN ITEMS
+        tracker opencv_version frames lost_frames mean_fps mean_iou success_rate)
+  string(FIND "${_metrics_json}" "\"${_metrics_key}\"" _key_position)
+  if(_key_position EQUAL -1)
+    message(FATAL_ERROR
+      "${_metrics_path} is missing the '${_metrics_key}' key")
+  endif()
+endforeach()
+if(NOT _metrics_json MATCHES "\"frames\"[ \t]*:[ \t]*80([,\\n])")
+  message(FATAL_ERROR
+    "${_metrics_path} does not report the expected 80 processed frames")
+endif()
+if(NOT _metrics_json MATCHES "\"lost_frames\"[ \t]*:[ \t]*0([,\\n])")
+  message(FATAL_ERROR
+    "${_metrics_path} reports a lost frame on the deterministic clip")
+endif()
+
+# Open both AVIs through the real example entry point. MIL is model-free and
+# processing to end-of-stream proves that both files decode to all 80 expected
+# frames. This catches the historical bug where tracked output omitted the
+# initialization frame even though metrics reported it.
+foreach(_video_name IN ITEMS synthetic_clip.avi tracked_${TRACKER}.avi)
+  set(_video_path "${OUTPUT_DIR}/${_video_name}")
+  execute_process(
+    COMMAND "${EXECUTABLE}"
+            --tracker=mil
+            "--input=${_video_path}"
+            --bbox=20,20,40,40
+            --max-frames=81
+            --no-display
+    RESULT_VARIABLE _read_result
+    OUTPUT_VARIABLE _read_stdout
+    ERROR_VARIABLE _read_stderr)
+  set(_read_log "${_read_stdout}${_read_stderr}")
+  if(NOT "${_read_result}" STREQUAL "0")
+    message(FATAL_ERROR
+      "Could not read ${_video_path}:\n${_read_log}")
+  endif()
+  if(NOT _read_log MATCHES "frames=80([^0-9]|$)")
+    message(FATAL_ERROR
+      "Expected 80 decodable frames in ${_video_path}:\n${_read_log}")
+  endif()
+endforeach()
+
+# MIL's validation test also covers the normal-mode JSON and one-frame output
+# contract once per CTest run. Normal tracking has no ground truth, so both
+# score fields must remain present as JSON null rather than disappearing.
+if(TRACKER STREQUAL "mil")
+  set(_normal_dir "${OUTPUT_DIR}_normal")
+  file(REMOVE_RECURSE "${_normal_dir}")
+  file(MAKE_DIRECTORY "${_normal_dir}")
+  execute_process(
+    COMMAND "${EXECUTABLE}"
+            --tracker=mil
+            "--input=${OUTPUT_DIR}/synthetic_clip.avi"
+            --bbox=20,148,64,64
+            --max-frames=1
+            --no-display
+            "--output-dir=${_normal_dir}"
+    RESULT_VARIABLE _normal_result
+    OUTPUT_VARIABLE _normal_stdout
+    ERROR_VARIABLE _normal_stderr)
+  set(_normal_log "${_normal_stdout}${_normal_stderr}")
+  if(NOT "${_normal_result}" STREQUAL "0" OR
+     NOT _normal_log MATCHES "frames=1([^0-9]|$)")
+    message(FATAL_ERROR
+      "Normal one-frame run failed its contract:\n${_normal_log}")
+  endif()
+
+  set(_normal_expected "metrics_mil.json" "tracked_mil.avi")
+  list(SORT _normal_expected)
+  file(GLOB _normal_actual
+       LIST_DIRECTORIES false
+       RELATIVE "${_normal_dir}"
+       "${_normal_dir}/*")
+  list(SORT _normal_actual)
+  if(NOT "${_normal_actual}" STREQUAL "${_normal_expected}")
+    message(FATAL_ERROR
+      "Normal artifacts differ. Expected ${_normal_expected}; "
+      "actual ${_normal_actual}")
+  endif()
+  foreach(_normal_artifact IN LISTS _normal_expected)
+    file(SIZE "${_normal_dir}/${_normal_artifact}" _normal_size)
+    if(_normal_size EQUAL 0)
+      message(FATAL_ERROR
+        "${_normal_dir}/${_normal_artifact} is empty")
+    endif()
+  endforeach()
+
+  file(READ "${_normal_dir}/metrics_mil.json" _normal_metrics)
+  if(NOT _normal_metrics MATCHES "\"frames\"[ \t]*:[ \t]*1([,\\n])" OR
+     NOT _normal_metrics MATCHES "\"mean_iou\"[ \t]*:[ \t]*null" OR
+     NOT _normal_metrics MATCHES "\"success_rate\"[ \t]*:[ \t]*null")
+    message(FATAL_ERROR
+      "Normal metrics schema or frame count is wrong:\n${_normal_metrics}")
+  endif()
+
+  # Decode the one-frame artifact through the real executable so a container
+  # header without readable media cannot satisfy the size check above.
+  execute_process(
+    COMMAND "${EXECUTABLE}"
+            --tracker=mil
+            "--input=${_normal_dir}/tracked_mil.avi"
+            --bbox=20,148,64,64
+            --max-frames=2
+            --no-display
+    RESULT_VARIABLE _normal_read_result
+    OUTPUT_VARIABLE _normal_read_stdout
+    ERROR_VARIABLE _normal_read_stderr)
+  set(_normal_read_log "${_normal_read_stdout}${_normal_read_stderr}")
+  if(NOT "${_normal_read_result}" STREQUAL "0" OR
+     NOT _normal_read_log MATCHES "frames=1([^0-9]|$)")
+    message(FATAL_ERROR
+      "Normal one-frame AVI was not readable:\n${_normal_read_log}")
+  endif()
+endif()
+
+message(STATUS "${TRACKER}: validation outputs and readback checks passed")

--- a/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
+++ b/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
@@ -1,0 +1,502 @@
+// Single-object tracking with every tracker that ships with OpenCV 5.
+//
+// This is the C++ twin of ../python/object_tracking.py. One executable
+// drives all six trackers:
+//
+//     classical (no model files):  MIL, KCF, CSRT
+//     deep-learning (ONNX files):  DaSiamRPN, NanoTrack, TrackerVit
+//
+// The same source builds unchanged against OpenCV 4.x (4.9+) and OpenCV 5.x.
+// KCF and CSRT come from the opencv_contrib "tracking" module; the code
+// detects its absence at compile time and degrades gracefully instead of
+// failing to build on a main-only OpenCV installation.
+//
+// Examples:
+//     ./object_tracking --list
+//     ./object_tracking --tracker=vittrack --input=video.mp4
+//     ./object_tracking --tracker=mil --validate --no-display
+
+// Core matrix types, cv::Rect, cv::TickMeter, and cv::CommandLineParser.
+#include <opencv2/core.hpp>
+// Reports which modules this OpenCV build contains (HAVE_OPENCV_TRACKING).
+#include <opencv2/opencv_modules.hpp>
+// Drawing primitives (rectangle, putText) and image resizing.
+#include <opencv2/imgproc.hpp>
+// VideoCapture and VideoWriter for file, camera, and clip generation.
+#include <opencv2/videoio.hpp>
+// The main-module trackers: MIL, DaSiamRPN, Nano, Vit (GOTURN in 4.x only).
+#include <opencv2/video/tracking.hpp>
+// The GUI calls are needed only for interactive display, but highgui is a
+// hard OpenCV dependency of this example so we include it unconditionally.
+#include <opencv2/highgui.hpp>
+
+// The contrib tracking module supplies KCF and CSRT when present.
+#ifdef HAVE_OPENCV_TRACKING
+#include <opencv2/tracking.hpp>
+#endif
+
+// Standard library: filesystem for path handling, containers, formatting.
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+// ---------------------------------------------------------------------------
+// Constants mirrored from the Python implementation so that the synthetic
+// validation clip and the pass criteria stay in lockstep across languages.
+// ---------------------------------------------------------------------------
+
+// Frame geometry and length of the synthetic validation clip.
+constexpr int kSynthWidth = 640;
+constexpr int kSynthHeight = 360;
+constexpr int kSynthFrames = 80;
+constexpr int kSynthTarget = 64;   // side length of the moving square
+constexpr int kSynthSeed = 7;      // fixed seed keeps the clip deterministic
+
+// Validation thresholds: loose on purpose. They catch a broken tracker or a
+// broken API call, not small quality differences between algorithms.
+constexpr double kValidateMeanIou = 0.45;
+constexpr double kValidateSuccessIou = 0.30;
+constexpr double kValidateSuccessRate = 0.90;
+
+// MODELS_DIR is injected by CMake as the absolute path of ../models so the
+// executable finds the shared ONNX files regardless of the current directory.
+#ifndef MODELS_DIR
+#define MODELS_DIR "../models"
+#endif
+
+// ---------------------------------------------------------------------------
+// Tracker factory
+// ---------------------------------------------------------------------------
+
+// Build the requested tracker, or return an empty pointer with a reason the
+// caller can show. Missing contrib and missing model files are different
+// user problems, so the message distinguishes them.
+static cv::Ptr<cv::Tracker> createTracker(const std::string& name,
+                                          const fs::path& modelsDir,
+                                          std::string& whyNot)
+{
+    // Small helper: true when every listed model file exists on disk.
+    const auto allExist = [&](std::initializer_list<const char*> files) {
+        for (const char* file : files)
+            if (!fs::exists(modelsDir / file)) return false;
+        return true;
+    };
+
+    if (name == "mil")
+    {
+        // MIL lives in the main video module of both 4.x and 5.x.
+        return cv::TrackerMIL::create();
+    }
+    if (name == "kcf" || name == "csrt")
+    {
+#ifdef HAVE_OPENCV_TRACKING
+        // KCF and CSRT come from opencv_contrib's tracking module.
+        if (name == "kcf") return cv::TrackerKCF::create();
+        return cv::TrackerCSRT::create();
+#else
+        whyNot = name + " requires an OpenCV build with the opencv_contrib "
+                        "tracking module";
+        return nullptr;
+#endif
+    }
+    if (name == "dasiamrpn")
+    {
+        // DaSiamRPN needs a backbone network plus two correlation kernels.
+        if (!allExist({"dasiamrpn_model.onnx", "dasiamrpn_kernel_cls1.onnx",
+                       "dasiamrpn_kernel_r1.onnx"}))
+        {
+            whyNot = "dasiamrpn model files missing; run download_models.py";
+            return nullptr;
+        }
+        cv::TrackerDaSiamRPN::Params params;
+        params.model = (modelsDir / "dasiamrpn_model.onnx").string();
+        params.kernel_cls1 = (modelsDir / "dasiamrpn_kernel_cls1.onnx").string();
+        params.kernel_r1 = (modelsDir / "dasiamrpn_kernel_r1.onnx").string();
+        return cv::TrackerDaSiamRPN::create(params);
+    }
+    if (name == "nanotrack")
+    {
+        // NanoTrack splits its ~2 MB network into a backbone and neck+head.
+        if (!allExist({"nanotrack_backbone_sim.onnx", "nanotrack_head_sim.onnx"}))
+        {
+            whyNot = "nanotrack model files missing; run download_models.py";
+            return nullptr;
+        }
+        cv::TrackerNano::Params params;
+        params.backbone = (modelsDir / "nanotrack_backbone_sim.onnx").string();
+        params.neckhead = (modelsDir / "nanotrack_head_sim.onnx").string();
+        return cv::TrackerNano::create(params);
+    }
+    if (name == "vittrack")
+    {
+        // TrackerVit uses a single sub-megabyte transformer ONNX file.
+        if (!allExist({"object_tracking_vittrack_2023sep.onnx"}))
+        {
+            whyNot = "vittrack model file missing; run download_models.py";
+            return nullptr;
+        }
+        cv::TrackerVit::Params params;
+        params.net = (modelsDir / "object_tracking_vittrack_2023sep.onnx").string();
+        return cv::TrackerVit::create(params);
+    }
+    whyNot = "unknown tracker name: " + name;
+    return nullptr;
+}
+
+// The canonical tracker order used by --list and the help text.
+static const std::vector<std::string> kTrackerNames =
+    {"mil", "kcf", "csrt", "dasiamrpn", "nanotrack", "vittrack"};
+
+// ---------------------------------------------------------------------------
+// Synthetic validation clip
+// ---------------------------------------------------------------------------
+
+// Ground-truth trajectory: the same Lissajous-style path as the Python
+// version, topping out near 10 px/frame so every tracker can follow.
+static cv::Rect groundTruthBox(int frameIndex)
+{
+    const double phase = static_cast<double>(frameIndex) / kSynthFrames;
+    const int x = static_cast<int>(
+        (kSynthWidth - kSynthTarget - 40) * 0.5 *
+            (1.0 + std::sin(CV_PI * phase - CV_PI / 2)) + 20);
+    const int y = static_cast<int>(
+        (kSynthHeight - kSynthTarget - 40) * 0.5 *
+            (1.0 + std::sin(2 * CV_PI * phase)) + 20);
+    return {x, y, kSynthTarget, kSynthTarget};
+}
+
+// Write the deterministic clip of a textured square moving over a noisy
+// background and return the per-frame ground-truth boxes. cv::RNG and
+// numpy differ, so the pixels are not byte-identical to Python's clip, but
+// the geometry, path, and difficulty are the same by construction.
+static std::vector<cv::Rect> makeSyntheticVideo(const fs::path& path)
+{
+    // Seeded RNG makes every generation of the clip identical.
+    cv::RNG rng(kSynthSeed);
+    // Background: horizontal gradient with per-channel uniform noise.
+    cv::Mat background(kSynthHeight, kSynthWidth, CV_8UC3);
+    for (int row = 0; row < kSynthHeight; ++row)
+    {
+        for (int col = 0; col < kSynthWidth; ++col)
+        {
+            // Gradient term matches Python's linspace(60, 120) horizontally.
+            const int gradient = 60 + col * 60 / (kSynthWidth - 1);
+            auto& pixel = background.at<cv::Vec3b>(row, col);
+            for (int channel = 0; channel < 3; ++channel)
+                pixel[channel] = static_cast<unsigned char>(
+                    std::min(255, gradient + static_cast<int>(rng.uniform(0, 40))));
+        }
+    }
+    // Target: an 8x8 grid of random bright colors, upscaled with nearest
+    // neighbor so each cell stays a crisp, trackable block.
+    cv::Mat targetSmall(8, 8, CV_8UC3);
+    rng.fill(targetSmall, cv::RNG::UNIFORM, 64, 255);
+    cv::Mat target;
+    cv::resize(targetSmall, target, {kSynthTarget, kSynthTarget}, 0, 0,
+               cv::INTER_NEAREST);
+    // MJPG in AVI is compiled into every OpenCV binary; no external codec.
+    cv::VideoWriter writer(path.string(),
+                           cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+                           30.0, {kSynthWidth, kSynthHeight});
+    if (!writer.isOpened())
+        throw std::runtime_error("Cannot open video writer for " + path.string());
+    std::vector<cv::Rect> boxes;
+    boxes.reserve(kSynthFrames);
+    for (int index = 0; index < kSynthFrames; ++index)
+    {
+        // Compose each frame: background copy, then paste the target.
+        const cv::Rect box = groundTruthBox(index);
+        cv::Mat frame = background.clone();
+        target.copyTo(frame(box));
+        writer.write(frame);
+        boxes.push_back(box);
+    }
+    return boxes;
+}
+
+// Intersection-over-union of two rectangles; cv::Rect supports operator&.
+static double iou(const cv::Rect& a, const cv::Rect& b)
+{
+    const double intersection = static_cast<double>((a & b).area());
+    const double unionArea = a.area() + b.area() - intersection;
+    return unionArea > 0.0 ? intersection / unionArea : 0.0;
+}
+
+// ---------------------------------------------------------------------------
+// Tracking loop
+// ---------------------------------------------------------------------------
+
+// Options shared by the normal and validation code paths.
+struct RunOptions
+{
+    std::string trackerName;          // which tracker to run
+    std::optional<fs::path> outputDir;// annotated video + metrics target
+    bool noDisplay = false;           // headless mode for tests and CI
+    int maxFrames = 0;                // 0 means process the whole stream
+};
+
+// Result metrics; written as JSON so tests and benchmarks can consume them.
+struct RunMetrics
+{
+    int frames = 0;                   // frames processed including init
+    int lostFrames = 0;               // frames where update() reported loss
+    double meanFps = 0.0;             // average tracker-update FPS
+    std::optional<double> meanIou;    // vs ground truth when validating
+    std::optional<double> successRate;// fraction of frames with IoU > 0.30
+};
+
+// Serialize metrics as a small JSON object, mirroring the Python output.
+static void writeMetricsJson(const RunMetrics& metrics, const RunOptions& options)
+{
+    if (!options.outputDir) return;
+    std::ofstream out(*options.outputDir / ("metrics_" + options.trackerName + ".json"));
+    out << "{\n"
+        << "  \"tracker\": \"" << options.trackerName << "\",\n"
+        << "  \"opencv_version\": \"" << CV_VERSION << "\",\n"
+        << "  \"frames\": " << metrics.frames << ",\n"
+        << "  \"lost_frames\": " << metrics.lostFrames << ",\n"
+        << "  \"mean_fps\": " << metrics.meanFps;
+    if (metrics.meanIou)
+        out << ",\n  \"mean_iou\": " << *metrics.meanIou
+            << ",\n  \"success_rate\": " << *metrics.successRate;
+    out << "\n}\n";
+}
+
+// Core loop shared by normal runs and validation, mirroring Python's track().
+static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
+                        cv::Rect initBox, const RunOptions& options,
+                        const std::vector<cv::Rect>* groundTruth)
+{
+    // Read the first frame and teach the tracker the target's appearance.
+    cv::Mat frame;
+    if (!capture.read(frame))
+        throw std::runtime_error("Input has no frames");
+    tracker->init(frame, initBox);
+    // Prepare the optional annotated-video writer.
+    cv::VideoWriter writer;
+    if (options.outputDir)
+    {
+        // Create the directory explicitly instead of failing on open.
+        fs::create_directories(*options.outputDir);
+        const fs::path videoPath =
+            *options.outputDir / ("tracked_" + options.trackerName + ".avi");
+        writer.open(videoPath.string(),
+                    cv::VideoWriter::fourcc('M', 'J', 'P', 'G'), 30.0,
+                    frame.size());
+        if (!writer.isOpened())
+            throw std::runtime_error("Cannot write output video in " +
+                                     options.outputDir->string());
+    }
+    // TickMeter times exactly the tracker updates for an honest FPS figure.
+    cv::TickMeter meter;
+    RunMetrics metrics;
+    metrics.frames = 1;  // the init frame counts toward the total
+    std::vector<double> ious;
+    while (true)
+    {
+        // Honor the optional frame budget used by quick test runs.
+        if (options.maxFrames > 0 && metrics.frames >= options.maxFrames)
+            break;
+        if (!capture.read(frame))
+            break;  // end of stream
+        cv::Rect box;
+        // Time only the update call, not drawing or file I/O.
+        meter.start();
+        const bool found = tracker->update(frame, box);
+        meter.stop();
+        if (found)
+        {
+            // Draw the tracked box in green.
+            cv::rectangle(frame, box, {0, 255, 0}, 2);
+        }
+        else
+        {
+            // Announce failure on the frame and count it.
+            ++metrics.lostFrames;
+            cv::putText(frame, "tracking failure", {20, 60},
+                        cv::FONT_HERSHEY_SIMPLEX, 0.8, {0, 0, 255}, 2);
+        }
+        // Score against ground truth while validating.
+        if (groundTruth != nullptr &&
+            metrics.frames < static_cast<int>(groundTruth->size()))
+        {
+            const cv::Rect truth = (*groundTruth)[metrics.frames];
+            ious.push_back(found ? iou(box, truth) : 0.0);
+        }
+        // Overlay the running-average FPS of tracker updates.
+        cv::putText(frame,
+                    options.trackerName + cv::format("  %5.1f FPS", meter.getFPS()),
+                    {20, 30}, cv::FONT_HERSHEY_SIMPLEX, 0.8, {50, 170, 50}, 2);
+        if (writer.isOpened())
+            writer.write(frame);
+        // Display unless headless; ESC exits an interactive session.
+        if (!options.noDisplay)
+        {
+            cv::imshow("Tracking", frame);
+            if ((cv::waitKey(1) & 0xFF) == 27)
+                break;
+        }
+        ++metrics.frames;
+    }
+    // Aggregate the metrics after the loop.
+    metrics.meanFps = meter.getFPS();
+    if (!ious.empty())
+    {
+        double sum = 0.0;
+        int successes = 0;
+        for (const double value : ious)
+        {
+            sum += value;
+            if (value > kValidateSuccessIou) ++successes;
+        }
+        metrics.meanIou = sum / static_cast<double>(ious.size());
+        metrics.successRate =
+            static_cast<double>(successes) / static_cast<double>(ious.size());
+    }
+    return metrics;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+    // cv::CommandLineParser keeps the CLI declaration compact and readable.
+    const std::string keys =
+        "{help h        |          | print this help }"
+        "{tracker       | vittrack | mil kcf csrt dasiamrpn nanotrack vittrack }"
+        "{input         | 0        | video path or camera index }"
+        "{bbox          |          | initial box as x,y,w,h }"
+        "{models-dir    |          | directory holding the ONNX models }"
+        "{output-dir    |          | write annotated video and metrics here }"
+        "{max-frames    | 0        | stop after this many frames (0 = all) }"
+        "{no-display    |          | run headless: no windows, no waitKey }"
+        "{validate      |          | run the synthetic-clip regression check }"
+        "{list          |          | report tracker availability and exit }";
+    cv::CommandLineParser parser(argc, argv, keys);
+    parser.about("Single-object tracking with the OpenCV 5 tracker lineup");
+    if (parser.has("help"))
+    {
+        parser.printMessage();
+        return 0;
+    }
+    // Resolve the models directory: CLI flag first, compiled default second.
+    const fs::path modelsDir = parser.get<std::string>("models-dir").empty()
+        ? fs::path(MODELS_DIR)
+        : fs::path(parser.get<std::string>("models-dir"));
+    // --list probes every tracker and reports availability, like Python's
+    // --list-trackers, then exits successfully.
+    if (parser.has("list"))
+    {
+        std::cout << "OpenCV version: " << CV_VERSION << "\n";
+        for (const std::string& name : kTrackerNames)
+        {
+            std::string whyNot;
+            cv::Ptr<cv::Tracker> probe;
+            try { probe = createTracker(name, modelsDir, whyNot); }
+            catch (const cv::Exception&) { probe = nullptr; }
+            std::cout << "  " << name << (probe ? "  available" : "  NOT available")
+                      << (whyNot.empty() ? "" : "  (" + whyNot + ")") << "\n";
+        }
+        return 0;
+    }
+    try
+    {
+        // Gather the shared options once.
+        RunOptions options;
+        options.trackerName = parser.get<std::string>("tracker");
+        options.noDisplay = parser.has("no-display");
+        options.maxFrames = parser.get<int>("max-frames");
+        if (!parser.get<std::string>("output-dir").empty())
+            options.outputDir = fs::path(parser.get<std::string>("output-dir"));
+        // Build the tracker or explain exactly why it cannot be built.
+        std::string whyNot;
+        cv::Ptr<cv::Tracker> tracker =
+            createTracker(options.trackerName, modelsDir, whyNot);
+        if (!tracker)
+            throw std::runtime_error(whyNot);
+        if (parser.has("validate"))
+        {
+            // Validation mode: synthesize the clip, then require the tracker
+            // to stay on target within the documented thresholds.
+            const fs::path outputDir =
+                options.outputDir.value_or(fs::path("outputs"));
+            fs::create_directories(outputDir);
+            options.outputDir = outputDir;
+            const fs::path clipPath = outputDir / "synthetic_clip.avi";
+            const std::vector<cv::Rect> truth = makeSyntheticVideo(clipPath);
+            cv::VideoCapture capture(clipPath.string());
+            if (!capture.isOpened())
+                throw std::runtime_error("Cannot open input: " + clipPath.string());
+            const RunMetrics metrics =
+                track(tracker, capture, truth.front(), options, &truth);
+            writeMetricsJson(metrics, options);
+            // Print the metrics and the unambiguous CI marker.
+            std::cout << "mean_iou=" << metrics.meanIou.value_or(0.0)
+                      << " success_rate=" << metrics.successRate.value_or(0.0)
+                      << " mean_fps=" << metrics.meanFps << "\n";
+            const bool passed = metrics.meanIou &&
+                                *metrics.meanIou >= kValidateMeanIou &&
+                                *metrics.successRate >= kValidateSuccessRate;
+            std::cout << (passed ? "VALIDATION PASSED" : "VALIDATION FAILED")
+                      << std::endl;
+            return passed ? 0 : 1;
+        }
+        // Normal mode: open the requested video file or camera index.
+        const std::string input = parser.get<std::string>("input");
+        const bool isCameraIndex =
+            !input.empty() &&
+            input.find_first_not_of("0123456789") == std::string::npos;
+        cv::VideoCapture capture;
+        if (isCameraIndex) capture.open(std::stoi(input));
+        else capture.open(input);
+        if (!capture.isOpened())
+            throw std::runtime_error("Cannot open input: " + input);
+        // Determine the initial box: parsed from --bbox, or drawn by hand.
+        cv::Rect initBox;
+        const std::string bbox = parser.get<std::string>("bbox");
+        if (!bbox.empty())
+        {
+            // Parse the "x,y,w,h" string with sscanf-style extraction.
+            if (std::sscanf(bbox.c_str(), "%d,%d,%d,%d", &initBox.x, &initBox.y,
+                            &initBox.width, &initBox.height) != 4)
+                throw std::runtime_error("Cannot parse --bbox=" + bbox);
+        }
+        else
+        {
+            if (options.noDisplay)
+                throw std::runtime_error("--bbox is required when --no-display is set");
+            // Let the user draw the box on the first frame interactively.
+            cv::Mat first;
+            if (!capture.read(first))
+                throw std::runtime_error("Input has no frames");
+            initBox = cv::selectROI("Select object", first, true);
+            cv::destroyWindow("Select object");
+            // Rewind file inputs so tracking starts at the first frame again.
+            capture.set(cv::CAP_PROP_POS_FRAMES, 0);
+        }
+        const RunMetrics metrics = track(tracker, capture, initBox, options, nullptr);
+        writeMetricsJson(metrics, options);
+        std::cout << "frames=" << metrics.frames
+                  << " lost=" << metrics.lostFrames
+                  << " mean_fps=" << metrics.meanFps << std::endl;
+        return 0;
+    }
+    catch (const std::exception& error)
+    {
+        // One readable error line beats an unhandled-exception abort.
+        std::cerr << "error: " << error.what() << std::endl;
+        return 1;
+    }
+}

--- a/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
+++ b/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
@@ -1,4 +1,4 @@
-// Single-object tracking with every tracker that ships with OpenCV 5.
+// Single-object tracking with OpenCV 5's six modern, non-legacy trackers.
 //
 // This is the C++ twin of ../python/object_tracking.py. One executable
 // drives all six trackers:
@@ -37,15 +37,17 @@
 
 // Standard library: filesystem for path handling, containers, formatting.
 #include <algorithm>
+#include <array>
+#include <charconv>
 #include <cmath>
-#include <cstdio>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
-#include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -204,7 +206,8 @@ static std::vector<cv::Rect> makeSyntheticVideo(const fs::path& path)
     cv::Mat target;
     cv::resize(targetSmall, target, {kSynthTarget, kSynthTarget}, 0, 0,
                cv::INTER_NEAREST);
-    // MJPG in AVI is compiled into every OpenCV binary; no external codec.
+    // MJPG in AVI is widely available in desktop OpenCV builds. The explicit
+    // isOpened() check reports builds without a compatible writer backend.
     cv::VideoWriter writer(path.string(),
                            cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
                            30.0, {kSynthWidth, kSynthHeight});
@@ -259,7 +262,15 @@ struct RunMetrics
 static void writeMetricsJson(const RunMetrics& metrics, const RunOptions& options)
 {
     if (!options.outputDir) return;
-    std::ofstream out(*options.outputDir / ("metrics_" + options.trackerName + ".json"));
+    // Open explicitly and check the stream before emitting JSON. Without this
+    // guard, a permissions or disk error could leave the user with no metrics
+    // while the program still reported success.
+    const fs::path metricsPath =
+        *options.outputDir / ("metrics_" + options.trackerName + ".json");
+    std::ofstream out(metricsPath, std::ios::out | std::ios::trunc);
+    if (!out.is_open())
+        throw std::runtime_error("Cannot open metrics file for writing: " +
+                                 metricsPath.string());
     out << "{\n"
         << "  \"tracker\": \"" << options.trackerName << "\",\n"
         << "  \"opencv_version\": \"" << CV_VERSION << "\",\n"
@@ -269,19 +280,128 @@ static void writeMetricsJson(const RunMetrics& metrics, const RunOptions& option
     if (metrics.meanIou)
         out << ",\n  \"mean_iou\": " << *metrics.meanIou
             << ",\n  \"success_rate\": " << *metrics.successRate;
+    else
+        // Normal runs have no ground truth. Explicit nulls keep the metrics
+        // schema identical to Python and easier for downstream tools to parse.
+        out << ",\n  \"mean_iou\": null"
+            << ",\n  \"success_rate\": null";
     out << "\n}\n";
+    // Flushing here turns delayed filesystem failures into a clean nonzero
+    // program exit instead of allowing a truncated JSON file to pass silently.
+    out.flush();
+    if (!out)
+        throw std::runtime_error("Cannot write metrics file: " +
+                                 metricsPath.string());
+}
+
+// Parse exactly four comma-separated base-10 integers. std::from_chars does
+// not skip whitespace and reports both overflow and trailing characters, so
+// malformed values such as "10,20,30,40junk" cannot be accepted accidentally.
+static cv::Rect parseBoundingBox(const std::string& text)
+{
+    std::array<int, 4> values{};
+    std::size_t componentStart = 0;
+    for (std::size_t index = 0; index < values.size(); ++index)
+    {
+        // Only the first three components may be followed by a comma. Requiring
+        // the fourth component to end at text.size() rejects extra fields.
+        const std::size_t componentEnd =
+            index + 1 < values.size() ? text.find(',', componentStart)
+                                      : text.size();
+        if (componentEnd == std::string::npos || componentEnd == componentStart)
+            throw std::runtime_error(
+                "Invalid --bbox: expected exactly x,y,w,h integers");
+
+        const char* const begin = text.data() + componentStart;
+        const char* const end = text.data() + componentEnd;
+        const auto result = std::from_chars(begin, end, values[index]);
+        if (result.ec != std::errc{} || result.ptr != end)
+            throw std::runtime_error(
+                "Invalid --bbox: expected exactly x,y,w,h integers");
+
+        componentStart = componentEnd + 1;
+    }
+    // A fourth comma would have been parsed as trailing junk in the final
+    // component, but this explicit condition documents the exact contract.
+    if (componentStart != text.size() + 1)
+        throw std::runtime_error(
+            "Invalid --bbox: expected exactly x,y,w,h integers");
+    if (values[2] <= 0 || values[3] <= 0)
+        throw std::runtime_error(
+            "Invalid --bbox: width and height must be positive");
+    return {values[0], values[1], values[2], values[3]};
+}
+
+// Check the rectangle without adding coordinates, which avoids integer
+// overflow when a hostile or mistyped command-line value is near INT_MAX.
+static void validateBoundingBox(const cv::Rect& box, const cv::Mat& frame)
+{
+    if (box.width <= 0 || box.height <= 0)
+        throw std::runtime_error(
+            "Invalid --bbox: width and height must be positive");
+    if (box.x < 0 || box.y < 0 || box.x > frame.cols ||
+        box.y > frame.rows || box.width > frame.cols - box.x ||
+        box.height > frame.rows - box.y)
+    {
+        throw std::runtime_error(
+            "Invalid --bbox: rectangle must lie inside the first frame");
+    }
+}
+
+// Video files normally advertise their native frame rate. Cameras and unusual
+// containers can report zero, NaN, or infinity, so use 30 FPS only when the
+// source does not provide a usable positive value.
+static double outputFrameRate(const cv::VideoCapture& capture)
+{
+    const double sourceFps = capture.get(cv::CAP_PROP_FPS);
+    return std::isfinite(sourceFps) && sourceFps > 0.0 ? sourceFps : 30.0;
+}
+
+// OpenCV's parser validates conversions for declared keys but silently ignores
+// undeclared keys. Scan only the option names here so a typo cannot fall
+// through to a run with defaults; CommandLineParser still owns value parsing,
+// aliases, help text, and conversion-error reporting.
+static std::optional<std::string> findUnknownCommandLineToken(int argc,
+                                                              char** argv)
+{
+    static const std::vector<std::string> knownNames = {
+        "help", "h", "tracker", "input", "bbox", "models-dir",
+        "output-dir", "max-frames", "no-display", "validate", "list"};
+    for (int index = 1; index < argc; ++index)
+    {
+        const std::string argument = argv[index];
+        if (argument.size() < 2 || argument.front() != '-')
+            return "Unexpected positional argument: " + argument;
+
+        // CommandLineParser accepts either one or two leading dashes and an
+        // optional '=value' suffix. Compare only the name before that suffix.
+        const std::size_t nameStart =
+            argument.size() > 2 && argument[1] == '-' ? 2 : 1;
+        const std::size_t equals = argument.find('=', nameStart);
+        const std::string name =
+            argument.substr(nameStart, equals - nameStart);
+        if (std::find(knownNames.begin(), knownNames.end(), name) ==
+            knownNames.end())
+        {
+            return "Unknown option: " + argument;
+        }
+    }
+    return std::nullopt;
 }
 
 // Core loop shared by normal runs and validation, mirroring Python's track().
+// The caller supplies the already-read first frame. This guarantees that an
+// interactive camera ROI initializes the tracker on the exact image the user
+// saw, without attempting an impossible camera rewind.
 static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
-                        cv::Rect initBox, const RunOptions& options,
+                        const cv::Mat& firstFrame, cv::Rect initBox,
+                        const RunOptions& options,
                         const std::vector<cv::Rect>* groundTruth)
 {
-    // Read the first frame and teach the tracker the target's appearance.
-    cv::Mat frame;
-    if (!capture.read(frame))
-        throw std::runtime_error("Input has no frames");
-    tracker->init(frame, initBox);
+    // Reject an empty or out-of-frame ROI before any tracker accesses it.
+    validateBoundingBox(initBox, firstFrame);
+    // Teach the tracker from the pristine frame before adding annotations.
+    tracker->init(firstFrame, initBox);
     // Prepare the optional annotated-video writer.
     cv::VideoWriter writer;
     if (options.outputDir)
@@ -291,8 +411,8 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
         const fs::path videoPath =
             *options.outputDir / ("tracked_" + options.trackerName + ".avi");
         writer.open(videoPath.string(),
-                    cv::VideoWriter::fourcc('M', 'J', 'P', 'G'), 30.0,
-                    frame.size());
+                    cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+                    outputFrameRate(capture), firstFrame.size());
         if (!writer.isOpened())
             throw std::runtime_error("Cannot write output video in " +
                                      options.outputDir->string());
@@ -302,7 +422,22 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
     RunMetrics metrics;
     metrics.frames = 1;  // the init frame counts toward the total
     std::vector<double> ious;
-    while (true)
+    // The initialized frame is a processed frame too. Annotating and writing
+    // it here makes output frame counts agree with metrics.frames and leaves a
+    // readable one-frame AVI when --max-frames=1 is requested.
+    cv::Mat frame = firstFrame.clone();
+    cv::rectangle(frame, initBox, {0, 255, 0}, 2);
+    cv::putText(frame, options.trackerName + "  initialized", {20, 30},
+                cv::FONT_HERSHEY_SIMPLEX, 0.8, {50, 170, 50}, 2);
+    if (writer.isOpened())
+        writer.write(frame);
+    bool userStopped = false;
+    if (!options.noDisplay)
+    {
+        cv::imshow("Tracking", frame);
+        userStopped = (cv::waitKey(1) & 0xFF) == 27;
+    }
+    while (!userStopped)
     {
         // Honor the optional frame budget used by quick test runs.
         if (options.maxFrames > 0 && metrics.frames >= options.maxFrames)
@@ -337,6 +472,9 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
         cv::putText(frame,
                     options.trackerName + cv::format("  %5.1f FPS", meter.getFPS()),
                     {20, 30}, cv::FONT_HERSHEY_SIMPLEX, 0.8, {50, 170, 50}, 2);
+        // Count this frame before any interactive early exit; it has already
+        // been read, tracked, scored, and will be written below.
+        ++metrics.frames;
         if (writer.isOpened())
             writer.write(frame);
         // Display unless headless; ESC exits an interactive session.
@@ -346,7 +484,6 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
             if ((cv::waitKey(1) & 0xFF) == 27)
                 break;
         }
-        ++metrics.frames;
     }
     // Aggregate the metrics after the loop.
     metrics.meanFps = meter.getFPS();
@@ -386,15 +523,44 @@ int main(int argc, char** argv)
         "{list          |          | report tracker availability and exit }";
     cv::CommandLineParser parser(argc, argv, keys);
     parser.about("Single-object tracking with the OpenCV 5 tracker lineup");
+    // Retrieve every typed option before check(): conversion errors are added
+    // to the parser's error list by get() and printed together below.
+    const std::string trackerArgument = parser.get<std::string>("tracker");
+    const std::string inputArgument = parser.get<std::string>("input");
+    const std::string bboxArgument = parser.get<std::string>("bbox");
+    const std::string modelsDirArgument =
+        parser.get<std::string>("models-dir");
+    const std::string outputDirArgument =
+        parser.get<std::string>("output-dir");
+    const int maxFramesArgument = parser.get<int>("max-frames");
+    // OpenCV 4.14 and 5.0 both ignore undeclared keys internally, so close that
+    // gap explicitly while retaining CommandLineParser for declared options.
+    if (const auto unknown = findUnknownCommandLineToken(argc, argv))
+    {
+        std::cerr << "error: " << *unknown << std::endl;
+        return 2;
+    }
+    if (!parser.check())
+    {
+        // CommandLineParser formats all accumulated errors consistently.
+        parser.printErrors();
+        return 2;
+    }
+    if (maxFramesArgument < 0)
+    {
+        std::cerr << "error: --max-frames must be zero or positive"
+                  << std::endl;
+        return 2;
+    }
     if (parser.has("help"))
     {
         parser.printMessage();
         return 0;
     }
     // Resolve the models directory: CLI flag first, compiled default second.
-    const fs::path modelsDir = parser.get<std::string>("models-dir").empty()
+    const fs::path modelsDir = modelsDirArgument.empty()
         ? fs::path(MODELS_DIR)
-        : fs::path(parser.get<std::string>("models-dir"));
+        : fs::path(modelsDirArgument);
     // --list probes every tracker and reports availability, like Python's
     // --list-trackers, then exits successfully.
     if (parser.has("list"))
@@ -415,11 +581,11 @@ int main(int argc, char** argv)
     {
         // Gather the shared options once.
         RunOptions options;
-        options.trackerName = parser.get<std::string>("tracker");
+        options.trackerName = trackerArgument;
         options.noDisplay = parser.has("no-display");
-        options.maxFrames = parser.get<int>("max-frames");
-        if (!parser.get<std::string>("output-dir").empty())
-            options.outputDir = fs::path(parser.get<std::string>("output-dir"));
+        options.maxFrames = maxFramesArgument;
+        if (!outputDirArgument.empty())
+            options.outputDir = fs::path(outputDirArgument);
         // Build the tracker or explain exactly why it cannot be built.
         std::string whyNot;
         cv::Ptr<cv::Tracker> tracker =
@@ -439,22 +605,31 @@ int main(int argc, char** argv)
             cv::VideoCapture capture(clipPath.string());
             if (!capture.isOpened())
                 throw std::runtime_error("Cannot open input: " + clipPath.string());
+            // Read once here so track() receives exactly the initialization
+            // frame and begins update() calls on the following frame.
+            cv::Mat firstFrame;
+            if (!capture.read(firstFrame))
+                throw std::runtime_error("Input has no frames");
             const RunMetrics metrics =
-                track(tracker, capture, truth.front(), options, &truth);
+                track(tracker, capture, firstFrame, truth.front(), options, &truth);
             writeMetricsJson(metrics, options);
             // Print the metrics and the unambiguous CI marker.
             std::cout << "mean_iou=" << metrics.meanIou.value_or(0.0)
                       << " success_rate=" << metrics.successRate.value_or(0.0)
                       << " mean_fps=" << metrics.meanFps << "\n";
-            const bool passed = metrics.meanIou &&
-                                *metrics.meanIou >= kValidateMeanIou &&
-                                *metrics.successRate >= kValidateSuccessRate;
+            // A short high-quality prefix is not a complete regression.
+            // Require all generated frames as well as the quality thresholds.
+            const bool passed =
+                metrics.frames == static_cast<int>(truth.size()) &&
+                metrics.meanIou &&
+                *metrics.meanIou >= kValidateMeanIou &&
+                *metrics.successRate >= kValidateSuccessRate;
             std::cout << (passed ? "VALIDATION PASSED" : "VALIDATION FAILED")
                       << std::endl;
             return passed ? 0 : 1;
         }
         // Normal mode: open the requested video file or camera index.
-        const std::string input = parser.get<std::string>("input");
+        const std::string input = inputArgument;
         const bool isCameraIndex =
             !input.empty() &&
             input.find_first_not_of("0123456789") == std::string::npos;
@@ -463,30 +638,28 @@ int main(int argc, char** argv)
         else capture.open(input);
         if (!capture.isOpened())
             throw std::runtime_error("Cannot open input: " + input);
+        // Capture the initialization image once. For live cameras it cannot be
+        // replayed, so both ROI selection and tracker initialization use it.
+        cv::Mat firstFrame;
+        if (!capture.read(firstFrame))
+            throw std::runtime_error("Input has no frames");
         // Determine the initial box: parsed from --bbox, or drawn by hand.
         cv::Rect initBox;
-        const std::string bbox = parser.get<std::string>("bbox");
+        const std::string bbox = bboxArgument;
         if (!bbox.empty())
         {
-            // Parse the "x,y,w,h" string with sscanf-style extraction.
-            if (std::sscanf(bbox.c_str(), "%d,%d,%d,%d", &initBox.x, &initBox.y,
-                            &initBox.width, &initBox.height) != 4)
-                throw std::runtime_error("Cannot parse --bbox=" + bbox);
+            initBox = parseBoundingBox(bbox);
         }
         else
         {
             if (options.noDisplay)
                 throw std::runtime_error("--bbox is required when --no-display is set");
             // Let the user draw the box on the first frame interactively.
-            cv::Mat first;
-            if (!capture.read(first))
-                throw std::runtime_error("Input has no frames");
-            initBox = cv::selectROI("Select object", first, true);
+            initBox = cv::selectROI("Select object", firstFrame, true);
             cv::destroyWindow("Select object");
-            // Rewind file inputs so tracking starts at the first frame again.
-            capture.set(cv::CAP_PROP_POS_FRAMES, 0);
         }
-        const RunMetrics metrics = track(tracker, capture, initBox, options, nullptr);
+        const RunMetrics metrics =
+            track(tracker, capture, firstFrame, initBox, options, nullptr);
         writeMetricsJson(metrics, options);
         std::cout << "frames=" << metrics.frames
                   << " lost=" << metrics.lostFrames

--- a/Object-Tracking-OpenCV5/download_models.py
+++ b/Object-Tracking-OpenCV5/download_models.py
@@ -9,6 +9,7 @@ Python and C++ examples expect to find it.
 Usage:
     python3 download_models.py            # download everything that is missing
     python3 download_models.py --force    # re-download even if present
+    python3 download_models.py --models-dir /tmp/tracker-models
 """
 
 # argparse builds the small command-line interface for this script.
@@ -19,6 +20,10 @@ import hashlib
 from pathlib import Path
 # sys provides the exit code used to signal success or failure to callers.
 import sys
+# tempfile creates same-directory partial files for atomic replacement.
+import tempfile
+# urllib.error supplies the download-specific exception classes.
+import urllib.error
 # urllib.request performs the actual HTTP downloads using only the standard library.
 import urllib.request
 
@@ -26,42 +31,67 @@ import urllib.request
 # current working directory, so the script works from anywhere.
 MODELS_DIR = Path(__file__).resolve().parent / "models"
 
-# Each entry: destination filename -> (download URL, expected SHA-256 or None).
-# A None checksum means the upstream host does not publish one; the script
-# prints the computed hash so it can be pinned after a verified download.
+# Bound each network read and stream in modest chunks so a stalled or malicious
+# response cannot hang indefinitely or consume model-sized memory.
+DOWNLOAD_TIMEOUT_SECONDS = 60
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+
+# Each entry maps the local filename to an immutable upstream URL and its
+# expected SHA-256 and byte size. A download never replaces a model until both
+# pinned properties match.
 MODELS = {
     # --- TrackerNano (NanoTrack v2): a ~2 MB two-file siamese tracker. ---
     "nanotrack_backbone_sim.onnx": (
-        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/master/"
+        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/"
+        "248663fde6bf7c40190cf10ee396d5662919ecd3/"
         "NanoTrack/models/nanotrackv2/nanotrack_backbone_sim.onnx",
         "530bdd0cd00f19afab79a863e71ba71e3312395a5dc9151af675082bdaaa2fc4",
+        1056849,
     ),
     "nanotrack_head_sim.onnx": (
-        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/master/"
+        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/"
+        "248663fde6bf7c40190cf10ee396d5662919ecd3/"
         "NanoTrack/models/nanotrackv2/nanotrack_head_sim.onnx",
         "0d8c0637be849f092cc7236cae02e55c8b9455ebe37ba50601d6115db4247cd9",
+        726198,
     ),
     # --- TrackerVit: the transformer tracker from the OpenCV model zoo. ---
     # The zoo stores the file in Git LFS, so we fetch through the media
-    # endpoint which serves the real payload instead of the LFS pointer.
+    # endpoint at an immutable commit, which serves the real payload instead
+    # of the LFS pointer.
     "object_tracking_vittrack_2023sep.onnx": (
-        "https://media.githubusercontent.com/media/opencv/opencv_zoo/main/"
+        "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+        "47534e27c9851bb1128ccc0102f1145e27f23f98/"
         "models/object_tracking_vittrack/object_tracking_vittrack_2023sep.onnx",
         "2990f0b7cd44d92afa48cd97db6de7be113fc1d9594fddb74e2725c10478e91d",
+        714726,
     ),
-    # --- TrackerDaSiamRPN: three files hosted at the URLs documented in the
-    # official OpenCV sample (samples/python/tracker.py). ---
+    # --- TrackerDaSiamRPN: three files from the immutable OpenCV Zoo revision
+    # documented by OpenCV 5's samples/dnn/models.yml. The local names retain
+    # the defaults expected by cv::TrackerDaSiamRPN and the Python binding. ---
     "dasiamrpn_model.onnx": (
-        "https://www.dropbox.com/s/rr1lk9355vzolqv/dasiamrpn_model.onnx?dl=1",
-        None,
+        "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+        "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+        "models/object_tracking_dasiamrpn/"
+        "object_tracking_dasiamrpn_model_2021nov.onnx",
+        "e88370b85cbad914a5eb414d9d9e0820f87fd0cd89b65205a766174206c35719",
+        91040894,
     ),
     "dasiamrpn_kernel_r1.onnx": (
-        "https://www.dropbox.com/s/999cqx5zrfi7w4p/dasiamrpn_kernel_r1.onnx?dl=1",
-        None,
+        "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+        "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+        "models/object_tracking_dasiamrpn/"
+        "object_tracking_dasiamrpn_kernel_r1_2021nov.onnx",
+        "082c85d231b88b97a1b2a50e73b640a332c5d98d7c1d80b5da9ab534fa7a9e5b",
+        47206788,
     ),
     "dasiamrpn_kernel_cls1.onnx": (
-        "https://www.dropbox.com/s/qvmtszx5h339a0w/dasiamrpn_kernel_cls1.onnx?dl=1",
-        None,
+        "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+        "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+        "models/object_tracking_dasiamrpn/"
+        "object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx",
+        "d85b03e2aeded6cc9be945dfdc3ed6b8f4151f101e485037b6c5d5b36a6c4204",
+        23603598,
     ),
 }
 
@@ -76,33 +106,93 @@ def sha256_of(path: Path) -> str:
     return digest.hexdigest()
 
 
-def download_one(name: str, url: str, expected_sha: str, force: bool) -> bool:
-    """Download a single model file and verify it. Returns True on success."""
-    destination = MODELS_DIR / name
+def download_one(
+        name: str, url: str, expected_sha: str, expected_size: int,
+        force: bool, models_dir: Path) -> bool:
+    """Atomically download and verify one model. Return True on success."""
+    destination = models_dir / name
     # Skip files that already exist and pass verification unless forced.
     if destination.exists() and not force:
-        if expected_sha is None or sha256_of(destination) == expected_sha:
-            print(f"[skip] {name} already present")
-            return True
-        print(f"[warn] {name} exists but fails checksum; re-downloading")
+        try:
+            existing_size = destination.stat().st_size
+            existing_sha = (
+                sha256_of(destination)
+                if existing_size == expected_size else None
+            )
+        except OSError as error:
+            print(f"[warn] cannot verify existing {name}: {error}")
+        else:
+            if existing_size == expected_size and existing_sha == expected_sha:
+                print(f"[skip] {name} already present")
+                return True
+            print(f"[warn] {name} exists but fails checksum; re-downloading")
     print(f"[get ] {name}")
+    temporary_path = None
     try:
-        # A plain urlretrieve is enough; every host serves over HTTPS.
-        urllib.request.urlretrieve(url, destination)
-    except OSError as error:
-        # Report the failure but let the caller decide whether it is fatal;
-        # the examples degrade gracefully when a model is missing.
+        # A unique partial file in the destination directory makes concurrent
+        # runs safe and lets replacement stay atomic on one filesystem.
+        with tempfile.NamedTemporaryFile(
+                dir=models_dir, prefix=f".{name}.", suffix=".part",
+                delete=False) as temporary:
+            temporary_path = Path(temporary.name)
+        # Download into the partial path with a socket timeout. Streamed writes
+        # and an exact byte ceiling prevent an oversized response from filling
+        # memory or disk before the checksum can reject it.
+        with urllib.request.urlopen(
+                url, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    advertised_size = int(content_length)
+                except ValueError:
+                    advertised_size = None
+                if (advertised_size is not None
+                        and advertised_size > expected_size):
+                    print(
+                        f"[fail] {name}: server advertised "
+                        f"{advertised_size} bytes; expected {expected_size}"
+                    )
+                    return False
+            downloaded_size = 0
+            with temporary_path.open("wb") as output:
+                while True:
+                    chunk = response.read(DOWNLOAD_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    downloaded_size += len(chunk)
+                    if downloaded_size > expected_size:
+                        print(
+                            f"[fail] {name}: response exceeded "
+                            f"{expected_size} bytes"
+                        )
+                        return False
+                    output.write(chunk)
+        if downloaded_size != expected_size:
+            print(
+                f"[fail] {name}: received {downloaded_size} bytes; "
+                f"expected {expected_size}"
+            )
+            return False
+        actual_sha = sha256_of(temporary_path)
+        if actual_sha != expected_sha:
+            print(f"[fail] {name}: checksum mismatch ({actual_sha})")
+            return False
+        # Path.replace is an atomic rename when both paths share a filesystem.
+        temporary_path.replace(destination)
+    except (OSError, urllib.error.URLError) as error:
         print(f"[fail] {name}: {error}")
         return False
-    # Verify the payload before declaring success.
-    actual_sha = sha256_of(destination)
-    if expected_sha is not None and actual_sha != expected_sha:
-        # Remove the corrupt file so a later run does not trust it.
-        destination.unlink()
-        print(f"[fail] {name}: checksum mismatch ({actual_sha})")
-        return False
-    # Print the hash either way so unpinned entries can be pinned later.
-    print(f"[ ok ] {name} sha256={actual_sha}")
+    finally:
+        # If the rename succeeded this path no longer exists; otherwise remove
+        # only this run's partial file, never a previously verified model.
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError as error:
+                # Cleanup trouble should be visible but must not hide the
+                # original download or checksum result.
+                print(f"[warn] cannot remove partial file {temporary_path}: {error}")
+    print(f"[ ok ] {name} sha256={expected_sha}")
     return True
 
 
@@ -113,13 +203,23 @@ def main() -> int:
         "--force", action="store_true",
         help="re-download files even when they already exist",
     )
+    parser.add_argument(
+        "--models-dir", type=Path, default=MODELS_DIR,
+        help=f"destination directory (default: {MODELS_DIR})",
+    )
     arguments = parser.parse_args()
     # Create the models directory on first use.
-    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        arguments.models_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        print(f"[fail] cannot create {arguments.models_dir}: {error}")
+        return 1
     # Download each model, tracking whether anything failed.
     results = [
-        download_one(name, url, sha, arguments.force)
-        for name, (url, sha) in MODELS.items()
+        download_one(
+            name, url, sha, size, arguments.force, arguments.models_dir
+        )
+        for name, (url, sha, size) in MODELS.items()
     ]
     # Non-zero exit signals at least one failed download to shell callers.
     return 0 if all(results) else 1

--- a/Object-Tracking-OpenCV5/download_models.py
+++ b/Object-Tracking-OpenCV5/download_models.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Download the ONNX models required by the DNN-based OpenCV trackers.
+
+The classical trackers (MIL, KCF, CSRT) need no model files, so this script
+only fetches the assets for TrackerDaSiamRPN, TrackerNano, and TrackerVit.
+Every file lands in ``<repo>/Object-Tracking-OpenCV5/models/`` where both the
+Python and C++ examples expect to find it.
+
+Usage:
+    python3 download_models.py            # download everything that is missing
+    python3 download_models.py --force    # re-download even if present
+"""
+
+# argparse builds the small command-line interface for this script.
+import argparse
+# hashlib computes SHA-256 checksums so a truncated or tampered download fails loudly.
+import hashlib
+# pathlib gives us robust, OS-independent path handling anchored at this file.
+from pathlib import Path
+# sys provides the exit code used to signal success or failure to callers.
+import sys
+# urllib.request performs the actual HTTP downloads using only the standard library.
+import urllib.request
+
+# Resolve the models directory relative to this script, never the caller's
+# current working directory, so the script works from anywhere.
+MODELS_DIR = Path(__file__).resolve().parent / "models"
+
+# Each entry: destination filename -> (download URL, expected SHA-256 or None).
+# A None checksum means the upstream host does not publish one; the script
+# prints the computed hash so it can be pinned after a verified download.
+MODELS = {
+    # --- TrackerNano (NanoTrack v2): a ~2 MB two-file siamese tracker. ---
+    "nanotrack_backbone_sim.onnx": (
+        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/master/"
+        "NanoTrack/models/nanotrackv2/nanotrack_backbone_sim.onnx",
+        "530bdd0cd00f19afab79a863e71ba71e3312395a5dc9151af675082bdaaa2fc4",
+    ),
+    "nanotrack_head_sim.onnx": (
+        "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/master/"
+        "NanoTrack/models/nanotrackv2/nanotrack_head_sim.onnx",
+        "0d8c0637be849f092cc7236cae02e55c8b9455ebe37ba50601d6115db4247cd9",
+    ),
+    # --- TrackerVit: the transformer tracker from the OpenCV model zoo. ---
+    # The zoo stores the file in Git LFS, so we fetch through the media
+    # endpoint which serves the real payload instead of the LFS pointer.
+    "object_tracking_vittrack_2023sep.onnx": (
+        "https://media.githubusercontent.com/media/opencv/opencv_zoo/main/"
+        "models/object_tracking_vittrack/object_tracking_vittrack_2023sep.onnx",
+        "2990f0b7cd44d92afa48cd97db6de7be113fc1d9594fddb74e2725c10478e91d",
+    ),
+    # --- TrackerDaSiamRPN: three files hosted at the URLs documented in the
+    # official OpenCV sample (samples/python/tracker.py). ---
+    "dasiamrpn_model.onnx": (
+        "https://www.dropbox.com/s/rr1lk9355vzolqv/dasiamrpn_model.onnx?dl=1",
+        None,
+    ),
+    "dasiamrpn_kernel_r1.onnx": (
+        "https://www.dropbox.com/s/999cqx5zrfi7w4p/dasiamrpn_kernel_r1.onnx?dl=1",
+        None,
+    ),
+    "dasiamrpn_kernel_cls1.onnx": (
+        "https://www.dropbox.com/s/qvmtszx5h339a0w/dasiamrpn_kernel_cls1.onnx?dl=1",
+        None,
+    ),
+}
+
+
+def sha256_of(path: Path) -> str:
+    """Return the SHA-256 hex digest of a file, reading in 1 MiB chunks."""
+    # Stream the file instead of loading it fully so large models stay cheap.
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_one(name: str, url: str, expected_sha: str, force: bool) -> bool:
+    """Download a single model file and verify it. Returns True on success."""
+    destination = MODELS_DIR / name
+    # Skip files that already exist and pass verification unless forced.
+    if destination.exists() and not force:
+        if expected_sha is None or sha256_of(destination) == expected_sha:
+            print(f"[skip] {name} already present")
+            return True
+        print(f"[warn] {name} exists but fails checksum; re-downloading")
+    print(f"[get ] {name}")
+    try:
+        # A plain urlretrieve is enough; every host serves over HTTPS.
+        urllib.request.urlretrieve(url, destination)
+    except OSError as error:
+        # Report the failure but let the caller decide whether it is fatal;
+        # the examples degrade gracefully when a model is missing.
+        print(f"[fail] {name}: {error}")
+        return False
+    # Verify the payload before declaring success.
+    actual_sha = sha256_of(destination)
+    if expected_sha is not None and actual_sha != expected_sha:
+        # Remove the corrupt file so a later run does not trust it.
+        destination.unlink()
+        print(f"[fail] {name}: checksum mismatch ({actual_sha})")
+        return False
+    # Print the hash either way so unpinned entries can be pinned later.
+    print(f"[ ok ] {name} sha256={actual_sha}")
+    return True
+
+
+def main() -> int:
+    """Entry point: download every model and report an overall exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force", action="store_true",
+        help="re-download files even when they already exist",
+    )
+    arguments = parser.parse_args()
+    # Create the models directory on first use.
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    # Download each model, tracking whether anything failed.
+    results = [
+        download_one(name, url, sha, arguments.force)
+        for name, (url, sha) in MODELS.items()
+    ]
+    # Non-zero exit signals at least one failed download to shell callers.
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Object-Tracking-OpenCV5/python/object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/object_tracking.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Single-object tracking with every tracker that ships with OpenCV 5.
+"""Single-object tracking with OpenCV 5's six modern, non-legacy trackers.
 
 One command-line application drives all six trackers:
 
@@ -58,7 +58,7 @@ def _resolve_creator(class_name):
     OpenCV's Python bindings historically exposed two spellings:
     ``cv2.TrackerMIL_create()`` (flat, older) and ``cv2.TrackerMIL.create()``
     (class static method, current). Checking both keeps the script working
-    across every 4.8+ and 5.x build.
+    across every supported 4.9+ and 5.x build.
     """
     # Prefer the flat function when present because it exists on both APIs.
     flat = getattr(cv2, f"{class_name}_create", None)
@@ -208,7 +208,8 @@ def iou(box_a, box_b):
     return inter / union if union > 0 else 0.0
 
 
-def make_synthetic_video(path, size=SYNTH_SIZE, frames=SYNTH_FRAMES):
+def make_synthetic_video(
+        path, size=SYNTH_SIZE, frames=SYNTH_FRAMES, fps=30.0):
     """Write a deterministic clip of a textured square on a noisy background.
 
     Returns the list of ground-truth (x, y, w, h) boxes, one per frame. Both
@@ -230,15 +231,14 @@ def make_synthetic_video(path, size=SYNTH_SIZE, frames=SYNTH_FRAMES):
     ])
     # Target: an 8x8 grid of random bright colors gives strong, unique
     # texture that every tracker family can latch onto.
-    cell = SYNTH_TARGET // 8
     target = rng.randint(64, 255, (8, 8, 3), dtype=np.uint8)
     target = cv2.resize(target, (SYNTH_TARGET, SYNTH_TARGET),
                         interpolation=cv2.INTER_NEAREST)
-    _ = cell  # cell size folded into the resize above
-    # MJPG in an AVI container is built into every OpenCV binary, so the
-    # writer never depends on an external codec being installed.
+    # MJPG in an AVI container is widely available in desktop OpenCV builds.
+    # The explicit isOpened() check below reports a clear error on builds that
+    # were configured without a compatible writer backend.
     writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"MJPG"),
-                             30.0, (width, height))
+                             float(fps), (width, height))
     if not writer.isOpened():
         raise RuntimeError(f"Cannot open video writer for {path}")
     boxes = []
@@ -270,6 +270,40 @@ def open_capture(source):
     return capture
 
 
+def parse_bbox(text):
+    """Parse an exact ``x,y,w,h`` box and reject malformed dimensions."""
+    # Splitting first prevents partial parses such as "10,20,30,40junk".
+    fields = text.split(",")
+    if len(fields) != 4:
+        raise RuntimeError(
+            f"Cannot parse --bbox={text!r}; expected exactly x,y,w,h"
+        )
+    try:
+        box = tuple(int(field) for field in fields)
+    except ValueError as error:
+        raise RuntimeError(
+            f"Cannot parse --bbox={text!r}; every value must be an integer"
+        ) from error
+    # A tracker cannot initialize from an empty or inverted rectangle.
+    if box[2] <= 0 or box[3] <= 0:
+        raise RuntimeError("--bbox width and height must both be positive")
+    return box
+
+
+def _validate_bbox_in_frame(box, frame):
+    """Return an integer box after proving that it lies inside ``frame``."""
+    # Convert selector-provided numeric values as well as CLI values uniformly.
+    x, y, width, height = (int(value) for value in box)
+    frame_height, frame_width = frame.shape[:2]
+    if (x < 0 or y < 0 or width <= 0 or height <= 0
+            or x + width > frame_width or y + height > frame_height):
+        raise RuntimeError(
+            "--bbox must have positive size and lie fully inside the first "
+            f"frame ({frame_width}x{frame_height})"
+        )
+    return x, y, width, height
+
+
 def track(tracker, capture, init_box, args, ground_truth=None):
     """Core loop shared by normal runs and validation.
 
@@ -286,8 +320,12 @@ def track(tracker, capture, init_box, args, ground_truth=None):
             raise RuntimeError("--bbox is required when --no-display is set")
         init_box = cv2.selectROI("Select object", frame, showCrosshair=True)
         cv2.destroyWindow("Select object")
+    # Validate both CLI boxes and interactively selected boxes before asking
+    # the tracker to consume them; this replaces opaque OpenCV assertions with
+    # an actionable message.
+    init_box = _validate_bbox_in_frame(init_box, frame)
     # init() learns the appearance model from the first frame and box.
-    tracker.init(frame, tuple(int(v) for v in init_box))
+    tracker.init(frame, init_box)
     # Prepare the optional annotated-video writer in the output directory.
     writer = None
     if args.output_dir is not None:
@@ -295,9 +333,15 @@ def track(tracker, capture, init_box, args, ground_truth=None):
         # Create the directory explicitly instead of failing on write.
         output_dir.mkdir(parents=True, exist_ok=True)
         height, width = frame.shape[:2]
+        # Preserve the source playback rate. Camera backends and a few unusual
+        # containers report zero or NaN, in which case 30 FPS is a safe
+        # documented fallback for the output container.
+        source_fps = float(capture.get(cv2.CAP_PROP_FPS))
+        if not np.isfinite(source_fps) or source_fps <= 0:
+            source_fps = 30.0
         writer = cv2.VideoWriter(
             str(output_dir / f"tracked_{args.tracker}.avi"),
-            cv2.VideoWriter_fourcc(*"MJPG"), 30.0, (width, height))
+            cv2.VideoWriter_fourcc(*"MJPG"), source_fps, (width, height))
         if not writer.isOpened():
             raise RuntimeError(f"Cannot write output video in {output_dir}")
     # TickMeter gives portable, monotonic per-frame timing for the FPS overlay.
@@ -305,6 +349,20 @@ def track(tracker, capture, init_box, args, ground_truth=None):
     ious = []            # per-frame IoU against ground truth, if provided
     frames_done = 1      # the init frame counts toward the total
     lost_frames = 0      # frames where update() reported failure
+    if writer is not None:
+        # Include the initialized frame so the annotated output has exactly
+        # the same number of processed frames reported in the metrics. Draw on
+        # a copy because the tracker has already learned from the clean frame.
+        first_output = frame.copy()
+        x, y, width, height = init_box
+        cv2.rectangle(
+            first_output, (x, y), (x + width, y + height), (0, 255, 0), 2
+        )
+        cv2.putText(
+            first_output, f"{args.tracker}    0.0 FPS", (20, 30),
+            cv2.FONT_HERSHEY_SIMPLEX, 0.8, (50, 170, 50), 2
+        )
+        writer.write(first_output)
     while True:
         # Stop early when a frame budget was requested (useful for tests).
         if args.max_frames and frames_done >= args.max_frames:
@@ -335,12 +393,14 @@ def track(tracker, capture, init_box, args, ground_truth=None):
                     cv2.FONT_HERSHEY_SIMPLEX, 0.8, (50, 170, 50), 2)
         if writer is not None:
             writer.write(frame)
+        # Count the frame before a possible interactive ESC exit because it
+        # has already been read, tracked, scored, drawn, and written.
+        frames_done += 1
         # Display unless the caller runs headless; ESC quits interactively.
         if not args.no_display:
             cv2.imshow("Tracking", frame)
             if cv2.waitKey(1) & 0xFF == 27:
                 break
-        frames_done += 1
     # Release resources deterministically; important on Windows file locks.
     capture.release()
     if writer is not None:
@@ -354,9 +414,12 @@ def track(tracker, capture, init_box, args, ground_truth=None):
         "frames": frames_done,
         "lost_frames": lost_frames,
         "mean_fps": round(meter.getFPS(), 2),
-        "mean_iou": round(float(np.mean(ious)), 4) if ious else None,
+        # Keep full precision for validation. Rounding before comparing a value
+        # with its threshold can make Python disagree with the C++ example at
+        # the boundary.
+        "mean_iou": float(np.mean(ious)) if ious else None,
         "success_rate": (
-            round(float(np.mean([v > VALIDATE_SUCCESS_IOU for v in ious])), 4)
+            float(np.mean([v > VALIDATE_SUCCESS_IOU for v in ious]))
             if ious else None),
     }
 
@@ -367,8 +430,7 @@ def run(args):
     tracker = create_tracker(args.tracker, models_dir)
     capture = open_capture(args.input)
     # Parse "x,y,w,h" once here so track() receives a ready-to-use tuple.
-    init_box = (tuple(int(v) for v in args.bbox.split(","))
-                if args.bbox else None)
+    init_box = parse_bbox(args.bbox) if args.bbox else None
     metrics = track(tracker, capture, init_box, args)
     _write_metrics(metrics, args)
     print(json.dumps(metrics, indent=2))
@@ -393,7 +455,10 @@ def validate(args):
     _write_metrics(metrics, args)
     print(json.dumps(metrics, indent=2))
     # Apply the pass criteria and print an unambiguous marker for CI greps.
-    passed = (metrics["mean_iou"] is not None
+    # A short high-quality prefix is not a complete regression. Require all
+    # generated frames in addition to the tracking-quality thresholds.
+    passed = (metrics["frames"] == len(ground_truth)
+              and metrics["mean_iou"] is not None
               and metrics["mean_iou"] >= VALIDATE_MEAN_IOU
               and metrics["success_rate"] >= VALIDATE_SUCCESS_RATE)
     print("VALIDATION PASSED" if passed else "VALIDATION FAILED")
@@ -404,7 +469,12 @@ def _write_metrics(metrics, args):
     """Persist metrics as JSON next to the annotated video when requested."""
     if args.output_dir is not None:
         metrics_path = Path(args.output_dir) / f"metrics_{args.tracker}.json"
-        metrics_path.write_text(json.dumps(metrics, indent=2))
+        try:
+            metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+        except OSError as error:
+            raise RuntimeError(
+                f"Cannot write metrics file {metrics_path}: {error}"
+            ) from error
 
 
 def parse_args(argv=None):
@@ -430,7 +500,10 @@ def parse_args(argv=None):
                         help="run the synthetic-clip regression check")
     parser.add_argument("--list-trackers", action="store_true",
                         help="report tracker availability and exit")
-    return parser.parse_args(argv)
+    arguments = parser.parse_args(argv)
+    if arguments.max_frames < 0:
+        parser.error("--max-frames must be zero or a positive integer")
+    return arguments
 
 
 def main(argv=None):
@@ -441,7 +514,7 @@ def main(argv=None):
         return 0
     try:
         return validate(args) if args.validate else run(args)
-    except (RuntimeError, cv2.error) as error:
+    except (RuntimeError, OSError, cv2.error) as error:
         # A readable one-line error beats a traceback for tutorial code.
         print(f"error: {error}", file=sys.stderr)
         return 1

--- a/Object-Tracking-OpenCV5/python/object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/object_tracking.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Single-object tracking with every tracker that ships with OpenCV 5.
+
+One command-line application drives all six trackers:
+
+    classical (no model files):  MIL, KCF, CSRT
+    deep-learning (ONNX files):  DaSiamRPN, NanoTrack, TrackerVit
+
+The same source runs unchanged on OpenCV 4.x (4.9+) and OpenCV 5.x, which is
+exactly the compatibility contract the accompanying LearnOpenCV article
+explains. KCF and CSRT come from opencv_contrib, so they appear only when the
+contrib build (for example the ``opencv-contrib-python`` wheel) is installed.
+
+Examples:
+    python3 object_tracking.py --list-trackers
+    python3 object_tracking.py --tracker vittrack --input video.mp4
+    python3 object_tracking.py --tracker csrt --input 0            # webcam
+    python3 object_tracking.py --tracker mil --validate --no-display
+"""
+
+# argparse implements the command-line interface shared by all trackers.
+import argparse
+# json serializes the run metrics so tests and benchmarks can consume them.
+import json
+# pathlib anchors every bundled asset at this file, not the caller's cwd.
+from pathlib import Path
+# sys supplies exit codes and access to the interpreter for error reporting.
+import sys
+
+# NumPy generates the deterministic synthetic validation video.
+import numpy as np
+
+# OpenCV provides the tracker implementations, video I/O, and drawing calls.
+import cv2
+
+# The models directory sits one level above this script and is shared with
+# the C++ example, so both languages read identical ONNX files.
+DEFAULT_MODELS_DIR = Path(__file__).resolve().parent.parent / "models"
+
+# Geometry of the synthetic validation clip. Kept small so validation runs in
+# a couple of seconds yet long enough to expose drift.
+SYNTH_SIZE = (640, 360)      # frame width and height in pixels
+SYNTH_FRAMES = 80            # number of frames in the clip
+SYNTH_TARGET = 64            # side length of the moving square target
+SYNTH_SEED = 7               # fixed seed makes every run byte-identical
+
+# Validation passes when the tracked box stays this close to ground truth.
+# The thresholds are intentionally loose: they catch a broken tracker or a
+# broken API call, not small quality differences between algorithms.
+VALIDATE_MEAN_IOU = 0.45     # required mean IoU over the whole clip
+VALIDATE_SUCCESS_IOU = 0.30  # per-frame IoU counted as "still on target"
+VALIDATE_SUCCESS_RATE = 0.90 # required fraction of frames on target
+
+
+def _resolve_creator(class_name):
+    """Return the ``create`` callable for a tracker class, or None.
+
+    OpenCV's Python bindings historically exposed two spellings:
+    ``cv2.TrackerMIL_create()`` (flat, older) and ``cv2.TrackerMIL.create()``
+    (class static method, current). Checking both keeps the script working
+    across every 4.8+ and 5.x build.
+    """
+    # Prefer the flat function when present because it exists on both APIs.
+    flat = getattr(cv2, f"{class_name}_create", None)
+    if flat is not None:
+        return flat
+    # Fall back to the static method on the tracker class itself.
+    klass = getattr(cv2, class_name, None)
+    if klass is not None:
+        return getattr(klass, "create", None)
+    # Neither spelling exists: this build does not ship the tracker.
+    return None
+
+
+def _params_for(class_name):
+    """Instantiate the ``<Tracker>_Params`` object for DNN trackers, or None."""
+    # DNN trackers receive their model paths through a params struct that the
+    # bindings expose as e.g. ``cv2.TrackerVit_Params``.
+    params_class = getattr(cv2, f"{class_name}_Params", None)
+    return params_class() if params_class is not None else None
+
+
+def make_mil(_models_dir):
+    """MIL (2009): boosting over bags of positive patches. Always in main."""
+    creator = _resolve_creator("TrackerMIL")
+    return creator() if creator else None
+
+
+def make_kcf(_models_dir):
+    """KCF (2014): kernelized correlation filter. Lives in opencv_contrib."""
+    creator = _resolve_creator("TrackerKCF")
+    return creator() if creator else None
+
+
+def make_csrt(_models_dir):
+    """CSRT (2017): channel and spatial reliability DCF. In opencv_contrib."""
+    creator = _resolve_creator("TrackerCSRT")
+    return creator() if creator else None
+
+
+def make_dasiamrpn(models_dir):
+    """DaSiamRPN (2018): siamese region-proposal tracker, three ONNX files."""
+    creator = _resolve_creator("TrackerDaSiamRPN")
+    params = _params_for("TrackerDaSiamRPN")
+    if creator is None or params is None:
+        return None
+    # The params struct wants the backbone plus two correlation kernels.
+    model = models_dir / "dasiamrpn_model.onnx"
+    kernel_cls = models_dir / "dasiamrpn_kernel_cls1.onnx"
+    kernel_r1 = models_dir / "dasiamrpn_kernel_r1.onnx"
+    # Missing files mean the tracker is unavailable, not that we should crash;
+    # download_models.py explains how to fetch them.
+    if not (model.exists() and kernel_cls.exists() and kernel_r1.exists()):
+        return None
+    params.model = str(model)
+    params.kernel_cls1 = str(kernel_cls)
+    params.kernel_r1 = str(kernel_r1)
+    return creator(params)
+
+
+def make_nanotrack(models_dir):
+    """NanoTrack v2 (2022): ~2 MB siamese tracker built for edge devices."""
+    creator = _resolve_creator("TrackerNano")
+    params = _params_for("TrackerNano")
+    if creator is None or params is None:
+        return None
+    backbone = models_dir / "nanotrack_backbone_sim.onnx"
+    head = models_dir / "nanotrack_head_sim.onnx"
+    if not (backbone.exists() and head.exists()):
+        return None
+    # NanoTrack splits its network into a backbone and a neck+head pair.
+    params.backbone = str(backbone)
+    params.neckhead = str(head)
+    return creator(params)
+
+
+def make_vittrack(models_dir):
+    """VitTrack (2023): transformer tracker, OpenCV 5's flagship replacement
+    for the removed GOTURN."""
+    creator = _resolve_creator("TrackerVit")
+    params = _params_for("TrackerVit")
+    if creator is None or params is None:
+        return None
+    net = models_dir / "object_tracking_vittrack_2023sep.onnx"
+    if not net.exists():
+        return None
+    # A single ONNX file holds the whole model; it is under 1 MB.
+    params.net = str(net)
+    return creator(params)
+
+
+# Registry mapping the CLI name to a builder. Order matters only for help
+# text; availability is decided at runtime by each builder.
+TRACKER_BUILDERS = {
+    "mil": make_mil,
+    "kcf": make_kcf,
+    "csrt": make_csrt,
+    "dasiamrpn": make_dasiamrpn,
+    "nanotrack": make_nanotrack,
+    "vittrack": make_vittrack,
+}
+
+
+def create_tracker(name, models_dir):
+    """Build the requested tracker or raise a helpful error explaining why not."""
+    builder = TRACKER_BUILDERS[name]
+    tracker = builder(models_dir)
+    if tracker is not None:
+        return tracker
+    # Distinguish "not in this OpenCV build" from "model files not downloaded"
+    # because the user fixes the two problems differently.
+    if name in ("kcf", "csrt"):
+        raise RuntimeError(
+            f"{name} requires an opencv_contrib build "
+            "(pip install opencv-contrib-python)."
+        )
+    if name in ("dasiamrpn", "nanotrack", "vittrack"):
+        raise RuntimeError(
+            f"{name} model files not found in {models_dir}. "
+            "Run: python3 download_models.py"
+        )
+    raise RuntimeError(f"{name} is not available in this OpenCV build.")
+
+
+def list_trackers(models_dir):
+    """Print one line per tracker with its availability in this environment."""
+    print(f"OpenCV version: {cv2.__version__}")
+    for name, builder in TRACKER_BUILDERS.items():
+        # Building the tracker is the only reliable availability test.
+        try:
+            available = builder(models_dir) is not None
+        except cv2.error:
+            available = False
+        print(f"  {name:<10} {'available' if available else 'NOT available'}")
+
+
+def iou(box_a, box_b):
+    """Intersection-over-union of two (x, y, w, h) boxes; 0 when disjoint."""
+    # Convert to corner coordinates for the overlap computation.
+    ax1, ay1, ax2, ay2 = box_a[0], box_a[1], box_a[0] + box_a[2], box_a[1] + box_a[3]
+    bx1, by1, bx2, by2 = box_b[0], box_b[1], box_b[0] + box_b[2], box_b[1] + box_b[3]
+    # The intersection rectangle is bounded by the inner edges.
+    inter_w = max(0.0, min(ax2, bx2) - max(ax1, bx1))
+    inter_h = max(0.0, min(ay2, by2) - max(ay1, by1))
+    inter = inter_w * inter_h
+    # Union = sum of areas minus the double-counted intersection.
+    union = box_a[2] * box_a[3] + box_b[2] * box_b[3] - inter
+    return inter / union if union > 0 else 0.0
+
+
+def make_synthetic_video(path, size=SYNTH_SIZE, frames=SYNTH_FRAMES):
+    """Write a deterministic clip of a textured square on a noisy background.
+
+    Returns the list of ground-truth (x, y, w, h) boxes, one per frame. Both
+    the validation mode and the regression tests rely on this function, and
+    the C++ example generates the same scene from the same parameters so the
+    two implementations can be compared numerically.
+    """
+    width, height = size
+    # A fixed seed makes the background and target identical on every run.
+    rng = np.random.RandomState(SYNTH_SEED)
+    # Background: low-contrast noise over a horizontal gradient. Texture
+    # everywhere prevents trackers from locking onto a blank frame edge.
+    gradient = np.tile(np.linspace(60, 120, width, dtype=np.uint8), (height, 1))
+    noise = rng.randint(0, 40, (height, width), dtype=np.uint8)
+    background = cv2.merge([
+        cv2.add(gradient, noise),
+        cv2.add(gradient, rng.randint(0, 40, (height, width), dtype=np.uint8)),
+        cv2.add(gradient, rng.randint(0, 40, (height, width), dtype=np.uint8)),
+    ])
+    # Target: an 8x8 grid of random bright colors gives strong, unique
+    # texture that every tracker family can latch onto.
+    cell = SYNTH_TARGET // 8
+    target = rng.randint(64, 255, (8, 8, 3), dtype=np.uint8)
+    target = cv2.resize(target, (SYNTH_TARGET, SYNTH_TARGET),
+                        interpolation=cv2.INTER_NEAREST)
+    _ = cell  # cell size folded into the resize above
+    # MJPG in an AVI container is built into every OpenCV binary, so the
+    # writer never depends on an external codec being installed.
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"MJPG"),
+                             30.0, (width, height))
+    if not writer.isOpened():
+        raise RuntimeError(f"Cannot open video writer for {path}")
+    boxes = []
+    # Sweep the target along a smooth Lissajous-style path. The speed tops
+    # out near 10 px/frame: fast enough to expose a broken tracker, slow
+    # enough that even MIL's small search window can physically follow.
+    for index in range(frames):
+        phase = index / frames
+        x = int((width - SYNTH_TARGET - 40) * 0.5 *
+                (1 + np.sin(np.pi * phase - np.pi / 2)) + 20)
+        y = int((height - SYNTH_TARGET - 40) * 0.5 *
+                (1 + np.sin(2 * np.pi * phase)) + 20)
+        # Compose the frame: copy the background, paste the target.
+        frame = background.copy()
+        frame[y:y + SYNTH_TARGET, x:x + SYNTH_TARGET] = target
+        writer.write(frame)
+        boxes.append((x, y, SYNTH_TARGET, SYNTH_TARGET))
+    writer.release()
+    return boxes
+
+
+def open_capture(source):
+    """Open a video file or a numeric camera index and fail with a clear error."""
+    # A purely numeric argument selects a camera; anything else is a path.
+    capture = (cv2.VideoCapture(int(source)) if str(source).isdigit()
+               else cv2.VideoCapture(str(source)))
+    if not capture.isOpened():
+        raise RuntimeError(f"Cannot open input: {source}")
+    return capture
+
+
+def track(tracker, capture, init_box, args, ground_truth=None):
+    """Core loop shared by normal runs and validation.
+
+    Reads frames, updates the tracker, draws and optionally displays or
+    writes the annotated result, and returns a metrics dictionary.
+    """
+    # Read the first frame; the tracker is initialized on it.
+    ok, frame = capture.read()
+    if not ok:
+        raise RuntimeError("Input has no frames")
+    # If the caller gave no box, ask the user to draw one (GUI builds only).
+    if init_box is None:
+        if args.no_display:
+            raise RuntimeError("--bbox is required when --no-display is set")
+        init_box = cv2.selectROI("Select object", frame, showCrosshair=True)
+        cv2.destroyWindow("Select object")
+    # init() learns the appearance model from the first frame and box.
+    tracker.init(frame, tuple(int(v) for v in init_box))
+    # Prepare the optional annotated-video writer in the output directory.
+    writer = None
+    if args.output_dir is not None:
+        output_dir = Path(args.output_dir)
+        # Create the directory explicitly instead of failing on write.
+        output_dir.mkdir(parents=True, exist_ok=True)
+        height, width = frame.shape[:2]
+        writer = cv2.VideoWriter(
+            str(output_dir / f"tracked_{args.tracker}.avi"),
+            cv2.VideoWriter_fourcc(*"MJPG"), 30.0, (width, height))
+        if not writer.isOpened():
+            raise RuntimeError(f"Cannot write output video in {output_dir}")
+    # TickMeter gives portable, monotonic per-frame timing for the FPS overlay.
+    meter = cv2.TickMeter()
+    ious = []            # per-frame IoU against ground truth, if provided
+    frames_done = 1      # the init frame counts toward the total
+    lost_frames = 0      # frames where update() reported failure
+    while True:
+        # Stop early when a frame budget was requested (useful for tests).
+        if args.max_frames and frames_done >= args.max_frames:
+            break
+        ok, frame = capture.read()
+        if not ok:
+            break  # end of stream
+        # Time exactly the tracker update, not drawing or I/O.
+        meter.start()
+        found, box = tracker.update(frame)
+        meter.stop()
+        if found:
+            # Draw the tracked box; integer coordinates for the raster calls.
+            x, y, w, h = (int(v) for v in box)
+            cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
+        else:
+            # Be explicit on screen when the tracker declares failure.
+            lost_frames += 1
+            cv2.putText(frame, "tracking failure", (20, 60),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 255), 2)
+        # Score against ground truth while validating on the synthetic clip.
+        if ground_truth is not None and frames_done < len(ground_truth):
+            truth = ground_truth[frames_done]
+            ious.append(iou(box, truth) if found else 0.0)
+        # Overlay the running average FPS of tracker updates.
+        fps = meter.getFPS()
+        cv2.putText(frame, f"{args.tracker}  {fps:5.1f} FPS", (20, 30),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (50, 170, 50), 2)
+        if writer is not None:
+            writer.write(frame)
+        # Display unless the caller runs headless; ESC quits interactively.
+        if not args.no_display:
+            cv2.imshow("Tracking", frame)
+            if cv2.waitKey(1) & 0xFF == 27:
+                break
+        frames_done += 1
+    # Release resources deterministically; important on Windows file locks.
+    capture.release()
+    if writer is not None:
+        writer.release()
+    if not args.no_display:
+        cv2.destroyAllWindows()
+    # Bundle everything a test or benchmark needs into one dictionary.
+    return {
+        "tracker": args.tracker,
+        "opencv_version": cv2.__version__,
+        "frames": frames_done,
+        "lost_frames": lost_frames,
+        "mean_fps": round(meter.getFPS(), 2),
+        "mean_iou": round(float(np.mean(ious)), 4) if ious else None,
+        "success_rate": (
+            round(float(np.mean([v > VALIDATE_SUCCESS_IOU for v in ious])), 4)
+            if ious else None),
+    }
+
+
+def run(args):
+    """Normal mode: track a user-supplied video or camera stream."""
+    models_dir = Path(args.models_dir)
+    tracker = create_tracker(args.tracker, models_dir)
+    capture = open_capture(args.input)
+    # Parse "x,y,w,h" once here so track() receives a ready-to-use tuple.
+    init_box = (tuple(int(v) for v in args.bbox.split(","))
+                if args.bbox else None)
+    metrics = track(tracker, capture, init_box, args)
+    _write_metrics(metrics, args)
+    print(json.dumps(metrics, indent=2))
+    return 0
+
+
+def validate(args):
+    """Validation mode: synthesize a clip with known ground truth and verify
+    that the tracker follows the target within the documented thresholds."""
+    models_dir = Path(args.models_dir)
+    tracker = create_tracker(args.tracker, models_dir)
+    # The synthetic clip lives in the output directory (or a default) so a
+    # test can inspect it and nothing pollutes the source tree.
+    output_dir = Path(args.output_dir) if args.output_dir else Path("outputs")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    args.output_dir = str(output_dir)
+    clip_path = output_dir / "synthetic_clip.avi"
+    ground_truth = make_synthetic_video(clip_path)
+    capture = open_capture(clip_path)
+    # Initialize from the exact ground-truth box of frame zero.
+    metrics = track(tracker, capture, ground_truth[0], args, ground_truth)
+    _write_metrics(metrics, args)
+    print(json.dumps(metrics, indent=2))
+    # Apply the pass criteria and print an unambiguous marker for CI greps.
+    passed = (metrics["mean_iou"] is not None
+              and metrics["mean_iou"] >= VALIDATE_MEAN_IOU
+              and metrics["success_rate"] >= VALIDATE_SUCCESS_RATE)
+    print("VALIDATION PASSED" if passed else "VALIDATION FAILED")
+    return 0 if passed else 1
+
+
+def _write_metrics(metrics, args):
+    """Persist metrics as JSON next to the annotated video when requested."""
+    if args.output_dir is not None:
+        metrics_path = Path(args.output_dir) / f"metrics_{args.tracker}.json"
+        metrics_path.write_text(json.dumps(metrics, indent=2))
+
+
+def parse_args(argv=None):
+    """Define and parse the command-line interface."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--tracker", choices=sorted(TRACKER_BUILDERS),
+                        default="vittrack",
+                        help="which tracker to run (default: vittrack)")
+    parser.add_argument("--input", default="0",
+                        help="video path or camera index (default: 0)")
+    parser.add_argument("--bbox", default=None,
+                        help="initial box as x,y,w,h; drawn interactively if omitted")
+    parser.add_argument("--models-dir", default=str(DEFAULT_MODELS_DIR),
+                        help="directory holding the ONNX model files")
+    parser.add_argument("--output-dir", default=None,
+                        help="write annotated video and metrics JSON here")
+    parser.add_argument("--max-frames", type=int, default=0,
+                        help="stop after this many frames (0 = whole stream)")
+    parser.add_argument("--no-display", action="store_true",
+                        help="run headless: no windows, no waitKey")
+    parser.add_argument("--validate", action="store_true",
+                        help="run the synthetic-clip regression check")
+    parser.add_argument("--list-trackers", action="store_true",
+                        help="report tracker availability and exit")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Dispatch to list/validate/run and convert errors into clean exits."""
+    args = parse_args(argv)
+    if args.list_trackers:
+        list_trackers(Path(args.models_dir))
+        return 0
+    try:
+        return validate(args) if args.validate else run(args)
+    except (RuntimeError, cv2.error) as error:
+        # A readable one-line error beats a traceback for tutorial code.
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Object-Tracking-OpenCV5/python/requirements.txt
+++ b/Object-Tracking-OpenCV5/python/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.23,<3
+opencv-contrib-python>=4.9,<6

--- a/Object-Tracking-OpenCV5/python/tests/test_download_models.py
+++ b/Object-Tracking-OpenCV5/python/tests/test_download_models.py
@@ -1,0 +1,164 @@
+"""Offline regression tests for the atomic model downloader."""
+
+# hashlib provides the exact digest expected by download_one().
+import hashlib
+# pathlib addresses temporary destinations without current-directory coupling.
+from pathlib import Path
+# sys lets this test import the downloader from the project root.
+import sys
+# tempfile isolates every success and failure case.
+import tempfile
+# unittest provides the repository's standard test framework.
+import unittest
+# mock replaces only the network response; real file/checksum code still runs.
+from unittest import mock
+
+# Resolve and import the real project-root downloader.
+PROJECT_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_DIR))
+import download_models  # noqa: E402  (path setup must precede import)
+
+
+class FakeResponse:
+    """Small context-managed response that streams a fixed byte payload."""
+
+    def __init__(self, payload, advertised_size=None):
+        # Preserve the payload and a read cursor so chunked reads are realistic.
+        self.payload = payload
+        self.offset = 0
+        # Omit Content-Length when requested to exercise the streaming ceiling.
+        self.headers = {}
+        if advertised_size is not None:
+            self.headers["Content-Length"] = str(advertised_size)
+
+    def __enter__(self):
+        """Return the response just like urllib's HTTPResponse context manager."""
+        return self
+
+    def __exit__(self, _exception_type, _exception, _traceback):
+        """Do not suppress exceptions raised by the downloader."""
+        return False
+
+    def read(self, size):
+        """Return at most ``size`` bytes and then signal EOF with ``b''``."""
+        chunk = self.payload[self.offset:self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+def digest(payload):
+    """Return the SHA-256 digest used in the downloader's pinned metadata."""
+    return hashlib.sha256(payload).hexdigest()
+
+
+class DownloadOneTests(unittest.TestCase):
+    """Exercise success, bounds, integrity, timeout, and cleanup behavior."""
+
+    def _run_download(
+            self, directory, payload, expected_payload,
+            advertised_size=None, force=True):
+        """Call the real downloader with a deterministic mocked response."""
+        response = FakeResponse(payload, advertised_size)
+        with mock.patch.object(
+                download_models.urllib.request, "urlopen",
+                return_value=response):
+            return download_models.download_one(
+                "model.onnx",
+                "https://example.invalid/model.onnx",
+                digest(expected_payload),
+                len(expected_payload),
+                force,
+                Path(directory),
+            )
+
+    def _assert_no_partials(self, directory):
+        """A completed or rejected request must leave no temporary files."""
+        partials = list(Path(directory).glob(".*.part"))
+        self.assertEqual(partials, [])
+
+    def test_valid_payload_replaces_destination_atomically(self):
+        # The happy path should expose exactly the verified final file.
+        payload = b"verified-model-payload"
+        with tempfile.TemporaryDirectory() as directory:
+            success = self._run_download(
+                directory, payload, payload, advertised_size=len(payload)
+            )
+            destination = Path(directory) / "model.onnx"
+            self.assertTrue(success)
+            self.assertEqual(destination.read_bytes(), payload)
+            self.assertEqual(set(Path(directory).iterdir()), {destination})
+            self._assert_no_partials(directory)
+
+    def test_oversized_stream_preserves_existing_destination(self):
+        # Without Content-Length, the streaming byte ceiling must still stop an
+        # oversized body before it can replace the prior file.
+        expected = b"expected"
+        existing = b"previously-verified"
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "model.onnx"
+            destination.write_bytes(existing)
+            success = self._run_download(
+                directory, expected + b"extra", expected,
+                advertised_size=None,
+            )
+            self.assertFalse(success)
+            self.assertEqual(destination.read_bytes(), existing)
+            self._assert_no_partials(directory)
+
+    def test_undersized_stream_preserves_existing_destination(self):
+        # A clean EOF is not success unless the exact pinned byte count arrived.
+        expected = b"complete-model"
+        existing = b"previously-verified"
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "model.onnx"
+            destination.write_bytes(existing)
+            success = self._run_download(
+                directory, expected[:-1], expected,
+                advertised_size=len(expected) - 1,
+            )
+            self.assertFalse(success)
+            self.assertEqual(destination.read_bytes(), existing)
+            self._assert_no_partials(directory)
+
+    def test_bad_checksum_preserves_existing_destination(self):
+        # Equal byte counts are insufficient when the pinned digest disagrees.
+        expected = b"expected-model"
+        corrupted = b"corruptd-model"
+        self.assertEqual(len(corrupted), len(expected))
+        existing = b"previously-verified"
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "model.onnx"
+            destination.write_bytes(existing)
+            success = self._run_download(
+                directory, corrupted, expected,
+                advertised_size=len(expected),
+            )
+            self.assertFalse(success)
+            self.assertEqual(destination.read_bytes(), existing)
+            self._assert_no_partials(directory)
+
+    def test_timeout_preserves_existing_destination_and_cleans_partial(self):
+        # Network timeouts are ordinary failures: no traceback, replacement,
+        # or abandoned partial file should result.
+        existing = b"previously-verified"
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "model.onnx"
+            destination.write_bytes(existing)
+            with mock.patch.object(
+                    download_models.urllib.request, "urlopen",
+                    side_effect=TimeoutError("timed out")):
+                success = download_models.download_one(
+                    "model.onnx",
+                    "https://example.invalid/model.onnx",
+                    digest(b"expected"),
+                    len(b"expected"),
+                    True,
+                    Path(directory),
+                )
+            self.assertFalse(success)
+            self.assertEqual(destination.read_bytes(), existing)
+            self._assert_no_partials(directory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
@@ -2,9 +2,8 @@
 
 The tests exercise the real command-line entry point in a subprocess, from a
 temporary working directory, exactly as the OpenCV 5 migration workflow
-requires. Trackers that are unavailable in the current build (contrib not
-installed) or whose model files have not been downloaded are skipped with an
-explicit reason rather than silently passing.
+requires. Missing external model files produce explicit skips; missing tracker
+APIs, corrupt models, and runtime construction errors remain real failures.
 
 Run with:
     python3 -m unittest discover -s python/tests -v
@@ -23,8 +22,8 @@ import tempfile
 # unittest is the framework mandated by the project conventions.
 import unittest
 
-# Import the application module directly only to read its registry; every
-# behavioral test still goes through the subprocess CLI.
+# Import the application module for constants and synthetic-video generation;
+# every tracker behavior test still goes through the real subprocess CLI.
 APP_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(APP_DIR))
 import object_tracking  # noqa: E402  (path setup must precede the import)
@@ -33,20 +32,20 @@ import object_tracking  # noqa: E402  (path setup must precede the import)
 APP = APP_DIR / "object_tracking.py"
 MODELS_DIR = APP_DIR.parent / "models"
 
-
-def available_trackers():
-    """Return the tracker names that can actually be built right now."""
-    names = []
-    for name, builder in object_tracking.TRACKER_BUILDERS.items():
-        try:
-            if builder(MODELS_DIR) is not None:
-                names.append(name)
-        except Exception:  # noqa: BLE001 - any failure means unavailable
-            pass
-    return names
-
-
-AVAILABLE = available_trackers()
+# Only absent external model assets are an expected reason to skip a DNN
+# tracker. An installed-but-broken API or a corrupt model must fail loudly.
+MODEL_FILES = {
+    "dasiamrpn": (
+        "dasiamrpn_model.onnx",
+        "dasiamrpn_kernel_cls1.onnx",
+        "dasiamrpn_kernel_r1.onnx",
+    ),
+    "nanotrack": (
+        "nanotrack_backbone_sim.onnx",
+        "nanotrack_head_sim.onnx",
+    ),
+    "vittrack": ("object_tracking_vittrack_2023sep.onnx",),
+}
 
 
 def run_cli(arguments, cwd):
@@ -56,10 +55,42 @@ def run_cli(arguments, cwd):
         cwd=cwd, capture_output=True, text=True, timeout=600, check=False)
 
 
+def read_video(path):
+    """Return frame count, geometry, and FPS; fail on unreadable output."""
+    capture = object_tracking.cv2.VideoCapture(str(path))
+    if not capture.isOpened():
+        raise AssertionError(f"OpenCV cannot open {path}")
+    fps = float(capture.get(object_tracking.cv2.CAP_PROP_FPS))
+    frames = 0
+    geometry = None
+    while True:
+        ok, frame = capture.read()
+        if not ok:
+            break
+        frames += 1
+        current_geometry = (frame.shape[1], frame.shape[0])
+        if geometry is None:
+            geometry = current_geometry
+        elif geometry != current_geometry:
+            raise AssertionError(f"video geometry changed inside {path}")
+    capture.release()
+    if frames == 0:
+        raise AssertionError(f"OpenCV decoded no frames from {path}")
+    return frames, geometry, fps
+
+
 class ValidationPerTracker(unittest.TestCase):
-    """Every available tracker must pass the synthetic-clip validation."""
+    """Every tracker with downloaded model assets must pass validation."""
 
     def _validate_one(self, name):
+        missing_models = [
+            filename for filename in MODEL_FILES.get(name, ())
+            if not (MODELS_DIR / filename).is_file()
+        ]
+        if missing_models:
+            self.skipTest(
+                f"{name} model files not downloaded: {', '.join(missing_models)}"
+            )
         # A temporary cwd catches hidden current-directory assumptions, and a
         # temporary output dir keeps every artifact inspectable and isolated.
         with tempfile.TemporaryDirectory() as workdir:
@@ -71,15 +102,36 @@ class ValidationPerTracker(unittest.TestCase):
             # The run must succeed and print the explicit success marker.
             self.assertEqual(result.returncode, 0, msg=result.stderr)
             self.assertIn("VALIDATION PASSED", result.stdout)
-            # The exact expected artifacts must exist and be non-empty.
+            # No missing, stale, or unexpected artifacts may hide in the output.
             clip = output_dir / "synthetic_clip.avi"
             video = output_dir / f"tracked_{name}.avi"
             metrics_file = output_dir / f"metrics_{name}.json"
-            for artifact in (clip, video, metrics_file):
-                self.assertTrue(artifact.exists(), msg=f"missing {artifact}")
+            expected = {clip, video, metrics_file}
+            self.assertEqual(set(output_dir.iterdir()), expected)
+            for artifact in expected:
                 self.assertGreater(artifact.stat().st_size, 0)
-            # The stored metrics must repeat the thresholds the marker claims.
-            metrics = json.loads(metrics_file.read_text())
+            # Both generated videos must decode completely at the documented
+            # 640x360 geometry, with one output frame per processed input frame.
+            for artifact in (clip, video):
+                frames, geometry, fps = read_video(artifact)
+                self.assertEqual(frames, object_tracking.SYNTH_FRAMES)
+                self.assertEqual(geometry, object_tracking.SYNTH_SIZE)
+                self.assertAlmostEqual(fps, 30.0, places=1)
+            # The stored metrics must repeat the semantics the marker claims.
+            metrics = json.loads(metrics_file.read_text(encoding="utf-8"))
+            self.assertEqual(
+                set(metrics),
+                {
+                    "tracker", "opencv_version", "frames", "lost_frames",
+                    "mean_fps", "mean_iou", "success_rate",
+                },
+            )
+            self.assertEqual(metrics["tracker"], name)
+            self.assertEqual(
+                metrics["opencv_version"], object_tracking.cv2.__version__
+            )
+            self.assertEqual(metrics["frames"], object_tracking.SYNTH_FRAMES)
+            self.assertEqual(metrics["lost_frames"], 0)
             self.assertGreaterEqual(
                 metrics["mean_iou"], object_tracking.VALIDATE_MEAN_IOU)
             self.assertGreaterEqual(
@@ -89,8 +141,6 @@ class ValidationPerTracker(unittest.TestCase):
 # Generate one test method per tracker so results report individually.
 def _make_test(name):
     def test(self):
-        if name not in AVAILABLE:
-            self.skipTest(f"{name} unavailable in this build/model setup")
         self._validate_one(name)
     return test
 
@@ -139,6 +189,121 @@ class CliBehavior(unittest.TestCase):
                 cwd=workdir)
             self.assertEqual(result.returncode, 1)
             self.assertIn("--bbox is required", result.stderr)
+
+    def test_malformed_bbox_fails_without_traceback(self):
+        # A partial integer parse must never reach an OpenCV assertion.
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            object_tracking.make_synthetic_video(clip)
+            result = run_cli(
+                [
+                    "--tracker", "mil", "--input", str(clip),
+                    "--bbox", "1,2,nope,4", "--no-display",
+                ],
+                cwd=workdir,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Cannot parse --bbox", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_out_of_frame_bbox_fails_cleanly(self):
+        # Geometry is checked against the actual first frame, not just syntax.
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            object_tracking.make_synthetic_video(clip)
+            result = run_cli(
+                [
+                    "--tracker", "mil", "--input", str(clip),
+                    "--bbox", "620,340,64,64", "--no-display",
+                ],
+                cwd=workdir,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("lie fully inside", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_normal_mode_preserves_frame_count(self):
+        # Exercise the non-validation path and the one-frame edge case that
+        # previously produced an empty annotated AVI.
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            output_dir = Path(workdir) / "out"
+            # Use an integer rate because some minimal macOS backends quantize
+            # fractional AVI rates even though the application preserves the
+            # rate that VideoCapture reports.
+            source_fps = 12.0
+            boxes = object_tracking.make_synthetic_video(clip, fps=source_fps)
+            bbox = ",".join(str(value) for value in boxes[0])
+            result = run_cli(
+                [
+                    "--tracker", "mil", "--input", str(clip),
+                    "--bbox", bbox, "--max-frames", "1", "--no-display",
+                    "--output-dir", str(output_dir),
+                ],
+                cwd=workdir,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertEqual(
+                {path.name for path in output_dir.iterdir()},
+                {"tracked_mil.avi", "metrics_mil.json"},
+            )
+            frames, geometry, output_fps = read_video(
+                output_dir / "tracked_mil.avi"
+            )
+            self.assertEqual(frames, 1)
+            self.assertEqual(geometry, object_tracking.SYNTH_SIZE)
+            self.assertAlmostEqual(output_fps, source_fps, places=1)
+            metrics = json.loads(
+                (output_dir / "metrics_mil.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(metrics["frames"], 1)
+
+    def test_truncated_validation_fails(self):
+        # A high-IoU prefix is not the promised 80-frame regression and must
+        # never produce the validation success marker or a zero exit.
+        with tempfile.TemporaryDirectory() as workdir:
+            output_dir = Path(workdir) / "out"
+            result = run_cli(
+                [
+                    "--tracker", "mil", "--validate", "--no-display",
+                    "--max-frames", "2", "--output-dir", str(output_dir),
+                ],
+                cwd=workdir,
+            )
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            self.assertIn("VALIDATION FAILED", result.stdout)
+            self.assertNotIn("VALIDATION PASSED", result.stdout)
+            metrics = json.loads(
+                (output_dir / "metrics_mil.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(metrics["frames"], 2)
+
+    def test_output_write_failure_is_clean(self):
+        # An existing file cannot serve as an output directory; report that
+        # filesystem error without exposing a Python traceback.
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            not_a_directory = Path(workdir) / "occupied"
+            object_tracking.make_synthetic_video(clip)
+            not_a_directory.write_text("file", encoding="utf-8")
+            result = run_cli(
+                [
+                    "--tracker", "mil", "--input", str(clip),
+                    "--bbox", "20,148,64,64", "--no-display",
+                    "--output-dir", str(not_a_directory),
+                ],
+                cwd=workdir,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("occupied", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_negative_max_frames_is_rejected(self):
+        # argparse-style errors use exit code 2 and never run a tracker.
+        with tempfile.TemporaryDirectory() as workdir:
+            result = run_cli(["--max-frames", "-1"], cwd=workdir)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--max-frames must be zero or", result.stderr)
 
 
 class SyntheticVideoProperties(unittest.TestCase):

--- a/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
@@ -1,0 +1,171 @@
+"""Regression tests for the unified tracking example.
+
+The tests exercise the real command-line entry point in a subprocess, from a
+temporary working directory, exactly as the OpenCV 5 migration workflow
+requires. Trackers that are unavailable in the current build (contrib not
+installed) or whose model files have not been downloaded are skipped with an
+explicit reason rather than silently passing.
+
+Run with:
+    python3 -m unittest discover -s python/tests -v
+"""
+
+# json parses the metrics files the application writes.
+import json
+# pathlib locates the application relative to this test file.
+from pathlib import Path
+# subprocess runs the CLI exactly as a user would.
+import subprocess
+# sys supplies the interpreter path so the tests honor the active venv.
+import sys
+# tempfile provides isolated working and output directories per test.
+import tempfile
+# unittest is the framework mandated by the project conventions.
+import unittest
+
+# Import the application module directly only to read its registry; every
+# behavioral test still goes through the subprocess CLI.
+APP_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(APP_DIR))
+import object_tracking  # noqa: E402  (path setup must precede the import)
+
+# The application script and shared models directory under test.
+APP = APP_DIR / "object_tracking.py"
+MODELS_DIR = APP_DIR.parent / "models"
+
+
+def available_trackers():
+    """Return the tracker names that can actually be built right now."""
+    names = []
+    for name, builder in object_tracking.TRACKER_BUILDERS.items():
+        try:
+            if builder(MODELS_DIR) is not None:
+                names.append(name)
+        except Exception:  # noqa: BLE001 - any failure means unavailable
+            pass
+    return names
+
+
+AVAILABLE = available_trackers()
+
+
+def run_cli(arguments, cwd):
+    """Run the application CLI in a subprocess and capture its output."""
+    return subprocess.run(
+        [sys.executable, str(APP), *arguments],
+        cwd=cwd, capture_output=True, text=True, timeout=600, check=False)
+
+
+class ValidationPerTracker(unittest.TestCase):
+    """Every available tracker must pass the synthetic-clip validation."""
+
+    def _validate_one(self, name):
+        # A temporary cwd catches hidden current-directory assumptions, and a
+        # temporary output dir keeps every artifact inspectable and isolated.
+        with tempfile.TemporaryDirectory() as workdir:
+            output_dir = Path(workdir) / "out"
+            result = run_cli(
+                ["--tracker", name, "--validate", "--no-display",
+                 "--output-dir", str(output_dir)],
+                cwd=workdir)
+            # The run must succeed and print the explicit success marker.
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("VALIDATION PASSED", result.stdout)
+            # The exact expected artifacts must exist and be non-empty.
+            clip = output_dir / "synthetic_clip.avi"
+            video = output_dir / f"tracked_{name}.avi"
+            metrics_file = output_dir / f"metrics_{name}.json"
+            for artifact in (clip, video, metrics_file):
+                self.assertTrue(artifact.exists(), msg=f"missing {artifact}")
+                self.assertGreater(artifact.stat().st_size, 0)
+            # The stored metrics must repeat the thresholds the marker claims.
+            metrics = json.loads(metrics_file.read_text())
+            self.assertGreaterEqual(
+                metrics["mean_iou"], object_tracking.VALIDATE_MEAN_IOU)
+            self.assertGreaterEqual(
+                metrics["success_rate"], object_tracking.VALIDATE_SUCCESS_RATE)
+
+
+# Generate one test method per tracker so results report individually.
+def _make_test(name):
+    def test(self):
+        if name not in AVAILABLE:
+            self.skipTest(f"{name} unavailable in this build/model setup")
+        self._validate_one(name)
+    return test
+
+
+for _name in object_tracking.TRACKER_BUILDERS:
+    setattr(ValidationPerTracker, f"test_validate_{_name}", _make_test(_name))
+
+
+class CliBehavior(unittest.TestCase):
+    """Error handling and informational modes of the CLI."""
+
+    def test_list_trackers_reports_all_names(self):
+        # --list-trackers must mention every registry entry and the version.
+        with tempfile.TemporaryDirectory() as workdir:
+            result = run_cli(["--list-trackers"], cwd=workdir)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("OpenCV version", result.stdout)
+            for name in object_tracking.TRACKER_BUILDERS:
+                self.assertIn(name, result.stdout)
+
+    def test_missing_input_fails_cleanly(self):
+        # A nonexistent input file must produce a clean nonzero exit and a
+        # readable message, never a traceback.
+        with tempfile.TemporaryDirectory() as workdir:
+            result = run_cli(
+                ["--tracker", "mil", "--input", "no_such_file.mp4",
+                 "--bbox", "10,10,40,40", "--no-display"],
+                cwd=workdir)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Cannot open input", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_unknown_tracker_rejected_by_argparse(self):
+        # argparse rejects unknown tracker names with its usual exit code 2.
+        with tempfile.TemporaryDirectory() as workdir:
+            result = run_cli(["--tracker", "goturn"], cwd=workdir)
+            self.assertEqual(result.returncode, 2)
+
+    def test_headless_requires_bbox(self):
+        # Headless mode cannot pop the ROI selector, so it must demand --bbox.
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            object_tracking.make_synthetic_video(clip)
+            result = run_cli(
+                ["--tracker", "mil", "--input", str(clip), "--no-display"],
+                cwd=workdir)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("--bbox is required", result.stderr)
+
+
+class SyntheticVideoProperties(unittest.TestCase):
+    """The validation clip itself must be deterministic and well-formed."""
+
+    def test_ground_truth_boxes_stay_inside_frame(self):
+        with tempfile.TemporaryDirectory() as workdir:
+            clip = Path(workdir) / "clip.avi"
+            boxes = object_tracking.make_synthetic_video(clip)
+            self.assertEqual(len(boxes), object_tracking.SYNTH_FRAMES)
+            width, height = object_tracking.SYNTH_SIZE
+            for x, y, w, h in boxes:
+                # Every box must lie fully inside the frame bounds.
+                self.assertGreaterEqual(x, 0)
+                self.assertGreaterEqual(y, 0)
+                self.assertLessEqual(x + w, width)
+                self.assertLessEqual(y + h, height)
+
+    def test_clip_is_reproducible(self):
+        # Two generations must produce byte-identical files (fixed seed).
+        with tempfile.TemporaryDirectory() as workdir:
+            clip_a = Path(workdir) / "a.avi"
+            clip_b = Path(workdir) / "b.avi"
+            object_tracking.make_synthetic_video(clip_a)
+            object_tracking.make_synthetic_video(clip_b)
+            self.assertEqual(clip_a.read_bytes(), clip_b.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- Add one Python and one C++ command-line example covering the six modern
  single-object trackers: MIL, KCF, CSRT, DaSiamRPN, NanoTrack, and VitTrack.
- Support exact OpenCV 4.14.0 and 5.0.0 with shared headless validation,
  output, metrics, input override, and bounding-box controls.
- Add an atomic model downloader with immutable upstream revisions, pinned
  sizes, and SHA-256 verification.
- Add Python regressions and CTest wrappers for every tracker, output
  contracts, invalid inputs, incomplete validation, and downloader failures.
- Document setup, exact-version selection, run/test commands, compatibility
  behavior, and the checked-in directory tree.

## Why

This publishes the existing OpenCV 5 video-tracker work in LearnOpenCV while
preserving an exact OpenCV 4.14 compatibility target. The validation contract
now requires the complete deterministic 80-frame clip, so a short high-IoU
prefix cannot report a false pass.

## Scope and compatibility

- All 11 changed files are confined to `Object-Tracking-OpenCV5/`.
- The same sources run on OpenCV 4.14.0 and 5.0.0.
- Models, build trees, outputs, caches, and virtual environments remain
  untracked.
- The Big Vision footer is unchanged.

## Verification

- Python: 23/23 tests passed on OpenCV 4.14.0 and 23/23 on OpenCV 5.0.0, with
  zero skips.
- C++: fresh Release builds with `-Wall -Wextra -Wpedantic -Werror`; 17/17
  CTests passed on each exact version.
- Direct matrix: 24/24 tracker/language/version validation cells passed from
  an unrelated working directory.
- Verified exact 72-artifact manifests and decoded all 48 validation AVIs as
  80 frames, 640x360, 30 FPS.
- Metrics used the exact seven-key schema, reported 80 frames and zero lost
  frames, and passed the documented IoU thresholds.
- All four normal-mode cells produced one readable frame and preserved a
  12 FPS source rate.
- All four truncated two-frame validation cells exited nonzero with
  `VALIDATION FAILED`.
- Python reported exact versions 4.14.0/5.0.0; C++ linked exclusively to the
  matching `.414`/`.500` OpenCV libraries.
- All six real downloaded model files matched their pinned byte sizes and
  SHA-256 values.
- `git diff --check` passed.
