### PR TITLE
Standardize project README Download Code buttons

### DIFF
--- a/CameraCalibration/README.md
+++ b/CameraCalibration/README.md
@@ -2,9 +2,9 @@
 
 **This repository contains the code for [Camera Calibration Using Opencv](https://learnopencv.com/camera-calibration-using-opencv/) blog post**.
 
-Download the immutable, versioned
-[CameraCalibration.zip](https://github.com/spmallick/learnopencv/releases/download/camera-calibration-opencv-2026.07.23/CameraCalibration.zip)
-bundle and its
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/camera-calibration-opencv-2026.07.23/CameraCalibration.zip)
+
+The immutable, versioned bundle has a published
 [SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/camera-calibration-opencv-2026.07.23/CameraCalibration.zip.sha256).
 The ZIP contains exactly one top-level `CameraCalibration/` directory with the
 files shown in the directory layout below.

--- a/CenterofBlob/README.md
+++ b/CenterofBlob/README.md
@@ -2,9 +2,9 @@
 
 This directory contains the Python and C++ examples for [Find the Center of a Blob using OpenCV](https://learnopencv.com/find-center-of-blob-centroid-using-opencv-cpp-python/).
 
-Download the immutable, versioned
-[CenterofBlob.zip](https://github.com/spmallick/learnopencv/releases/download/center-of-blob-opencv-2026.07.23/CenterofBlob.zip)
-bundle and its
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/center-of-blob-opencv-2026.07.23/CenterofBlob.zip)
+
+The immutable, versioned bundle has a published
 [SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/center-of-blob-opencv-2026.07.23/CenterofBlob.zip.sha256).
 The ZIP contains exactly one top-level `CenterofBlob/` directory with the files
 shown in the directory layout below.

--- a/Contour-Detection-using-OpenCV/README.md
+++ b/Contour-Detection-using-OpenCV/README.md
@@ -2,7 +2,7 @@
 
 **This repository contains code for [Contour Detection using OpenCV](https://learnopencv.com/contour-detection-using-opencv-python-c/) blogpost**.
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://github.com/spmallick/learnopencv/releases/download/contour-detection-opencv-2026.07.22/Contour-Detection-using-OpenCV-2026.07.22.zip)
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/contour-detection-opencv-2026.07.22/Contour-Detection-using-OpenCV-2026.07.22.zip)
 
 ## Directory Structure
 

--- a/FPS/README.md
+++ b/FPS/README.md
@@ -13,7 +13,9 @@ The examples use APIs shared by OpenCV 4.x and 5.x, and CMake rejects major vers
 
 ## Download the standalone project
 
-Download the immutable, versioned [FPS.zip](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip) bundle and its [SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip.sha256). The ZIP contains exactly one top-level `FPS/` directory with the eight files shown in the directory layout below.
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip)
+
+The immutable, versioned bundle has a published [SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/fps-opencv-2026.07.23/FPS.zip.sha256). The ZIP contains exactly one top-level `FPS/` directory with the eight files shown in the directory layout below.
 
 On macOS or Linux, download and verify both files before extracting the project:
 

--- a/Install-OpenCV-5-on-Linux/README.md
+++ b/Install-OpenCV-5-on-Linux/README.md
@@ -115,10 +115,10 @@ The wheel verifier is designed around the official 5.0.0.93 wheel contracts. The
 
 ## Download the standalone companion bundle
 
-Download the immutable, versioned companion bundle and its checksum:
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/install-opencv-5-linux-2026.07.23/Install-OpenCV-5-on-Linux.zip)
 
-- [Install-OpenCV-5-on-Linux.zip](https://github.com/spmallick/learnopencv/releases/download/install-opencv-5-linux-2026.07.23/Install-OpenCV-5-on-Linux.zip)
-- [Install-OpenCV-5-on-Linux.zip.sha256](https://github.com/spmallick/learnopencv/releases/download/install-opencv-5-linux-2026.07.23/Install-OpenCV-5-on-Linux.zip.sha256)
+The immutable, versioned companion bundle has a published
+[SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/install-opencv-5-linux-2026.07.23/Install-OpenCV-5-on-Linux.zip.sha256).
 
 On Linux, download, verify, and extract it with:
 


### PR DESCRIPTION
## Summary

- use the standard LearnOpenCV “Download Code” image button in every project README that links to an immutable, versioned LearnOpenCV GitHub Release ZIP
- update CameraCalibration, CenterofBlob, FPS, and Install-OpenCV-5-on-Linux from plain ZIP links to the shared button
- normalize the Contour Detection button alt text to `Download Code`
- preserve all checksum links and command-line download/verification instructions

VideoStabilization already used the target format, so all six release-backed project READMEs are now consistent.

## Why

Recent standalone project releases used a mixture of prose links and the established LearnOpenCV download button. Standardizing the presentation makes the download action clear and keeps future release-backed README updates consistent.

## Validation

- `git diff --check`
- confirmed exactly six project READMEs link immutable LearnOpenCV Release ZIPs and all six use the standard button
- verified every referenced release contains its ZIP and SHA-256 checksum asset
- preserved existing checksum links and copy-paste verification commands

Documentation-only change; no runtime tests were required.
