### PR TITLE
Fix standalone download documentation

### DIFF
--- a/ImageAlignment-FeatureBased/README.md
+++ b/ImageAlignment-FeatureBased/README.md
@@ -4,7 +4,25 @@ This repository contains code for the blog post [Feature Based Image Alignment u
 
 <img src="https://learnopencv.com/wp-content/uploads/2018/03/image-alignment-using-opencv.jpg" alt="Image Alignment" width="900">
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://www.dropbox.com/scl/fo/7actm7m3yu4rg01mhve9b/h?dl=1&rlkey=7irdzdwlwniboxv6n0nyh4puh)
+## Download the standalone project
+
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/image-alignment-feature-based-opencv-2026.07.24/ImageAlignment-FeatureBased.zip)
+
+The immutable, versioned bundle has a published
+[SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/image-alignment-feature-based-opencv-2026.07.24/ImageAlignment-FeatureBased.zip.sha256).
+The ZIP contains exactly one top-level `ImageAlignment-FeatureBased/` directory
+with the nine files shown in the project layout below.
+
+On macOS or Linux, download and verify both files before extracting the project:
+
+```bash
+curl -LO \
+  https://github.com/spmallick/learnopencv/releases/download/image-alignment-feature-based-opencv-2026.07.24/ImageAlignment-FeatureBased.zip
+curl -LO \
+  https://github.com/spmallick/learnopencv/releases/download/image-alignment-feature-based-opencv-2026.07.24/ImageAlignment-FeatureBased.zip.sha256
+shasum -a 256 -c ImageAlignment-FeatureBased.zip.sha256
+unzip ImageAlignment-FeatureBased.zip
+```
 
 ## OpenCV compatibility
 

--- a/VideoStabilization/README.md
+++ b/VideoStabilization/README.md
@@ -10,6 +10,14 @@ original and stabilized views side by side.
 
 [<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/video-stabilization-opencv-2026.07.24/VideoStabilization.zip)
 
+The immutable, versioned bundle has a published
+[SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/video-stabilization-opencv-2026.07.24/VideoStabilization.zip.sha256).
+It contains exactly one top-level `VideoStabilization/` directory and the nine
+files shown in the standalone ZIP layout below. The repository also carries the
+article preview image `video-stabilization-opencv-4-14-5.jpg`; that
+documentation-only image was added after the tagged standalone release and is
+not required to build, run, or test the downloaded project.
+
 ## Compatibility contract
 
 - OpenCV 4.14.0
@@ -143,7 +151,7 @@ module and `goodFeaturesToTrack` from `imgproc` to the new `features` module.
 The CMake configuration and version-gated includes select the correct modules
 while the source keeps the same algorithm and public API calls in both releases.
 
-## Project files
+## Project files in the repository
 
 ```text
 VideoStabilization/
@@ -156,6 +164,22 @@ VideoStabilization/
 │   └── test_video_stabilization.py
 ├── video.mp4
 ├── video-stabilization-opencv-4-14-5.jpg
+├── video_stabilization.cpp
+└── video_stabilization.py
+```
+
+## Standalone ZIP layout
+
+```text
+VideoStabilization/
+├── .gitignore
+├── CMakeLists.txt
+├── README.md
+├── requirements.txt
+├── tests/
+│   ├── check_collision_guard.cmake
+│   └── test_video_stabilization.py
+├── video.mp4
 ├── video_stabilization.cpp
 └── video_stabilization.py
 ```


### PR DESCRIPTION
## What changed

- Replaces the legacy Dropbox button in `ImageAlignment-FeatureBased/README.md` with the immutable GitHub Release ZIP and checksum URLs for the new `image-alignment-feature-based-opencv-2026.07.24` release.
- Documents archive verification commands and the exact nine-file, single-root bundle contract.
- Adds the existing Video Stabilization checksum link and distinguishes its exact nine-file standalone archive from the later repository-only article preview image.
- Preserves both Big Vision footers unchanged.

## Why

The updated tutorials should expose the same verified standalone ZIP in the project README and WordPress Code URL metadata. The prior Image Alignment README still pointed to Dropbox, and its older ZIP did not satisfy the current reproducible-archive workflow. The new release will be built from the merged commit, validated, and published immediately after this PR merges.

## Validation

- `git diff --check`
- Image Alignment Python: 8/8 passed on exact OpenCV 4.14.0
- Image Alignment Python: 8/8 passed on exact OpenCV 5.0.0
- Image Alignment C++ Release build + CTest: 1/1 passed on OpenCV 4.14.0
- Image Alignment C++ Release build + CTest: 1/1 passed on OpenCV 5.0.0
- All five current public ZIPs passed container, path-safety, manifest, and SHA-256 checks against their tagged source trees.

After merge, the new Alignment tag, archive, and checksum will be created from the merge commit, retested from the extracted ZIP, published with `latest=false`, and anonymously downloaded for final byte verification.
