### PR TITLE
Report VitTrack confidence and reject low-score updates

### DIFF
--- a/Object-Tracking-OpenCV5/README.md
+++ b/Object-Tracking-OpenCV5/README.md
@@ -143,6 +143,13 @@ Python uses `--list-trackers`; C++ uses `--list`. Invalid options, malformed or
 out-of-frame boxes, missing inputs, and output failures return a clean nonzero
 exit.
 
+VitTrack is configured explicitly with `DNN_BACKEND_OPENCV`,
+`DNN_TARGET_CPU`, and a tracking-score threshold of `0.30`, matching OpenCV's
+DNN object-tracker sample. Its annotated output also shows
+`getTrackingScore()` on every updated frame. When the score falls below the
+threshold, the application reports a tracking failure and does not draw a
+potentially misleading box.
+
 Validation generates an 80-frame, 640×360 clip containing a textured square on
 a seeded noisy background. It initializes from frame zero and passes only when
 the 79 subsequent updates have mean IoU ≥ 0.45 and at least 90% exceed 0.30
@@ -152,7 +159,7 @@ JSON, then prints `VALIDATION PASSED` or `VALIDATION FAILED`.
 ## Test
 
 ```shell
-# Python: 23 tests, including all six tracker entry points.
+# Python: 24 tests, including all six tracker entry points.
 python3 -m unittest discover -s python/tests -v
 
 # C++: 17 tests with contrib and all downloaded models.
@@ -183,7 +190,8 @@ directory.
   in Python and C++. Tracker scores can differ across OpenCV versions; passing
   semantics and artifact contracts—not four-decimal score equality—are the
   compatibility guarantee.
-- OpenCV 5's new DNN graph engine prints `setPreferableTarget` warnings when the DNN trackers load; they are harmless and do not affect results.
+- VitTrack explicitly selects OpenCV's CPU DNN backend, so its result does not
+  depend on which backend a particular OpenCV build chooses by default.
 - The C++ and Python synthetic clips share the same geometry, trajectory, and thresholds, but use different random generators, so their pixels (and exact IoU values) differ slightly across languages by design.
 - Output videos preserve the input frame rate when the backend reports one and
   otherwise use a 30 FPS fallback.

--- a/Object-Tracking-OpenCV5/README.md
+++ b/Object-Tracking-OpenCV5/README.md
@@ -26,8 +26,9 @@ with it the GOTURN tracker. The article covers the migration path.
   `opencv_contrib`.
 - Python 3.9+ with NumPy 1.23–2.x. The dependency range is
   `opencv-contrib-python>=4.9,<6` and `numpy>=1.23,<3`; TrackerVit establishes
-  the OpenCV 4.9 API floor, while 4.14.0 and 5.0.0 are the exact validation
-  targets.
+  the OpenCV 4.9 API floor. Use OpenCV 4.11+ for the internal VitTrack
+  confidence threshold demonstrated in the article; 4.14.0 and 5.0.0 are the
+  exact validation targets.
 - C++17 and CMake 3.16+. OpenCV's `core`, `dnn`, `imgproc`, `videoio`,
   `highgui`, and `video` modules are required. The contrib `tracking` module
   enables KCF and CSRT; without it, the other four trackers still build and the
@@ -144,11 +145,13 @@ out-of-frame boxes, missing inputs, and output failures return a clean nonzero
 exit.
 
 VitTrack is configured explicitly with `DNN_BACKEND_OPENCV`,
-`DNN_TARGET_CPU`, and a tracking-score threshold of `0.30`, matching OpenCV's
-DNN object-tracker sample. Its annotated output also shows
-`getTrackingScore()` on every updated frame. When the score falls below the
-threshold, the application reports a tracking failure and does not draw a
-potentially misleading box.
+`DNN_TARGET_CPU`, and a tracking-score threshold of `0.30`. This promotes the
+official OpenCV demo's `0.30` visualization cutoff into the tracker's internal
+acceptance threshold on OpenCV 4.11+. OpenCV 4.9/4.10 do not expose that
+`Params` field, so the common tracking loop applies the same visible cutoff
+after `update()`. The annotated output shows `getTrackingScore()` on every
+updated frame; below `0.30`, it reports failure and draws no potentially
+misleading box.
 
 Validation generates an 80-frame, 640×360 clip containing a textured square on
 a seeded noisy background. It initializes from frame zero and passes only when
@@ -159,7 +162,7 @@ JSON, then prints `VALIDATION PASSED` or `VALIDATION FAILED`.
 ## Test
 
 ```shell
-# Python: 24 tests, including all six tracker entry points.
+# Python: 25 tests, including all six tracker entry points.
 python3 -m unittest discover -s python/tests -v
 
 # C++: 17 tests with contrib and all downloaded models.
@@ -192,6 +195,10 @@ directory.
   compatibility guarantee.
 - VitTrack explicitly selects OpenCV's CPU DNN backend, so its result does not
   depend on which backend a particular OpenCV build chooses by default.
+- OpenCV 4.9/4.10 expose VitTrack's score but not its internal threshold
+  parameter. The application hides updates below `0.30` on those releases, but
+  it cannot undo the tracker state change that already occurred. Use 4.11+ to
+  reproduce the anti-drift acceptance behavior shown in the article.
 - The C++ and Python synthetic clips share the same geometry, trajectory, and thresholds, but use different random generators, so their pixels (and exact IoU values) differ slightly across languages by design.
 - Output videos preserve the input frame rate when the backend reports one and
   otherwise use a 30 FPS fallback.

--- a/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
+++ b/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
@@ -72,9 +72,10 @@ constexpr double kValidateMeanIou = 0.45;
 constexpr double kValidateSuccessIou = 0.30;
 constexpr double kValidateSuccessRate = 0.90;
 
-// Match the OpenCV DNN tracker sample's confidence policy. OpenCV's lower
-// built-in default (0.20) is intended only to reject nearly black inputs and
-// can allow a weak prediction to update the template and trigger scale drift.
+// Promote the official demo's 0.30 visualization cutoff into this
+// application's acceptance policy. OpenCV's lower built-in default (0.20) is
+// intended only to reject nearly black inputs and can allow a weak prediction
+// to update the template and trigger scale drift.
 constexpr float kVitTrackingScoreThreshold = 0.30f;
 
 // MODELS_DIR is injected by CMake as the absolute path of ../models so the
@@ -156,11 +157,16 @@ static cv::Ptr<cv::Tracker> createTracker(const std::string& name,
         }
         cv::TrackerVit::Params params;
         params.net = (modelsDir / "object_tracking_vittrack_2023sep.onnx").string();
-        // Pin the portable CPU implementation and use the same acceptance
-        // threshold as OpenCV's official DNN object-tracker sample.
+        // Pin the portable CPU implementation and use the official demo's
+        // visualization cutoff as this application's acceptance threshold.
         params.backend = cv::dnn::DNN_BACKEND_OPENCV;
         params.target = cv::dnn::DNN_TARGET_CPU;
+#if CV_VERSION_MAJOR >= 5 || \
+    (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 11)
+        // OpenCV 4.9/4.10 expose the score but not this Params field. The
+        // tracking loop still applies the same display/acceptance cutoff.
         params.tracking_score_threshold = kVitTrackingScoreThreshold;
+#endif
         return cv::TrackerVit::create(params);
     }
     whyNot = "unknown tracker name: " + name;
@@ -473,10 +479,15 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
         cv::Rect box;
         // Time only the update call, not drawing or file I/O.
         meter.start();
-        const bool found = tracker->update(frame, box);
+        const bool located = tracker->update(frame, box);
         meter.stop();
         const std::optional<float> score =
             getVitTrackingScore(tracker, options.trackerName);
+        // The explicit comparison keeps the visible policy identical on
+        // OpenCV 4.9/4.10, whose TrackerVit::Params lacks the threshold field.
+        // On 4.11+ the internal threshold already makes located false.
+        const bool found =
+            located && (!score || *score >= kVitTrackingScoreThreshold);
         if (found)
         {
             // Draw the tracked box in green.

--- a/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
+++ b/Object-Tracking-OpenCV5/cpp/object_tracking.cpp
@@ -22,6 +22,8 @@
 #include <opencv2/opencv_modules.hpp>
 // Drawing primitives (rectangle, putText) and image resizing.
 #include <opencv2/imgproc.hpp>
+// Explicit DNN backend/target constants used by TrackerVit.
+#include <opencv2/dnn.hpp>
 // VideoCapture and VideoWriter for file, camera, and clip generation.
 #include <opencv2/videoio.hpp>
 // The main-module trackers: MIL, DaSiamRPN, Nano, Vit (GOTURN in 4.x only).
@@ -69,6 +71,11 @@ constexpr int kSynthSeed = 7;      // fixed seed keeps the clip deterministic
 constexpr double kValidateMeanIou = 0.45;
 constexpr double kValidateSuccessIou = 0.30;
 constexpr double kValidateSuccessRate = 0.90;
+
+// Match the OpenCV DNN tracker sample's confidence policy. OpenCV's lower
+// built-in default (0.20) is intended only to reject nearly black inputs and
+// can allow a weak prediction to update the template and trigger scale drift.
+constexpr float kVitTrackingScoreThreshold = 0.30f;
 
 // MODELS_DIR is injected by CMake as the absolute path of ../models so the
 // executable finds the shared ONNX files regardless of the current directory.
@@ -149,6 +156,11 @@ static cv::Ptr<cv::Tracker> createTracker(const std::string& name,
         }
         cv::TrackerVit::Params params;
         params.net = (modelsDir / "object_tracking_vittrack_2023sep.onnx").string();
+        // Pin the portable CPU implementation and use the same acceptance
+        // threshold as OpenCV's official DNN object-tracker sample.
+        params.backend = cv::dnn::DNN_BACKEND_OPENCV;
+        params.target = cv::dnn::DNN_TARGET_CPU;
+        params.tracking_score_threshold = kVitTrackingScoreThreshold;
         return cv::TrackerVit::create(params);
     }
     whyNot = "unknown tracker name: " + name;
@@ -158,6 +170,20 @@ static cv::Ptr<cv::Tracker> createTracker(const std::string& name,
 // The canonical tracker order used by --list and the help text.
 static const std::vector<std::string> kTrackerNames =
     {"mil", "kcf", "csrt", "dasiamrpn", "nanotrack", "vittrack"};
+
+// TrackerVit exposes a confidence score in addition to update()'s boolean.
+// Keep the factory's common cv::Tracker pointer while safely recovering the
+// more specific interface only for VitTrack.
+static std::optional<float> getVitTrackingScore(
+    const cv::Ptr<cv::Tracker>& tracker, const std::string& trackerName)
+{
+    if (trackerName != "vittrack") return std::nullopt;
+    const cv::Ptr<cv::TrackerVit> vit = tracker.dynamicCast<cv::TrackerVit>();
+    if (!vit)
+        throw std::runtime_error(
+            "Internal error: vittrack does not expose TrackerVit");
+    return vit->getTrackingScore();
+}
 
 // ---------------------------------------------------------------------------
 // Synthetic validation clip
@@ -449,6 +475,8 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
         meter.start();
         const bool found = tracker->update(frame, box);
         meter.stop();
+        const std::optional<float> score =
+            getVitTrackingScore(tracker, options.trackerName);
         if (found)
         {
             // Draw the tracked box in green.
@@ -469,9 +497,12 @@ static RunMetrics track(cv::Ptr<cv::Tracker> tracker, cv::VideoCapture& capture,
             ious.push_back(found ? iou(box, truth) : 0.0);
         }
         // Overlay the running-average FPS of tracker updates.
-        cv::putText(frame,
-                    options.trackerName + cv::format("  %5.1f FPS", meter.getFPS()),
-                    {20, 30}, cv::FONT_HERSHEY_SIMPLEX, 0.8, {50, 170, 50}, 2);
+        std::string status =
+            options.trackerName + cv::format("  %5.1f FPS", meter.getFPS());
+        if (score)
+            status += cv::format("  score %.2f", *score);
+        cv::putText(frame, status, {20, 30}, cv::FONT_HERSHEY_SIMPLEX, 0.8,
+                    {50, 170, 50}, 2);
         // Count this frame before any interactive early exit; it has already
         // been read, tracked, scored, and will be written below.
         ++metrics.frames;

--- a/Object-Tracking-OpenCV5/python/object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/object_tracking.py
@@ -51,9 +51,10 @@ VALIDATE_MEAN_IOU = 0.45     # required mean IoU over the whole clip
 VALIDATE_SUCCESS_IOU = 0.30  # per-frame IoU counted as "still on target"
 VALIDATE_SUCCESS_RATE = 0.90 # required fraction of frames on target
 
-# OpenCV's official DNN tracker sample uses 0.30 as the acceptance threshold.
-# The lower TrackerVit default (0.20) is intended only to reject nearly black
-# inputs and can accept weak predictions that later produce severe scale drift.
+# Promote the official demo's 0.30 visualization cutoff into this
+# application's acceptance policy. The lower TrackerVit default (0.20) is
+# intended only to reject nearly black inputs and can accept weak predictions
+# that later produce severe scale drift.
 VITTRACK_SCORE_THRESHOLD = 0.30
 
 
@@ -151,11 +152,14 @@ def make_vittrack(models_dir):
         return None
     # A single ONNX file holds the whole model; it is under 1 MB.
     params.net = str(net)
-    # Pin the portable CPU implementation and use the official sample's
-    # confidence policy instead of relying on version-dependent defaults.
+    # Pin the portable CPU implementation and use the official demo's
+    # visualization cutoff as this application's confidence policy.
     params.backend = cv2.dnn.DNN_BACKEND_OPENCV
     params.target = cv2.dnn.DNN_TARGET_CPU
-    params.tracking_score_threshold = VITTRACK_SCORE_THRESHOLD
+    # OpenCV 4.9/4.10 expose getTrackingScore() but not this Params field.
+    # track() applies the same visible cutoff after update() on those versions.
+    if hasattr(params, "tracking_score_threshold"):
+        params.tracking_score_threshold = VITTRACK_SCORE_THRESHOLD
     return creator(params)
 
 
@@ -382,14 +386,18 @@ def track(tracker, capture, init_box, args, ground_truth=None):
             break  # end of stream
         # Time exactly the tracker update, not drawing or I/O.
         meter.start()
-        found, box = tracker.update(frame)
+        located, box = tracker.update(frame)
         meter.stop()
-        # The boolean already reflects TrackerVit's configured threshold; the
-        # raw score explains marginal losses and should be logged or displayed
-        # instead of treating every returned box as equally trustworthy.
+        # The raw score lets the application enforce one visible policy across
+        # supported versions and explains marginal losses instead of treating
+        # every returned box as equally trustworthy.
         score = (
             float(tracker.getTrackingScore())
             if args.tracker == "vittrack" else None
+        )
+        found = (
+            located
+            and (score is None or score >= VITTRACK_SCORE_THRESHOLD)
         )
         if found:
             # Draw the tracked box; integer coordinates for the raster calls.

--- a/Object-Tracking-OpenCV5/python/object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/object_tracking.py
@@ -51,6 +51,11 @@ VALIDATE_MEAN_IOU = 0.45     # required mean IoU over the whole clip
 VALIDATE_SUCCESS_IOU = 0.30  # per-frame IoU counted as "still on target"
 VALIDATE_SUCCESS_RATE = 0.90 # required fraction of frames on target
 
+# OpenCV's official DNN tracker sample uses 0.30 as the acceptance threshold.
+# The lower TrackerVit default (0.20) is intended only to reject nearly black
+# inputs and can accept weak predictions that later produce severe scale drift.
+VITTRACK_SCORE_THRESHOLD = 0.30
+
 
 def _resolve_creator(class_name):
     """Return the ``create`` callable for a tracker class, or None.
@@ -146,6 +151,11 @@ def make_vittrack(models_dir):
         return None
     # A single ONNX file holds the whole model; it is under 1 MB.
     params.net = str(net)
+    # Pin the portable CPU implementation and use the official sample's
+    # confidence policy instead of relying on version-dependent defaults.
+    params.backend = cv2.dnn.DNN_BACKEND_OPENCV
+    params.target = cv2.dnn.DNN_TARGET_CPU
+    params.tracking_score_threshold = VITTRACK_SCORE_THRESHOLD
     return creator(params)
 
 
@@ -374,6 +384,13 @@ def track(tracker, capture, init_box, args, ground_truth=None):
         meter.start()
         found, box = tracker.update(frame)
         meter.stop()
+        # The boolean already reflects TrackerVit's configured threshold; the
+        # raw score explains marginal losses and should be logged or displayed
+        # instead of treating every returned box as equally trustworthy.
+        score = (
+            float(tracker.getTrackingScore())
+            if args.tracker == "vittrack" else None
+        )
         if found:
             # Draw the tracked box; integer coordinates for the raster calls.
             x, y, w, h = (int(v) for v in box)
@@ -389,7 +406,10 @@ def track(tracker, capture, init_box, args, ground_truth=None):
             ious.append(iou(box, truth) if found else 0.0)
         # Overlay the running average FPS of tracker updates.
         fps = meter.getFPS()
-        cv2.putText(frame, f"{args.tracker}  {fps:5.1f} FPS", (20, 30),
+        status = f"{args.tracker}  {fps:5.1f} FPS"
+        if score is not None:
+            status += f"  score {score:.2f}"
+        cv2.putText(frame, status, (20, 30),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.8, (50, 170, 50), 2)
         if writer is not None:
             writer.write(frame)

--- a/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 # unittest is the framework mandated by the project conventions.
 import unittest
+from unittest import mock
 
 # Import the application module for constants and synthetic-video generation;
 # every tracker behavior test still goes through the real subprocess CLI.
@@ -46,6 +47,46 @@ MODEL_FILES = {
     ),
     "vittrack": ("object_tracking_vittrack_2023sep.onnx",),
 }
+
+
+class VitTrackConfiguration(unittest.TestCase):
+    """VitTrack must keep the documented backend and confidence policy."""
+
+    def test_factory_pins_backend_target_and_threshold(self):
+        class Params:
+            net = ""
+            backend = -1
+            target = -1
+            tracking_score_threshold = -1.0
+
+        captured = {}
+
+        def creator(params):
+            captured["params"] = params
+            return object()
+
+        with tempfile.TemporaryDirectory() as workdir:
+            models_dir = Path(workdir)
+            (models_dir / "object_tracking_vittrack_2023sep.onnx").touch()
+            with mock.patch.object(
+                object_tracking, "_resolve_creator", return_value=creator
+            ):
+                with mock.patch.object(
+                    object_tracking, "_params_for", return_value=Params()
+                ):
+                    self.assertIsNotNone(
+                        object_tracking.make_vittrack(models_dir)
+                    )
+
+        params = captured["params"]
+        self.assertEqual(
+            params.backend, object_tracking.cv2.dnn.DNN_BACKEND_OPENCV
+        )
+        self.assertEqual(params.target, object_tracking.cv2.dnn.DNN_TARGET_CPU)
+        self.assertEqual(
+            params.tracking_score_threshold,
+            object_tracking.VITTRACK_SCORE_THRESHOLD,
+        )
 
 
 def run_cli(arguments, cwd):

--- a/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
+++ b/Object-Tracking-OpenCV5/python/tests/test_object_tracking.py
@@ -88,6 +88,34 @@ class VitTrackConfiguration(unittest.TestCase):
             object_tracking.VITTRACK_SCORE_THRESHOLD,
         )
 
+    def test_factory_supports_legacy_params_without_threshold_field(self):
+        class LegacyParams:
+            __slots__ = ("net", "backend", "target")
+
+            def __init__(self):
+                self.net = ""
+                self.backend = -1
+                self.target = -1
+
+        with tempfile.TemporaryDirectory() as workdir:
+            models_dir = Path(workdir)
+            (models_dir / "object_tracking_vittrack_2023sep.onnx").touch()
+            with mock.patch.object(
+                object_tracking, "_resolve_creator",
+                return_value=lambda params: params,
+            ):
+                with mock.patch.object(
+                    object_tracking, "_params_for",
+                    return_value=LegacyParams(),
+                ):
+                    tracker = object_tracking.make_vittrack(models_dir)
+
+        self.assertIsInstance(tracker, LegacyParams)
+        self.assertEqual(
+            tracker.backend, object_tracking.cv2.dnn.DNN_BACKEND_OPENCV
+        )
+        self.assertEqual(tracker.target, object_tracking.cv2.dnn.DNN_TARGET_CPU)
+
 
 def run_cli(arguments, cwd):
     """Run the application CLI in a subprocess and capture its output."""


### PR DESCRIPTION
## What changed

- configure VitTrack explicitly for OpenCV CPU DNN execution
- use a 0.30 tracking-score acceptance threshold on OpenCV 4.11+
- report `getTrackingScore()` in Python and C++ output
- render low-score updates as `LOST` without a misleading rectangle
- retain source/runtime compatibility with OpenCV 4.9 and 4.10, where the threshold field is unavailable
- add focused Python tests and document the 4.9/4.10 internal-state limitation

## Why

The soccer comparison exposed a failure mode where VitTrack drifted onto a player and then expanded while the application continued to draw the returned box. The tracker invocation was valid, but accepting every returned update made the result look more trustworthy than its confidence supported. The 0.30 policy turns that into an explicit, inspectable loss state.

## Impact

Fish, car, and the corrected full-person Chaplin initialization remain tracked. The difficult soccer sequence now reports low-confidence loss instead of drawing a runaway box. OpenCV 4.9/4.10 continue to build and run with best-effort post-update filtering; OpenCV 4.11+ applies the threshold internally.

## Validation

- Python: 25/25 tests passed on the rebased branch
- C++: 17/17 CTest passed on exact OpenCV 4.14 and 5.0 builds
- Python tracker matrix passed on exact OpenCV 4.14 and 5.0
- real OpenCV 4.9 and 4.10 VitTrack construction and 80-frame validation passed
- C++17 and Python 3.9 syntax compatibility checked
- full 4-video × 4-tracker OpenCV 5 result matrix regenerated and visually reviewed
