### PR TITLE
Add Download Code button to VideoStabilization README

### DIFF
--- a/VideoStabilization/README.md
+++ b/VideoStabilization/README.md
@@ -8,7 +8,7 @@ tutorial. Both examples track point features between adjacent frames, estimate
 partial-affine camera motion, smooth the resulting trajectory, and write the
 original and stabilized views side by side.
 
-Download the immutable, versioned [VideoStabilization.zip](https://github.com/spmallick/learnopencv/releases/download/video-stabilization-opencv-2026.07.24/VideoStabilization.zip) bundle.
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/video-stabilization-opencv-2026.07.24/VideoStabilization.zip)
 
 ## Compatibility contract
 


### PR DESCRIPTION
## Summary

- replace the plain VideoStabilization ZIP link with the standard LearnOpenCV “Download Code” image button
- preserve the existing immutable, versioned GitHub Release URL

## Why

The README exposed the download as prose, while other LearnOpenCV project READMEs use the shared visual Download Code button.

## Validation

- `git diff --check`
- confirmed the button image returns HTTP 200 with `image/png`
- confirmed the GitHub Release ZIP returns HTTP 200 with `application/octet-stream`
- compared the markup with the established pattern used by current LearnOpenCV READMEs

Documentation-only change; no runtime tests were required.
