### PR TITLE
Upgrade Delaunay tutorial for OpenCV 5

### DIFF
--- a/Delaunay/.gitignore
+++ b/Delaunay/.gitignore
@@ -1,0 +1,4 @@
+/build*/
+/output/
+__pycache__/
+*.py[cod]

--- a/Delaunay/CMakeLists.txt
+++ b/Delaunay/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(delaunay_voronoi LANGUAGES CXX)
+
+# OpenCV 5 requires C++17, and OpenCV 4.14 supports the same language level.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# The geometry component exists only in OpenCV 5, so discover it opportunistically.
+find_package(
+  OpenCV CONFIG REQUIRED
+  COMPONENTS core highgui imgcodecs imgproc
+  OPTIONAL_COMPONENTS geometry
+)
+
+# Keep this tutorial's compatibility contract explicit.
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(
+    FATAL_ERROR
+    "Delaunay supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}"
+  )
+endif()
+
+# Subdiv2D moved into opencv_geometry in OpenCV 5.
+if(OpenCV_VERSION_MAJOR GREATER_EQUAL 5 AND NOT OpenCV_geometry_FOUND)
+  message(FATAL_ERROR "OpenCV 5 requires the geometry module for Subdiv2D")
+endif()
+
+add_executable(delaunay delaunay.cpp)
+
+# Treat third-party OpenCV headers as system headers before enabling -Werror.
+target_include_directories(delaunay SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS})
+
+# The OpenCV package supplies only the components resolved above.
+target_link_libraries(delaunay PRIVATE ${OpenCV_LIBS})
+
+# Bundled defaults remain valid when the executable runs from another directory.
+target_compile_definitions(
+  delaunay
+  PRIVATE DELAUNAY_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+# Strict warnings catch accidental regressions in the tutorial source itself.
+if(MSVC)
+  target_compile_options(delaunay PRIVATE /W4 /WX)
+else()
+  target_compile_options(delaunay PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()
+
+include(CTest)
+
+if(BUILD_TESTING)
+  # The regression executes the real CLI without opening GUI windows.
+  add_test(
+    NAME delaunay_regression
+    COMMAND
+      "${CMAKE_COMMAND}"
+      "-DDELAUNAY_EXE=$<TARGET_FILE:delaunay>"
+      "-DTEST_ROOT=${CMAKE_CURRENT_BINARY_DIR}/regression-test"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/tests/check_cpp_regression.cmake"
+  )
+
+  # Guard two important failure paths through the compiled executable.
+  add_test(
+    NAME delaunay_failure_safety
+    COMMAND
+      "${CMAKE_COMMAND}"
+      "-DDELAUNAY_EXE=$<TARGET_FILE:delaunay>"
+      "-DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
+      "-DTEST_ROOT=${CMAKE_CURRENT_BINARY_DIR}/failure-tests"
+      -P "${CMAKE_CURRENT_SOURCE_DIR}/tests/check_cpp_failures.cmake"
+  )
+endif()

--- a/Delaunay/README.md
+++ b/Delaunay/README.md
@@ -1,10 +1,180 @@
-# Delaunay Triangulation and Voronoi Diagram using OpenCV
+# Delaunay Triangulation and Voronoi Diagrams with OpenCV
 
-The repository contains code for the blog post [Delaunay Triangulation and Voronoi Diagram using OpenCV ( C++ / Python )](https://www.learnopencv.com/delaunay-triangulation-and-voronoi-diagram-using-opencv-c-python/).
+This folder contains the Python and C++ examples for the LearnOpenCV article
+[Delaunay Triangulation and Voronoi Diagram using OpenCV (C++/Python)](https://learnopencv.com/delaunay-triangulation-and-voronoi-diagram-using-opencv-c-python/).
+The examples insert facial landmarks into `Subdiv2D`, render the Delaunay
+triangulation, and render its dual Voronoi diagram.
 
-<p align="center"><img src="https://learnopencv.com/wp-content/uploads/2015/11/opencv-delaunay-vornoi-subdiv-example.jpg" alt="Delaunay"></p>
+<p align="center"><img src="https://learnopencv.com/wp-content/uploads/2015/11/opencv-delaunay-vornoi-subdiv-example.jpg" alt="Delaunay triangulation and Voronoi diagram"></p>
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="download" width="200">](https://www.dropbox.com/scl/fo/n6w3vq6t1kbhzn790p2k8/h?dl=1&rlkey=0e8mq6a4vyvriz68ystgahx7v)
+## OpenCV 4.14 and OpenCV 5 compatibility
+
+The complete Python and C++ acceptance matrix was run with:
+
+| Implementation | OpenCV | Other tested tools |
+| --- | --- | --- |
+| Python | 4.14.0 and 5.0.0 | Python 3.14.3, NumPy 2.4.2 |
+| C++ | 4.14.0 and 5.0.0 | Apple Clang 21.0.0, CMake 3.29.3, C++17 |
+
+The Python implementation requires Python 3.10 or newer. Run the commands below
+from the tracked `Delaunay/` directory unless the command uses absolute paths.
+
+OpenCV 5 moved `cv::Subdiv2D` from `imgproc` into the new `geometry` module.
+The C++ source includes and links that module only for OpenCV 5. The Python API
+remains `cv2.Subdiv2D` in both supported major versions.
+
+The upgraded examples also:
+
+- resolve bundled inputs from the source directory, independent of the current
+  working directory;
+- replace the removed `CV_AA`, `CV_FILLED`, `cv2.cv`, `xrange`, and `np.int`
+  interfaces;
+- round floating-point `Subdiv2D` geometry explicitly before raster drawing;
+- de-duplicate the two repeated records in `obama.txt` before insertion;
+- canonicalize triangles and sort Voronoi cells by site before assigning a
+  deterministic palette;
+- generate repeatable `delaunay.png` and `voronoi.png` outputs;
+- support headless execution, custom inputs, and stable geometry validation.
+
+## Python
+
+Enter the project directory:
+
+```bash
+cd Delaunay
+```
+
+Install dependencies:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+Run the bundled example headlessly and validate it:
+
+```bash
+python3 delaunay.py \
+  --no-display \
+  --no-animation \
+  --validate \
+  --output-dir output
+```
+
+To watch points being inserted and view the final diagrams:
+
+```bash
+python3 delaunay.py --display --animate --output-dir output
+```
+
+Run all Python regression tests:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+The tests execute the real CLI from an unrelated temporary directory, verify
+both generated PNG files, repeat the run to check deterministic output, and
+exercise missing, invalid, and output-colliding inputs.
+
+## C++
+
+OpenCV 5 requires a C++17 compiler. Configure a fresh build by pointing
+`OpenCV_DIR` at the exact installation you want to test. GCC users should use
+GCC 9 or newer so `std::filesystem` links without the legacy GCC 8
+`stdc++fs` workaround.
+
+OpenCV 4.14 example:
+
+```bash
+cmake -S . -B build-4.14 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DOpenCV_DIR=/path/to/opencv-4.14/lib/cmake/opencv4
+cmake --build build-4.14 --parallel
+ctest --test-dir build-4.14 --output-on-failure
+```
+
+OpenCV 5 example:
+
+```bash
+cmake -S . -B build-5.0 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DOpenCV_DIR=/path/to/opencv-5.0/lib/cmake/opencv5
+cmake --build build-5.0 --parallel
+ctest --test-dir build-5.0 --output-on-failure
+```
+
+The executable embeds the source directory only to locate the bundled default
+inputs. Custom inputs and outputs remain available:
+
+```bash
+./build-5.0/delaunay \
+  --image /path/to/image.jpg \
+  --points /path/to/points.txt \
+  --output-dir /tmp/delaunay-output \
+  --no-display
+```
+
+## Command-line options
+
+Both implementations expose equivalent controls:
+
+| Option | Purpose |
+| --- | --- |
+| `--image PATH` | Override the bundled `obama.jpg` image. |
+| `--points PATH` | Override the bundled two-column landmark file. |
+| `--output-dir PATH` | Select the directory for both PNG outputs. |
+| `--display` / `--no-display` | Enable or disable final GUI windows. |
+| `--animate` / `--no-animation` | Enable or disable insertion animation. Animation requires display. |
+| `--animation-delay-ms N` | Set the positive delay between animated insertions. |
+| `--validate` | Check the bundled-data regression contract. |
+
+The point file accepts one finite integer `x y` pixel coordinate pair per line.
+Blank lines and trailing `#` comments are allowed. Every point must lie inside
+the image's half-open rectangle: `0 <= x < width` and
+`0 <= y < height`. The CLI also rejects an output directory that would replace
+the input image or landmark file.
+
+## Outputs and validation
+
+Each successful run writes:
+
+- `delaunay.png`: the source image with triangulation edges and landmark sites;
+- `voronoi.png`: deterministically colored Voronoi cells and their sites.
+
+For the bundled 512×697 image, validation confirms:
+
+- 68 landmark records, 66 unique sites, and 2 duplicates;
+- 110 triangles, 175 unique edges, and 20 convex-hull edges;
+- 66 nonvirtual Voronoi facets;
+- a total triangulated area of 30,853 square pixels;
+- matching Delaunay topology and Voronoi center sets;
+- a Delaunay render that differs from the source and a nonblank,
+  multicolor Voronoi render.
+
+The tests compare ordering-independent geometric invariants because OpenCV does
+not guarantee triangle or facet collection order. They do not rely on a
+platform-specific hash of antialiased pixels.
+
+## Project layout
+
+```text
+Delaunay/
+├── .gitignore
+├── CMakeLists.txt
+├── README.md
+├── delaunay.cpp
+├── delaunay.py
+├── obama.jpg
+├── obama.txt
+├── requirements.txt
+└── tests/
+    ├── check_cpp_failures.cmake
+    ├── check_cpp_regression.cmake
+    └── test_delaunay.py
+```
+
+`Subdiv2D` produces an ordinary Delaunay triangulation. It does not implement a
+constrained Delaunay triangulation with user-enforced edges.
 
 
 ---

--- a/Delaunay/delaunay.cpp
+++ b/Delaunay/delaunay.cpp
@@ -1,143 +1,1047 @@
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <iostream>
+#include <opencv2/core.hpp>
+#include <opencv2/core/version.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+// OpenCV 5 moved Subdiv2D from imgproc into the new geometry module.
+#if CV_VERSION_MAJOR >= 5
+#include <opencv2/geometry.hpp>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
-using namespace cv;
-using namespace std;
+namespace fs = std::filesystem;
 
-// Draw a single point
-static void draw_point( Mat& img, Point2f fp, Scalar color )
-{
-    circle( img, fp, 2, color, cv::FILLED, cv::LINE_AA, 0 );
+namespace {
+
+// The CMake target supplies the tracked asset directory at compile time.
+#ifndef DELAUNAY_SOURCE_DIR
+#define DELAUNAY_SOURCE_DIR "."
+#endif
+
+// These values form the ordering-independent regression contract for bundled data.
+constexpr int kExpectedWidth = 512;
+constexpr int kExpectedHeight = 697;
+constexpr std::size_t kExpectedPointRecords = 68;
+constexpr std::size_t kExpectedUniquePoints = 66;
+constexpr std::size_t kExpectedDuplicatePoints = 2;
+constexpr std::size_t kExpectedTriangles = 110;
+constexpr std::size_t kExpectedUniqueEdges = 175;
+constexpr std::size_t kExpectedBoundaryEdges = 20;
+constexpr std::size_t kExpectedInteriorEdges = 155;
+constexpr std::size_t kExpectedVoronoiFacets = 66;
+constexpr double kExpectedTriangleArea = 30853.0;
+
+// Integer point pairs provide standard ordering for sets, maps, and canonical output.
+using IntPoint = std::pair<int, int>;
+// Sorting all three vertices makes a triangle independent of OpenCV's vertex order.
+using Triangle = std::array<IntPoint, 3>;
+// Sorting both endpoints makes an edge independent of its traversal direction.
+using Edge = std::pair<IntPoint, IntPoint>;
+
+struct Options {
+    // Defaults resolve from the source directory instead of the current directory.
+    fs::path image_path = fs::path(DELAUNAY_SOURCE_DIR) / "obama.jpg";
+    // The bundled two-column landmark file accompanies the default image.
+    fs::path points_path = fs::path(DELAUNAY_SOURCE_DIR) / "obama.txt";
+    // Generated artifacts stay in an explicit subdirectory by default.
+    fs::path output_dir = fs::path(DELAUNAY_SOURCE_DIR) / "output";
+    // GUI display is opt-in so servers and continuous integration never block.
+    bool display = false;
+    // Progressive point insertion is also opt-in and requires display.
+    bool animate = false;
+    // A short positive delay keeps an animation responsive.
+    int animation_delay_ms = 100;
+    // Validation activates the bundled-data regression contract.
+    bool validate = false;
+    // Help prints usage without executing the example.
+    bool help = false;
+};
+
+struct PointData {
+    // Subdiv2D receives only unique sites in stable source order.
+    std::vector<cv::Point2f> unique_points;
+    // The record count includes exact duplicates skipped before insertion.
+    std::size_t record_count = 0;
+};
+
+struct VoronoiData {
+    // Each facet is a floating-point convex polygon returned by Subdiv2D.
+    std::vector<std::vector<cv::Point2f>> facets;
+    // Each center is the generating site paired with the corresponding facet.
+    std::vector<cv::Point2f> centers;
+};
+
+struct GeometryMetrics {
+    // The following fields deliberately avoid undocumented collection ordering.
+    int width = 0;
+    int height = 0;
+    std::size_t point_records = 0;
+    std::size_t unique_points = 0;
+    std::size_t duplicate_points = 0;
+    std::size_t triangles = 0;
+    std::size_t unique_edges = 0;
+    std::size_t boundary_edges = 0;
+    std::size_t interior_edges = 0;
+    std::size_t voronoi_facets = 0;
+    double triangle_area = 0.0;
+};
+
+[[nodiscard]] std::string usage(const char* program_name) {
+    // Build one concise help string for both --help and parse failures.
+    std::ostringstream stream;
+    // Name the program and every supported input/output control.
+    stream
+        << "Usage: " << program_name << " [options]\n"
+        << "  --image PATH                 Input image\n"
+        << "  --points PATH                Two-column landmark file\n"
+        << "  --output-dir PATH            Output directory\n"
+        << "  --display | --no-display     Toggle GUI windows (default: off)\n"
+        << "  --animate | --no-animation   Toggle insertion animation\n"
+        << "  --animation-delay-ms N       Positive animation delay\n"
+        << "  --validate                   Check bundled regression data\n"
+        << "  --help                       Show this message\n";
+    // Return an ordinary string suitable for stdout or an exception message.
+    return stream.str();
 }
 
-// Draw delaunay triangles
-static void draw_delaunay( Mat& img, Subdiv2D& subdiv, Scalar delaunay_color )
-{
+[[nodiscard]] std::string require_value(
+    int argc,
+    char** argv,
+    int& index,
+    const std::string& option
+) {
+    // Every path and integer option needs one following argument.
+    if (index + 1 >= argc) {
+        throw std::invalid_argument(option + " requires a value");
+    }
+    // Advance the caller's loop index and return the consumed token.
+    return argv[++index];
+}
 
-    vector<Vec6f> triangleList;
-    subdiv.getTriangleList(triangleList);
-    vector<Point> pt(3);
-    Size size = img.size();
-    Rect rect(0,0, size.width, size.height);
+[[nodiscard]] Options parse_options(int argc, char** argv) {
+    // Start with script-relative defaults matching the Python example.
+    Options options;
+    // Process each command-line token once from left to right.
+    for (int index = 1; index < argc; ++index) {
+        // Copy argv data into a managed string before comparisons.
+        const std::string argument = argv[index];
+        // Override the bundled portrait when requested.
+        if (argument == "--image") {
+            options.image_path = require_value(argc, argv, index, argument);
+        // Override the bundled landmark file when requested.
+        } else if (argument == "--points") {
+            options.points_path = require_value(argc, argv, index, argument);
+        // Select a caller-controlled artifact directory.
+        } else if (argument == "--output-dir") {
+            options.output_dir = require_value(argc, argv, index, argument);
+        // Enable final GUI windows explicitly.
+        } else if (argument == "--display") {
+            options.display = true;
+        // Disable GUI windows explicitly for readable automation commands.
+        } else if (argument == "--no-display") {
+            options.display = false;
+        // Enable progressive triangulation while points are inserted.
+        } else if (argument == "--animate") {
+            options.animate = true;
+        // Disable progressive insertion explicitly.
+        } else if (argument == "--no-animation") {
+            options.animate = false;
+        // Parse a positive delay rather than hardcoding waitKey behavior.
+        } else if (argument == "--animation-delay-ms") {
+            const std::string value = require_value(argc, argv, index, argument);
+            // std::stoi rejects nonnumeric prefixes through its exception behavior.
+            std::size_t consumed = 0;
+            options.animation_delay_ms = std::stoi(value, &consumed);
+            // Reject trailing text such as "100ms".
+            if (consumed != value.size()) {
+                throw std::invalid_argument(
+                    "--animation-delay-ms must be an integer"
+                );
+            }
+        // Activate stable geometric regression checks.
+        } else if (argument == "--validate") {
+            options.validate = true;
+        // Print usage without touching input or output files.
+        } else if (argument == "--help" || argument == "-h") {
+            options.help = true;
+        // Fail on typos rather than silently ignoring unsupported controls.
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
 
-    for( size_t i = 0; i < triangleList.size(); i++ )
-    {
-        Vec6f t = triangleList[i];
-        pt[0] = Point(cvRound(t[0]), cvRound(t[1]));
-        pt[1] = Point(cvRound(t[2]), cvRound(t[3]));
-        pt[2] = Point(cvRound(t[4]), cvRound(t[5]));
+    // Invisible animation is almost certainly a command-line mistake.
+    if (options.animate && !options.display) {
+        throw std::invalid_argument("--animate requires --display");
+    }
+    // cv::waitKey needs a positive delay during insertion animation.
+    if (options.animation_delay_ms <= 0) {
+        throw std::invalid_argument(
+            "--animation-delay-ms must be positive"
+        );
+    }
+    // Return the fully validated configuration.
+    return options;
+}
 
-        // Draw rectangles completely inside the image.
-        if ( rect.contains(pt[0]) && rect.contains(pt[1]) && rect.contains(pt[2]))
-        {
-            line(img, pt[0], pt[1], delaunay_color, 1, cv::LINE_AA, 0);
-            line(img, pt[1], pt[2], delaunay_color, 1, cv::LINE_AA, 0);
-            line(img, pt[2], pt[0], delaunay_color, 1, cv::LINE_AA, 0);
+[[nodiscard]] bool rect_contains(
+    const cv::Rect& rect,
+    const cv::Point2f& point
+) {
+    // OpenCV rectangles are half-open at the right and bottom boundaries.
+    return (
+        static_cast<float>(rect.x) <= point.x
+        && point.x < static_cast<float>(rect.x + rect.width)
+        && static_cast<float>(rect.y) <= point.y
+        && point.y < static_cast<float>(rect.y + rect.height)
+    );
+}
+
+[[nodiscard]] IntPoint rounded_point(const cv::Point2f& point) {
+    // cvRound is the conversion used by OpenCV's official Delaunay sample.
+    return {cvRound(point.x), cvRound(point.y)};
+}
+
+[[nodiscard]] cv::Point to_cv_point(const IntPoint& point) {
+    // Convert the canonical standard-library pair back to an OpenCV raster point.
+    return {point.first, point.second};
+}
+
+[[nodiscard]] cv::Scalar deterministic_color(std::size_t index) {
+    // Match the Python example's repeatable blue channel.
+    const int blue = 64 + static_cast<int>((37 * index) % 192);
+    // Match the Python example's repeatable green channel.
+    const int green = 64 + static_cast<int>((17 * index) % 192);
+    // Match the Python example's repeatable red channel.
+    const int red = 64 + static_cast<int>((29 * index) % 192);
+    // cv::Scalar uses blue-green-red order for a BGR image.
+    return {
+        static_cast<double>(blue),
+        static_cast<double>(green),
+        static_cast<double>(red)
+    };
+}
+
+[[nodiscard]] PointData load_points(
+    const fs::path& points_path,
+    const cv::Rect& rect
+) {
+    // Open the source explicitly so missing inputs produce a controlled error.
+    std::ifstream input(points_path);
+    if (!input.is_open()) {
+        throw std::runtime_error(
+            "Point file not found: " + points_path.string()
+        );
+    }
+
+    // Build the result in source order while filtering exact duplicates.
+    PointData data;
+    // Float pairs provide deterministic duplicate detection for parsed coordinates.
+    std::set<std::pair<float, float>> seen;
+    // Preserve line numbers for actionable parse errors.
+    std::size_t line_number = 0;
+    // Read one record or comment line at a time.
+    std::string raw_line;
+    while (std::getline(input, raw_line)) {
+        // Increment before validation so diagnostics use one-based line numbers.
+        ++line_number;
+        // Remove trailing comments using the same rule as the Python implementation.
+        const std::size_t comment = raw_line.find('#');
+        const std::string line = raw_line.substr(0, comment);
+        // Parse exactly two floating-point coordinates from the remaining text.
+        std::istringstream stream(line);
+        double x = 0.0;
+        double y = 0.0;
+        // Blank or comment-only lines contain no first coordinate.
+        if (!(stream >> x)) {
+            // Whitespace-only lines are valid separators.
+            stream.clear();
+            stream >> std::ws;
+            if (stream.eof()) {
+                continue;
+            }
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": coordinates must be numeric"
+            );
+        }
+        // A nonblank record must contain its y coordinate.
+        if (!(stream >> y)) {
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": expected two coordinates"
+            );
+        }
+        // Reject any unexpected third field.
+        std::string extra;
+        if (stream >> extra) {
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": expected two coordinates"
+            );
+        }
+        // NaN and infinity would otherwise surface as opaque Subdiv2D errors.
+        if (!std::isfinite(x) || !std::isfinite(y)) {
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": coordinates must be finite"
+            );
+        }
+        // This raster tutorial intentionally accepts integer pixel landmarks only.
+        if (std::trunc(x) != x || std::trunc(y) != y) {
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": coordinates must be integers"
+            );
+        }
+        // Convert into the Point2f precision expected by Subdiv2D.
+        const cv::Point2f point(
+            static_cast<float>(x),
+            static_cast<float>(y)
+        );
+        // Subdiv2D rejects any site outside its initialization rectangle.
+        if (!rect_contains(rect, point)) {
+            throw std::runtime_error(
+                points_path.string() + ":" + std::to_string(line_number)
+                + ": point is outside the image rectangle"
+            );
+        }
+
+        // Count every valid source record, including an exact duplicate.
+        ++data.record_count;
+        // Insert returns the existing vertex for duplicates; filter them explicitly.
+        const auto key = std::make_pair(point.x, point.y);
+        if (!seen.insert(key).second) {
+            continue;
+        }
+        // Preserve the first occurrence for repeatable insertion and animation.
+        data.unique_points.push_back(point);
+    }
+
+    // A triangulation needs at least three distinct sites.
+    if (data.unique_points.size() < 3) {
+        throw std::runtime_error(
+            points_path.string()
+            + ": at least three unique points are required"
+        );
+    }
+    // Return both unique sites and the transparent source-record count.
+    return data;
+}
+
+[[nodiscard]] Triangle canonical_triangle(const cv::Vec6f& raw_triangle) {
+    // Convert all three Point2f vertices with the official cvRound rule.
+    Triangle triangle = {
+        rounded_point({raw_triangle[0], raw_triangle[1]}),
+        rounded_point({raw_triangle[2], raw_triangle[3]}),
+        rounded_point({raw_triangle[4], raw_triangle[5]})
+    };
+    // Sorting removes any dependency on clockwise order or starting vertex.
+    std::sort(triangle.begin(), triangle.end());
+    // Return the canonical integer representation.
+    return triangle;
+}
+
+[[nodiscard]] std::vector<Triangle> collect_triangles(
+    const cv::Subdiv2D& subdiv,
+    const cv::Rect& rect
+) {
+    // Subdiv2D exposes every triangle as six floating-point coordinates.
+    std::vector<cv::Vec6f> raw_triangles;
+    subdiv.getTriangleList(raw_triangles);
+    // A set prevents duplicate triangles and supplies deterministic iteration.
+    std::set<Triangle> canonical_triangles;
+
+    // Inspect each returned triangle independently of collection ordering.
+    for (const cv::Vec6f& raw_triangle : raw_triangles) {
+        // Retain floating-point coordinates for the half-open bounds test.
+        const std::array<cv::Point2f, 3> vertices = {
+            cv::Point2f(raw_triangle[0], raw_triangle[1]),
+            cv::Point2f(raw_triangle[2], raw_triangle[3]),
+            cv::Point2f(raw_triangle[4], raw_triangle[5])
+        };
+        // Ignore any triangle that is not completely inside the image rectangle.
+        if (
+            !rect_contains(rect, vertices[0])
+            || !rect_contains(rect, vertices[1])
+            || !rect_contains(rect, vertices[2])
+        ) {
+            continue;
+        }
+        // Canonicalization makes geometry checks ordering-independent.
+        canonical_triangles.insert(canonical_triangle(raw_triangle));
+    }
+
+    // Convert the sorted set into the sequence used by drawing and validation.
+    return {
+        canonical_triangles.begin(),
+        canonical_triangles.end()
+    };
+}
+
+[[nodiscard]] VoronoiData collect_voronoi(cv::Subdiv2D& subdiv) {
+    // An empty vertex-ID list requests every nonvirtual Voronoi facet.
+    const std::vector<int> all_vertices;
+    // Receive paired floating-point facets and their generating sites.
+    VoronoiData data;
+    subdiv.getVoronoiFacetList(
+        all_vertices,
+        data.facets,
+        data.centers
+    );
+    // A mismatch would make cell-to-site rendering ambiguous.
+    if (data.facets.size() != data.centers.size()) {
+        throw std::runtime_error(
+            "OpenCV returned mismatched Voronoi facets and centers"
+        );
+    }
+    // Build a stable cell order from the unique integer generating sites.
+    std::vector<std::pair<IntPoint, std::size_t>> cell_order;
+    cell_order.reserve(data.centers.size());
+    std::set<IntPoint> unique_centers;
+    for (std::size_t index = 0; index < data.centers.size(); ++index) {
+        const IntPoint center = rounded_point(data.centers[index]);
+        if (!unique_centers.insert(center).second) {
+            throw std::runtime_error(
+                "OpenCV returned duplicate rounded Voronoi centers"
+            );
+        }
+        cell_order.emplace_back(center, index);
+    }
+    // Palette assignment must not depend on the API's facet collection order.
+    std::sort(cell_order.begin(), cell_order.end());
+
+    // Rebuild the paired sequences in canonical center order.
+    VoronoiData sorted_data;
+    sorted_data.facets.reserve(data.facets.size());
+    sorted_data.centers.reserve(data.centers.size());
+    for (const auto& [center, original_index] : cell_order) {
+        // The center key controls ordering; the paired Point2f value is preserved.
+        static_cast<void>(center);
+        sorted_data.facets.push_back(data.facets[original_index]);
+        sorted_data.centers.push_back(data.centers[original_index]);
+    }
+    // Return deterministic cells shared with the Python implementation.
+    return sorted_data;
+}
+
+void draw_point(
+    cv::Mat& image,
+    const cv::Point2f& point,
+    const cv::Scalar& color
+) {
+    // Convert Point2f explicitly because raster drawing uses integer coordinates.
+    const cv::Point center = to_cv_point(rounded_point(point));
+    // FILLED creates a solid marker and LINE_AA keeps its edge smooth.
+    cv::circle(
+        image,
+        center,
+        2,
+        color,
+        cv::FILLED,
+        cv::LINE_AA
+    );
+}
+
+void draw_delaunay(
+    cv::Mat& image,
+    const std::vector<Triangle>& triangles,
+    const cv::Scalar& color
+) {
+    // Draw all three edges of every canonical triangle.
+    for (const Triangle& triangle : triangles) {
+        // Convert the canonical pair representation into OpenCV points once.
+        const cv::Point point_1 = to_cv_point(triangle[0]);
+        const cv::Point point_2 = to_cv_point(triangle[1]);
+        const cv::Point point_3 = to_cv_point(triangle[2]);
+        // Draw the first one-pixel antialiased edge.
+        cv::line(image, point_1, point_2, color, 1, cv::LINE_AA);
+        // Draw the second edge using identical raster settings.
+        cv::line(image, point_2, point_3, color, 1, cv::LINE_AA);
+        // Close the triangle with its final edge.
+        cv::line(image, point_3, point_1, color, 1, cv::LINE_AA);
+    }
+}
+
+void draw_voronoi(cv::Mat& image, const VoronoiData& data) {
+    // Draw each facet with the same deterministic palette as the Python example.
+    for (std::size_t index = 0; index < data.facets.size(); ++index) {
+        // A valid Voronoi polygon needs at least three vertices.
+        if (data.facets[index].size() < 3) {
+            throw std::runtime_error(
+                "Voronoi facet " + std::to_string(index)
+                + " has fewer than 3 vertices"
+            );
+        }
+        // Convert Point2f polygon vertices explicitly before rasterization.
+        std::vector<cv::Point> polygon;
+        polygon.reserve(data.facets[index].size());
+        for (const cv::Point2f& vertex : data.facets[index]) {
+            polygon.push_back(to_cv_point(rounded_point(vertex)));
+        }
+        // Fill the cell before drawing its outline and center marker.
+        cv::fillConvexPoly(
+            image,
+            polygon,
+            deterministic_color(index),
+            cv::LINE_AA
+        );
+        // polylines accepts a sequence of contours; this call has one polygon.
+        const std::vector<std::vector<cv::Point>> polygons = {polygon};
+        // A black outline separates adjacent cells with similar colors.
+        cv::polylines(
+            image,
+            polygons,
+            true,
+            cv::Scalar(0, 0, 0),
+            1,
+            cv::LINE_AA
+        );
+        // Mark the generating site paired with this facet.
+        cv::circle(
+            image,
+            to_cv_point(rounded_point(data.centers[index])),
+            3,
+            cv::Scalar(0, 0, 0),
+            cv::FILLED,
+            cv::LINE_AA
+        );
+    }
+}
+
+[[nodiscard]] double triangle_area(const Triangle& triangle) {
+    // Promote integer products to double before applying the shoelace formula.
+    const double x_1 = triangle[0].first;
+    const double y_1 = triangle[0].second;
+    const double x_2 = triangle[1].first;
+    const double y_2 = triangle[1].second;
+    const double x_3 = triangle[2].first;
+    const double y_3 = triangle[2].second;
+    // The determinant below is twice the signed area.
+    const double twice_area = (
+        x_1 * (y_2 - y_3)
+        + x_2 * (y_3 - y_1)
+        + x_3 * (y_1 - y_2)
+    );
+    // Regression checks use unsigned pixel-coordinate area.
+    return std::abs(twice_area) / 2.0;
+}
+
+[[nodiscard]] Edge normalized_edge(
+    const IntPoint& first,
+    const IntPoint& second
+) {
+    // Store the lexicographically smaller endpoint first.
+    return first < second
+        ? Edge{first, second}
+        : Edge{second, first};
+}
+
+[[nodiscard]] std::array<std::size_t, 3> edge_counts(
+    const std::vector<Triangle>& triangles
+) {
+    // Map each undirected edge to its number of incident triangles.
+    std::map<Edge, std::size_t> incidences;
+    // Visit every triangle independently of its canonical vertex order.
+    for (const Triangle& triangle : triangles) {
+        // Increment the first normalized edge.
+        ++incidences[normalized_edge(triangle[0], triangle[1])];
+        // Increment the second normalized edge.
+        ++incidences[normalized_edge(triangle[1], triangle[2])];
+        // Increment the closing normalized edge.
+        ++incidences[normalized_edge(triangle[2], triangle[0])];
+    }
+
+    // Hull edges have one incident triangle.
+    std::size_t boundary_edges = 0;
+    // Interior edges have two incident triangles.
+    std::size_t interior_edges = 0;
+    // Check every edge for manifold triangulation behavior.
+    for (const auto& [edge, count] : incidences) {
+        // The edge key itself is useful for ordering but not needed in this count.
+        static_cast<void>(edge);
+        if (count == 1) {
+            ++boundary_edges;
+        } else if (count == 2) {
+            ++interior_edges;
+        } else {
+            throw std::runtime_error(
+                "Triangulation contains an invalid edge incidence"
+            );
+        }
+    }
+    // Return total, boundary, and interior counts together.
+    return {incidences.size(), boundary_edges, interior_edges};
+}
+
+[[nodiscard]] GeometryMetrics calculate_metrics(
+    const cv::Mat& image,
+    const PointData& points,
+    const std::vector<Triangle>& triangles,
+    const VoronoiData& voronoi
+) {
+    // Count topology without relying on OpenCV triangle ordering.
+    const auto counts = edge_counts(triangles);
+    // Sum positive areas for an ordering-independent geometric measurement.
+    double total_area = 0.0;
+    for (const Triangle& triangle : triangles) {
+        const double area = triangle_area(triangle);
+        total_area += area;
+    }
+
+    // Return one immutable collection of stable metrics.
+    return {
+        image.cols,
+        image.rows,
+        points.record_count,
+        points.unique_points.size(),
+        points.record_count - points.unique_points.size(),
+        triangles.size(),
+        counts[0],
+        counts[1],
+        counts[2],
+        voronoi.facets.size(),
+        total_area
+    };
+}
+
+void validate_metrics(
+    const GeometryMetrics& metrics,
+    const PointData& points,
+    const std::vector<Triangle>& triangles,
+    const VoronoiData& voronoi
+) {
+    // Rounded membership checks are appropriate for the bundled integer landmarks.
+    std::set<IntPoint> rounded_sites;
+    for (const cv::Point2f& point : points.unique_points) {
+        rounded_sites.insert(rounded_point(point));
+    }
+    // Canonical Voronoi centers should equal the unique bundled sites.
+    std::set<IntPoint> rounded_centers;
+    for (const cv::Point2f& center : voronoi.centers) {
+        rounded_centers.insert(rounded_point(center));
+    }
+    if (rounded_centers != rounded_sites) {
+        throw std::runtime_error(
+            "Validation failed: Voronoi centers differ from sites"
+        );
+    }
+    // Every Delaunay vertex should also correspond to a bundled site.
+    for (const Triangle& triangle : triangles) {
+        if (triangle_area(triangle) <= 0.0) {
+            throw std::runtime_error(
+                "Validation failed: triangle has nonpositive area"
+            );
+        }
+        for (const IntPoint& vertex : triangle) {
+            if (rounded_sites.count(vertex) == 0) {
+                throw std::runtime_error(
+                    "Validation failed: triangle has a non-site vertex"
+                );
+            }
+        }
+    }
+
+    // Compare each invariant separately so a failure identifies its cause.
+    if (metrics.width != kExpectedWidth) {
+        throw std::runtime_error("Validation failed: image width");
+    }
+    if (metrics.height != kExpectedHeight) {
+        throw std::runtime_error("Validation failed: image height");
+    }
+    if (metrics.point_records != kExpectedPointRecords) {
+        throw std::runtime_error("Validation failed: point record count");
+    }
+    if (metrics.unique_points != kExpectedUniquePoints) {
+        throw std::runtime_error("Validation failed: unique point count");
+    }
+    if (metrics.duplicate_points != kExpectedDuplicatePoints) {
+        throw std::runtime_error("Validation failed: duplicate point count");
+    }
+    if (metrics.triangles != kExpectedTriangles) {
+        throw std::runtime_error("Validation failed: triangle count");
+    }
+    if (metrics.unique_edges != kExpectedUniqueEdges) {
+        throw std::runtime_error("Validation failed: unique edge count");
+    }
+    if (metrics.boundary_edges != kExpectedBoundaryEdges) {
+        throw std::runtime_error("Validation failed: boundary edge count");
+    }
+    if (metrics.interior_edges != kExpectedInteriorEdges) {
+        throw std::runtime_error("Validation failed: interior edge count");
+    }
+    if (metrics.voronoi_facets != kExpectedVoronoiFacets) {
+        throw std::runtime_error("Validation failed: Voronoi facet count");
+    }
+    if (std::abs(metrics.triangle_area - kExpectedTriangleArea) > 1e-9) {
+        throw std::runtime_error("Validation failed: triangle area");
+    }
+    // Euler's formula supplies an independent planar topology check.
+    const std::size_t faces_including_exterior = metrics.triangles + 1;
+    const auto euler_characteristic =
+        static_cast<long long>(metrics.unique_points)
+        - static_cast<long long>(metrics.unique_edges)
+        + static_cast<long long>(faces_including_exterior);
+    if (euler_characteristic != 2) {
+        throw std::runtime_error(
+            "Validation failed: Euler characteristic is not 2"
+        );
+    }
+}
+
+void validate_rendered_images(
+    const cv::Mat& source,
+    const cv::Mat& delaunay_image,
+    const cv::Mat& voronoi_image
+) {
+    // Removing all triangle/point drawing must make the regression fail.
+    cv::Mat delaunay_difference;
+    cv::absdiff(source, delaunay_image, delaunay_difference);
+    if (cv::countNonZero(delaunay_difference.reshape(1)) == 0) {
+        throw std::runtime_error(
+            "Validation failed: Delaunay output equals the input"
+        );
+    }
+    // A blank Voronoi canvas indicates that facet drawing did not run.
+    if (cv::countNonZero(voronoi_image.reshape(1)) == 0) {
+        throw std::runtime_error(
+            "Validation failed: Voronoi output is blank"
+        );
+    }
+    // Nonzero channel variation proves the output is not one flat color.
+    cv::Mat mean;
+    cv::Mat standard_deviation;
+    cv::meanStdDev(voronoi_image, mean, standard_deviation);
+    if (cv::norm(standard_deviation) <= 0.0) {
+        throw std::runtime_error(
+            "Validation failed: Voronoi output lacks color variation"
+        );
+    }
+}
+
+void write_image(const fs::path& path, const cv::Mat& image) {
+    // OpenCV reports several encoder and filesystem failures through a bool.
+    if (!cv::imwrite(path.string(), image)) {
+        throw std::runtime_error(
+            "Could not write output image: " + path.string()
+        );
+    }
+    // Decode the artifact again so validation covers the actual file on disk.
+    const cv::Mat decoded = cv::imread(path.string(), cv::IMREAD_COLOR);
+    if (decoded.empty()) {
+        throw std::runtime_error(
+            "Could not read generated output image: " + path.string()
+        );
+    }
+    // The generated file must preserve dimensions and three-channel type.
+    if (decoded.size() != image.size() || decoded.type() != image.type()) {
+        throw std::runtime_error(
+            "Generated output shape/type mismatch: " + path.string()
+        );
+    }
+}
+
+[[nodiscard]] fs::path comparable_path(const fs::path& path) {
+    // Build an absolute path before resolving existing symlink components.
+    std::error_code absolute_error;
+    const fs::path absolute = fs::absolute(path, absolute_error);
+    if (absolute_error) {
+        throw std::runtime_error(
+            "Could not resolve path "
+            + path.string()
+            + ": "
+            + absolute_error.message()
+        );
+    }
+    // weakly_canonical also supports output filenames that do not exist yet.
+    std::error_code canonical_error;
+    const fs::path canonical = fs::weakly_canonical(
+        absolute,
+        canonical_error
+    );
+    if (canonical_error) {
+        throw std::runtime_error(
+            "Could not normalize path "
+            + path.string()
+            + ": "
+            + canonical_error.message()
+        );
+    }
+    // Return one normalized representation for safe equality comparisons.
+    return canonical;
+}
+
+void ensure_output_paths_are_safe(const Options& options) {
+    // Retain original paths for filesystem-equivalence checks on existing files.
+    const std::array<fs::path, 2> input_paths = {
+        options.image_path,
+        options.points_path
+    };
+    // Check both documented outputs before creating a directory or writing a file.
+    const std::array<fs::path, 2> output_paths = {
+        options.output_dir / "delaunay.png",
+        options.output_dir / "voronoi.png"
+    };
+    // Refuse to overwrite either the image or the landmark source.
+    for (const fs::path& output_path : output_paths) {
+        for (const fs::path& input_path : input_paths) {
+            // Normalized equality handles ordinary and symlinked path aliases.
+            bool paths_match = (
+                comparable_path(output_path)
+                == comparable_path(input_path)
+            );
+            // Existing hard links and case aliases require inode equivalence.
+            std::error_code output_exists_error;
+            const bool output_exists = fs::exists(
+                output_path,
+                output_exists_error
+            );
+            if (output_exists_error) {
+                throw std::runtime_error(
+                    "Could not inspect output path "
+                    + output_path.string()
+                    + ": "
+                    + output_exists_error.message()
+                );
+            }
+            std::error_code input_exists_error;
+            const bool input_exists = fs::exists(
+                input_path,
+                input_exists_error
+            );
+            if (input_exists_error) {
+                throw std::runtime_error(
+                    "Could not inspect input path "
+                    + input_path.string()
+                    + ": "
+                    + input_exists_error.message()
+                );
+            }
+            if (!paths_match && output_exists && input_exists) {
+                std::error_code equivalent_error;
+                paths_match = fs::equivalent(
+                    output_path,
+                    input_path,
+                    equivalent_error
+                );
+                if (equivalent_error) {
+                    throw std::runtime_error(
+                        "Could not compare input and output paths: "
+                        + equivalent_error.message()
+                    );
+                }
+            }
+            if (paths_match) {
+                throw std::runtime_error(
+                    "Output path would overwrite an input file: "
+                    + output_path.string()
+                );
+            }
         }
     }
 }
 
-//Draw voronoi diagrams
-static void draw_voronoi( Mat& img, Subdiv2D& subdiv )
-{
-    vector<vector<Point2f> > facets;
-    vector<Point2f> centers;
-    subdiv.getVoronoiFacetList(vector<int>(), facets, centers);
-
-    vector<Point> ifacet;
-    vector<vector<Point> > ifacets(1);
-
-    for( size_t i = 0; i < facets.size(); i++ )
-    {
-        ifacet.resize(facets[i].size());
-        for( size_t j = 0; j < facets[i].size(); j++ )
-            ifacet[j] = facets[i][j];
-
-        Scalar color;
-        color[0] = rand() & 255;
-        color[1] = rand() & 255;
-        color[2] = rand() & 255;
-        fillConvexPoly(img, ifacet, color, 8, 0);
-
-        ifacets[0] = ifacet;
-        polylines(img, ifacets, true, Scalar(), 1, cv::LINE_AA, 0);
-        circle(img, centers[i], 3, Scalar(), cv::FILLED, cv::LINE_AA, 0);
-    }
-}
-
-int main( int argc, char** argv)
-{
-
-    // Define window names
-    string win_delaunay = "Delaunay Triangulation";
-    string win_voronoi = "Voronoi Diagram";
-
-    // Turn on animation while drawing triangles
-    bool animate = true;
-
-    // Define colors for drawing.
-    Scalar delaunay_color(255,255,255), points_color(0, 0, 255);
-
-    // Read in the image.
-    Mat img = imread("obama.jpg");
-
-    // Keep a copy around
-    Mat img_orig = img.clone();
-
-    // Rectangle to be used with Subdiv2D
-    Size size = img.size();
-    Rect rect(0, 0, size.width, size.height);
-
-    // Create an instance of Subdiv2D
-    Subdiv2D subdiv(rect);
-
-    // Create a vector of points.
-    vector<Point2f> points;
-
-    // Read in the points from a text file
-    ifstream ifs("obama.txt");
-    int x, y;
-    while(ifs >> x >> y)
-    {
-        points.push_back(Point2f(x,y));
-    }
-
-    // Insert points into subdiv
-    for( vector<Point2f>::iterator it = points.begin(); it != points.end(); it++)
-    {
-        subdiv.insert(*it);
-        // Show animation
-        if (animate)
-        {
-            Mat img_copy = img_orig.clone();
-            // Draw delaunay triangles
-            draw_delaunay( img_copy, subdiv, delaunay_color );
-            imshow(win_delaunay, img_copy);
-            waitKey(100);
+[[nodiscard]] cv::Subdiv2D build_subdivision(
+    const cv::Rect& rect,
+    const std::vector<cv::Point2f>& points,
+    const cv::Mat& image,
+    const Options& options
+) {
+    // Initialize Subdiv2D over the exact image rectangle.
+    cv::Subdiv2D subdiv(rect);
+    // Insert every unique point once in its source order.
+    for (const cv::Point2f& point : points) {
+        // Duplicate records were filtered before this API call.
+        subdiv.insert(point);
+        // Animation is opt-in so automated and remote runs remain headless.
+        if (options.display && options.animate) {
+            // Render the partial triangulation on a fresh image copy.
+            cv::Mat frame = image.clone();
+            // Collection canonicalization avoids depending on API ordering.
+            const std::vector<Triangle> partial_triangles =
+                collect_triangles(subdiv, rect);
+            // White edges remain visible against the portrait.
+            draw_delaunay(
+                frame,
+                partial_triangles,
+                cv::Scalar(255, 255, 255)
+            );
+            // Display the progressive tutorial frame.
+            cv::imshow("Delaunay Triangulation", frame);
+            // Let the GUI process events between insertions.
+            cv::waitKey(options.animation_delay_ms);
         }
     }
+    // Return the completed subdivision for final geometry extraction.
+    return subdiv;
+}
 
-    // Draw delaunay triangles
-    draw_delaunay( img, subdiv, delaunay_color );
-
-    // Draw points
-    for( vector<Point2f>::iterator it = points.begin(); it != points.end(); it++)
-    {
-        draw_point(img, *it, points_color);
+[[nodiscard]] GeometryMetrics run(const Options& options) {
+    // Resolve every intended artifact before reading or writing user-controlled paths.
+    ensure_output_paths_are_safe(options);
+    // Decode the source in color mode and fail before dereferencing an empty Mat.
+    const cv::Mat source = cv::imread(
+        options.image_path.string(),
+        cv::IMREAD_COLOR
+    );
+    if (source.empty()) {
+        throw std::runtime_error(
+            "Could not read input image: " + options.image_path.string()
+        );
+    }
+    // This visualization expects an ordinary three-channel BGR image.
+    if (source.type() != CV_8UC3) {
+        throw std::runtime_error(
+            "Expected an 8-bit three-channel input image"
+        );
     }
 
-    // Allocate space for voronoi Diagram
-    Mat img_voronoi = Mat::zeros(img.rows, img.cols, CV_8UC3);
+    // Build the half-open Subdiv2D rectangle from decoded dimensions.
+    const cv::Rect rect(0, 0, source.cols, source.rows);
+    // Parse, validate, and explicitly de-duplicate landmark records.
+    const PointData point_data = load_points(options.points_path, rect);
+    // Insert sites and optionally render the progressive triangulation.
+    cv::Subdiv2D subdiv = build_subdivision(
+        rect,
+        point_data.unique_points,
+        source,
+        options
+    );
+    // Extract canonical triangles after all sites have been inserted.
+    const std::vector<Triangle> triangles =
+        collect_triangles(subdiv, rect);
+    // Extract every nonvirtual Voronoi facet and its site.
+    const VoronoiData voronoi = collect_voronoi(subdiv);
 
-    // Draw voronoi diagram
-    draw_voronoi( img_voronoi, subdiv );
+    // Draw the final triangulation on a copy of the original image.
+    cv::Mat delaunay_image = source.clone();
+    draw_delaunay(
+        delaunay_image,
+        triangles,
+        cv::Scalar(255, 255, 255)
+    );
+    // Overlay every unique landmark in red.
+    for (const cv::Point2f& point : point_data.unique_points) {
+        draw_point(
+            delaunay_image,
+            point,
+            cv::Scalar(0, 0, 255)
+        );
+    }
 
-    // Show results.
-    imshow( win_delaunay, img);
-    imshow( win_voronoi, img_voronoi);
-    waitKey(0);
+    // Start the Voronoi visualization from a black canvas of matching type.
+    cv::Mat voronoi_image = cv::Mat::zeros(
+        source.rows,
+        source.cols,
+        CV_8UC3
+    );
+    // Fill, outline, and mark every facet deterministically.
+    draw_voronoi(voronoi_image, voronoi);
 
-    return 0;
+    // Calculate order-independent geometry before output or display.
+    const GeometryMetrics metrics = calculate_metrics(
+        source,
+        point_data,
+        triangles,
+        voronoi
+    );
+    // Activate the bundled-data acceptance contract only when requested.
+    if (options.validate) {
+        validate_metrics(metrics, point_data, triangles, voronoi);
+        validate_rendered_images(
+            source,
+            delaunay_image,
+            voronoi_image
+        );
+    }
+
+    // Create every missing parent directory and report filesystem errors.
+    std::error_code directory_error;
+    fs::create_directories(options.output_dir, directory_error);
+    if (directory_error) {
+        throw std::runtime_error(
+            "Could not create output directory "
+            + options.output_dir.string()
+            + ": "
+            + directory_error.message()
+        );
+    }
+    // Lossless PNG avoids codec-dependent JPEG artifacts.
+    write_image(
+        options.output_dir / "delaunay.png",
+        delaunay_image
+    );
+    // Verify the Voronoi artifact through the same write/read path.
+    write_image(
+        options.output_dir / "voronoi.png",
+        voronoi_image
+    );
+
+    // GUI windows remain optional for reliable server and CI behavior.
+    if (options.display) {
+        // Show the completed triangulation.
+        cv::imshow("Delaunay Triangulation", delaunay_image);
+        // Show the dual Voronoi diagram.
+        cv::imshow("Voronoi Diagram", voronoi_image);
+        // Wait for one key before closing both windows.
+        cv::waitKey(0);
+        // Release GUI resources explicitly.
+        cv::destroyAllWindows();
+    }
+
+    // Return the metrics for concise CLI reporting.
+    return metrics;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        // Parse all controls before reading inputs or creating output paths.
+        const Options options = parse_options(argc, argv);
+        // Help is a successful, side-effect-free command.
+        if (options.help) {
+            std::cout << usage(argv[0]);
+            return 0;
+        }
+
+        // Run the complete real entry point and collect validated metrics.
+        const GeometryMetrics metrics = run(options);
+        // Report the exact linked OpenCV version before geometry results.
+        std::cout << "OpenCV version: " << CV_VERSION << '\n';
+        // Keep the summary compact enough for readers and CTest logs.
+        std::cout
+            << "Geometry: "
+            << metrics.point_records << " records, "
+            << metrics.unique_points << " unique points, "
+            << metrics.triangles << " triangles, "
+            << metrics.voronoi_facets << " Voronoi facets\n";
+        // Emit the success marker only after outputs and metrics pass.
+        if (options.validate) {
+            std::cout << "DELAUNAY_VALIDATION_OK\n";
+        }
+        // Zero signals successful rendering and optional validation.
+        return 0;
+    } catch (const std::exception& error) {
+        // Convert expected parse, input, output, and OpenCV errors into one message.
+        std::cerr << "error: " << error.what() << '\n';
+        // Show available controls after a parse or runtime failure.
+        std::cerr << usage(argv[0]);
+        // Two denotes invalid input or an unusable runtime environment.
+        return 2;
+    }
 }

--- a/Delaunay/delaunay.py
+++ b/Delaunay/delaunay.py
@@ -1,131 +1,760 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+"""Render and validate Delaunay triangulation and Voronoi diagrams with OpenCV."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Iterable, Sequence
 
 import cv2
 import numpy as np
-import random
-
-# Check if a point is inside a rectangle
-def rect_contains(rect, point) :
-    if point[0] < rect[0] :
-        return False
-    elif point[1] < rect[1] :
-        return False
-    elif point[0] > rect[2] :
-        return False
-    elif point[1] > rect[3] :
-        return False
-    return True
-
-# Draw a point
-def draw_point(img, p, color ) :
-    cv2.circle( img, p, 2, color, cv2.cv.CV_FILLED, cv2.CV_AA, 0 )
 
 
-# Draw delaunay triangles
-def draw_delaunay(img, subdiv, delaunay_color ) :
-
-    triangleList = subdiv.getTriangleList();
-    size = img.shape
-    r = (0, 0, size[1], size[0])
-
-    for t in triangleList :
-        
-        pt1 = (t[0], t[1])
-        pt2 = (t[2], t[3])
-        pt3 = (t[4], t[5])
-        
-        if rect_contains(r, pt1) and rect_contains(r, pt2) and rect_contains(r, pt3) :
-        
-            cv2.line(img, pt1, pt2, delaunay_color, 1, cv2.CV_AA, 0)
-            cv2.line(img, pt2, pt3, delaunay_color, 1, cv2.CV_AA, 0)
-            cv2.line(img, pt3, pt1, delaunay_color, 1, cv2.CV_AA, 0)
+# The bundled regression data is intentionally small enough to inspect visually.
+EXPECTED_WIDTH = 512
+EXPECTED_HEIGHT = 697
+EXPECTED_POINT_RECORDS = 68
+EXPECTED_UNIQUE_POINTS = 66
+EXPECTED_DUPLICATE_POINTS = 2
+EXPECTED_TRIANGLES = 110
+EXPECTED_UNIQUE_EDGES = 175
+EXPECTED_BOUNDARY_EDGES = 20
+EXPECTED_INTERIOR_EDGES = 155
+EXPECTED_VORONOI_FACETS = 66
+EXPECTED_TRIANGLE_AREA = 30853.0
 
 
-# Draw voronoi diagram
-def draw_voronoi(img, subdiv) :
+@dataclass(frozen=True)
+class GeometryMetrics:
+    """Stable, ordering-independent measurements of the generated geometry."""
 
-    ( facets, centers) = subdiv.getVoronoiFacetList([])
-
-    for i in xrange(0,len(facets)) :
-        ifacet_arr = []
-        for f in facets[i] :
-            ifacet_arr.append(f)
-        
-        ifacet = np.array(ifacet_arr, np.int)
-        color = (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
-
-        cv2.fillConvexPoly(img, ifacet, color, cv2.CV_AA, 0);
-        ifacets = np.array([ifacet])
-        cv2.polylines(img, ifacets, True, (0, 0, 0), 1, cv2.CV_AA, 0)
-        cv2.circle(img, (centers[i][0], centers[i][1]), 3, (0, 0, 0), cv2.cv.CV_FILLED, cv2.CV_AA, 0)
+    width: int
+    height: int
+    point_records: int
+    unique_points: int
+    duplicate_points: int
+    triangles: int
+    unique_edges: int
+    boundary_edges: int
+    interior_edges: int
+    voronoi_facets: int
+    triangle_area: float
 
 
-if __name__ == '__main__':
+def rect_contains(
+    rect: tuple[int, int, int, int],
+    point: tuple[float, float],
+) -> bool:
+    """Return whether a point lies inside an OpenCV half-open rectangle."""
 
-    # Define window names
-    win_delaunay = "Delaunay Triangulation"
-    win_voronoi = "Voronoi Diagram"
-
-    # Turn on animation while drawing triangles
-    animate = True
-    
-    # Define colors for drawing.
-    delaunay_color = (255,255,255)
-    points_color = (0, 0, 255)
-
-    # Read in the image.
-    img = cv2.imread("obama.jpg");
-    
-    # Keep a copy around
-    img_orig = img.copy();
-    
-    # Rectangle to be used with Subdiv2D
-    size = img.shape
-    rect = (0, 0, size[1], size[0])
-    
-    # Create an instance of Subdiv2D
-    subdiv = cv2.Subdiv2D(rect);
-
-    # Create an array of points.
-    points = [];
-    
-    # Read in the points from a text file
-    with open("obama.txt") as file :
-        for line in file :
-            x, y = line.split()
-            points.append((int(x), int(y)))
-
-    # Insert points into subdiv
-    for p in points :
-        subdiv.insert(p)
-        
-        # Show animation
-        if animate :
-            img_copy = img_orig.copy()
-            # Draw delaunay triangles
-            draw_delaunay( img_copy, subdiv, (255, 255, 255) );
-            cv2.imshow(win_delaunay, img_copy)
-            cv2.waitKey(100)
-
-    # Draw delaunay triangles
-    draw_delaunay( img, subdiv, (255, 255, 255) );
-
-    # Draw points
-    for p in points :
-        draw_point(img, p, (0,0,255))
-
-    # Allocate space for voronoi Diagram
-    img_voronoi = np.zeros(img.shape, dtype = img.dtype)
-
-    # Draw voronoi diagram
-    draw_voronoi(img_voronoi,subdiv)
-
-    # Show results
-    cv2.imshow(win_delaunay,img)
-    cv2.imshow(win_voronoi,img_voronoi)
-    cv2.waitKey(0)
+    # OpenCV rectangles include their left and top edges but exclude right/bottom.
+    x, y, width, height = rect
+    # Keep the comparison in floating point because Subdiv2D returns Point2f data.
+    point_x, point_y = point
+    # Using x + width also makes this correct for rectangles not rooted at (0, 0).
+    return (
+        x <= point_x < x + width
+        and y <= point_y < y + height
+    )
 
 
+def rounded_point(point: Sequence[float]) -> tuple[int, int]:
+    """Round a floating-point OpenCV point for raster drawing."""
+
+    # np.rint matches the intent of the official C++ sample's cvRound conversion.
+    coordinates = np.rint(np.asarray(point, dtype=np.float32)).astype(np.int32)
+    # Python's drawing bindings require ordinary integer coordinates.
+    return int(coordinates[0]), int(coordinates[1])
 
 
+def deterministic_color(index: int) -> tuple[int, int, int]:
+    """Return a repeatable BGR color shared with the C++ example."""
 
+    # A simple modular palette avoids random output while keeping adjacent cells distinct.
+    blue = 64 + (37 * index) % 192
+    green = 64 + (17 * index) % 192
+    red = 64 + (29 * index) % 192
+    # OpenCV expects colors in blue-green-red order.
+    return blue, green, red
+
+
+def load_points(
+    points_path: Path,
+    rect: tuple[int, int, int, int],
+) -> tuple[list[tuple[float, float]], int]:
+    """Read, validate, and de-duplicate landmark records while preserving order."""
+
+    # Fail clearly before OpenCV receives an incomplete or missing point set.
+    if not points_path.is_file():
+        raise FileNotFoundError(f"Point file not found: {points_path}")
+
+    # Retain insertion order so the visual result remains easy to compare.
+    unique_points: list[tuple[float, float]] = []
+    # A set makes exact duplicate detection explicit instead of API-dependent.
+    seen: set[tuple[float, float]] = set()
+    # Track every non-comment record so validation can report skipped duplicates.
+    record_count = 0
+
+    # UTF-8 text is sufficient for the two numeric columns used by this example.
+    for line_number, raw_line in enumerate(
+        points_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        # Permit blank lines and trailing comments in user-supplied point files.
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        # Empty or comment-only lines do not represent landmark records.
+        if not line:
+            continue
+        # Each landmark must contain exactly one x and one y coordinate.
+        fields = line.split()
+        if len(fields) != 2:
+            raise ValueError(
+                f"{points_path}:{line_number}: expected two coordinates"
+            )
+        # Parse numerically first so NaN, infinity, and decimal input get clear errors.
+        try:
+            numeric_point = float(fields[0]), float(fields[1])
+        except ValueError as error:
+            raise ValueError(
+                f"{points_path}:{line_number}: coordinates must be numeric"
+            ) from error
+        # NaN and infinity can otherwise surface later as opaque OpenCV errors.
+        if not np.isfinite(numeric_point).all():
+            raise ValueError(
+                f"{points_path}:{line_number}: coordinates must be finite"
+            )
+        # This raster tutorial intentionally accepts integer pixel landmarks only.
+        if not all(coordinate.is_integer() for coordinate in numeric_point):
+            raise ValueError(
+                f"{points_path}:{line_number}: coordinates must be integers"
+            )
+        # Subdiv2D still receives Point2f values, matching its public API.
+        point = float(int(numeric_point[0])), float(int(numeric_point[1]))
+        # Subdiv2D raises for points outside its initialization rectangle.
+        if not rect_contains(rect, point):
+            raise ValueError(
+                f"{points_path}:{line_number}: point {point} is outside {rect}"
+            )
+
+        # Count the source record even when it repeats an earlier coordinate.
+        record_count += 1
+        # Skip exact duplicates deterministically; Subdiv2D would reuse the vertex.
+        if point in seen:
+            continue
+        # Remember the coordinate before inserting it into the output sequence.
+        seen.add(point)
+        # Preserve the first occurrence for predictable insertion and animation.
+        unique_points.append(point)
+
+    # A triangulation requires at least three distinct points.
+    if len(unique_points) < 3:
+        raise ValueError(
+            f"{points_path}: at least three unique points are required"
+        )
+    # Return both unique geometry and the source-record count for transparent metrics.
+    return unique_points, record_count
+
+
+def canonical_triangle(
+    triangle: np.ndarray,
+) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int]]:
+    """Convert one Vec6f triangle into an ordering-independent integer tuple."""
+
+    # Reshape six scalar coordinates into three x/y points.
+    vertices = np.asarray(triangle, dtype=np.float32).reshape(3, 2)
+    # Raster and regression logic use the same explicit rounding rule.
+    points = [rounded_point(vertex) for vertex in vertices]
+    # Vertex ordering is not an OpenCV API guarantee, so sort it for validation.
+    return tuple(sorted(points))
+
+
+def collect_triangles(
+    subdiv: cv2.Subdiv2D,
+    rect: tuple[int, int, int, int],
+) -> list[tuple[tuple[int, int], tuple[int, int], tuple[int, int]]]:
+    """Collect in-bounds triangles without relying on OpenCV output ordering."""
+
+    # Python returns a floating-point N-by-6 representation of Vec6f triangles.
+    raw_triangles = np.asarray(subdiv.getTriangleList(), dtype=np.float32)
+    # Normalize both empty and populated binding representations.
+    raw_triangles = raw_triangles.reshape(-1, 6)
+    # A set prevents accidental duplicate triangles from affecting validation.
+    triangles: set[
+        tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ] = set()
+
+    # Inspect each triangle independently because collection order is unspecified.
+    for raw_triangle in raw_triangles:
+        # Check the original Point2f values against half-open image bounds.
+        float_vertices = raw_triangle.reshape(3, 2)
+        if not all(
+            rect_contains(rect, (float(vertex[0]), float(vertex[1])))
+            for vertex in float_vertices
+        ):
+            continue
+        # Canonicalization makes subsequent edge and area metrics order-independent.
+        triangles.add(canonical_triangle(raw_triangle))
+
+    # Sorting is only for deterministic iteration and drawing, not geometric meaning.
+    return sorted(triangles)
+
+
+def collect_voronoi(
+    subdiv: cv2.Subdiv2D,
+) -> tuple[list[np.ndarray], list[tuple[int, int]]]:
+    """Return all nonvirtual Voronoi facets and their rounded centers."""
+
+    # Passing an empty index list asks OpenCV for every nonvirtual facet.
+    raw_facets, raw_centers = subdiv.getVoronoiFacetList([])
+    # Centers correspond to inserted sites, but their order is unspecified.
+    centers_array = np.asarray(raw_centers, dtype=np.float32).reshape(-1, 2)
+    # A mismatch would make facet-to-site rendering ambiguous.
+    if len(raw_facets) != len(centers_array):
+        raise RuntimeError("OpenCV returned mismatched Voronoi facets and centers")
+    # Pair every normalized facet with its rounded integer site.
+    cells = [
+        (
+            np.asarray(facet, dtype=np.float32).reshape(-1, 2),
+            rounded_point(center),
+        )
+        for facet, center in zip(raw_facets, centers_array)
+    ]
+    # Sort by site so palette assignment never depends on API collection order.
+    cells.sort(key=lambda cell: cell[1])
+    # Unzip the canonical sequence while keeping every facet with its center.
+    facets = [cell[0] for cell in cells]
+    centers = [cell[1] for cell in cells]
+    # Return a deterministic cell sequence shared with the C++ implementation.
+    return facets, centers
+
+
+def draw_point(
+    image: np.ndarray,
+    point: tuple[float, float],
+    color: tuple[int, int, int],
+) -> None:
+    """Draw one landmark with modern OpenCV constants."""
+
+    # cv2.circle requires an integer center in current Python bindings.
+    center = rounded_point(point)
+    # FILLED creates a solid marker and LINE_AA keeps its edge smooth.
+    cv2.circle(image, center, 2, color, cv2.FILLED, cv2.LINE_AA)
+
+
+def draw_delaunay(
+    image: np.ndarray,
+    triangles: Iterable[
+        tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ],
+    color: tuple[int, int, int],
+) -> None:
+    """Draw every canonical Delaunay triangle on an image."""
+
+    # Each triangle contributes three line segments.
+    for point_1, point_2, point_3 in triangles:
+        # Draw the first edge with a one-pixel antialiased stroke.
+        cv2.line(image, point_1, point_2, color, 1, cv2.LINE_AA)
+        # Draw the second edge using the same rasterization settings.
+        cv2.line(image, point_2, point_3, color, 1, cv2.LINE_AA)
+        # Close the triangle with its final edge.
+        cv2.line(image, point_3, point_1, color, 1, cv2.LINE_AA)
+
+
+def draw_voronoi(
+    image: np.ndarray,
+    facets: Sequence[np.ndarray],
+    centers: Sequence[tuple[int, int]],
+) -> None:
+    """Fill Voronoi cells with deterministic colors and mark their sites."""
+
+    # OpenCV returns facets and centers as corresponding sequences.
+    if len(facets) != len(centers):
+        raise RuntimeError("OpenCV returned mismatched Voronoi facets and centers")
+
+    # Pair each cell with its site while assigning a repeatable palette index.
+    for index, (facet, center) in enumerate(zip(facets, centers)):
+        # A valid Voronoi polygon needs at least three vertices.
+        if len(facet) < 3:
+            raise RuntimeError(f"Voronoi facet {index} has fewer than 3 vertices")
+        # Polygon drawing requires an explicit int32 array in Python.
+        polygon = np.rint(facet).astype(np.int32).reshape(-1, 1, 2)
+        # Fill the cell before drawing its black outline and center marker.
+        cv2.fillConvexPoly(
+            image,
+            polygon,
+            deterministic_color(index),
+            cv2.LINE_AA,
+        )
+        # The outline makes neighboring cells distinguishable at similar colors.
+        cv2.polylines(
+            image,
+            [polygon],
+            True,
+            (0, 0, 0),
+            1,
+            cv2.LINE_AA,
+        )
+        # Mark the generating site at the center returned by Subdiv2D.
+        cv2.circle(
+            image,
+            center,
+            3,
+            (0, 0, 0),
+            cv2.FILLED,
+            cv2.LINE_AA,
+        )
+
+
+def triangle_area(
+    triangle: tuple[tuple[int, int], tuple[int, int], tuple[int, int]],
+) -> float:
+    """Calculate the unsigned area of one integer-coordinate triangle."""
+
+    # Unpack the vertices for the two-dimensional shoelace formula.
+    (x_1, y_1), (x_2, y_2), (x_3, y_3) = triangle
+    # The determinant is twice the signed triangle area.
+    twice_area = (
+        x_1 * (y_2 - y_3)
+        + x_2 * (y_3 - y_1)
+        + x_3 * (y_1 - y_2)
+    )
+    # Geometry validation uses the unsigned area in pixel-coordinate units.
+    return abs(twice_area) / 2.0
+
+
+def edge_counts(
+    triangles: Sequence[
+        tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ],
+) -> tuple[int, int, int]:
+    """Count unique, hull, and interior edges independently of triangle order."""
+
+    # Each normalized edge maps to the number of incident triangles.
+    incidences: dict[tuple[tuple[int, int], tuple[int, int]], int] = {}
+    # Visit every triangle without assuming a clockwise vertex order.
+    for triangle in triangles:
+        # A triangle has the three undirected edges below.
+        edges = (
+            (triangle[0], triangle[1]),
+            (triangle[1], triangle[2]),
+            (triangle[2], triangle[0]),
+        )
+        # Canonicalize each endpoint pair before incrementing its incidence.
+        for edge in edges:
+            normalized = tuple(sorted(edge))
+            incidences[normalized] = incidences.get(normalized, 0) + 1
+
+    # Hull edges belong to exactly one triangle.
+    boundary_edges = sum(count == 1 for count in incidences.values())
+    # Interior edges are shared by exactly two triangles.
+    interior_edges = sum(count == 2 for count in incidences.values())
+    # Any other incidence indicates duplicate or nonmanifold triangulation data.
+    invalid_edges = [
+        edge for edge, count in incidences.items() if count not in (1, 2)
+    ]
+    if invalid_edges:
+        raise RuntimeError(
+            f"Triangulation contains {len(invalid_edges)} invalid edge incidences"
+        )
+    # Return the three stable counts used by the regression contract.
+    return len(incidences), boundary_edges, interior_edges
+
+
+def calculate_metrics(
+    image: np.ndarray,
+    point_records: int,
+    points: Sequence[tuple[float, float]],
+    triangles: Sequence[
+        tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ],
+    facets: Sequence[np.ndarray],
+) -> GeometryMetrics:
+    """Calculate stable geometry measurements for reporting and validation."""
+
+    # Image height and width define the Subdiv2D working rectangle.
+    height, width = image.shape[:2]
+    # Count edges through topology rather than relying on triangle list ordering.
+    unique_edges, boundary_edges, interior_edges = edge_counts(triangles)
+    # Sum triangle areas to compare the triangulation with its convex hull.
+    total_area = sum(triangle_area(triangle) for triangle in triangles)
+    # Construct the immutable result after all consistency checks pass.
+    return GeometryMetrics(
+        width=width,
+        height=height,
+        point_records=point_records,
+        unique_points=len(points),
+        duplicate_points=point_records - len(points),
+        triangles=len(triangles),
+        unique_edges=unique_edges,
+        boundary_edges=boundary_edges,
+        interior_edges=interior_edges,
+        voronoi_facets=len(facets),
+        triangle_area=total_area,
+    )
+
+
+def validate_metrics(
+    metrics: GeometryMetrics,
+    points: Sequence[tuple[float, float]],
+    triangles: Sequence[
+        tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    ],
+    centers: Sequence[tuple[int, int]],
+) -> None:
+    """Check the bundled example's ordering-independent regression contract."""
+
+    # Rounded membership checks are appropriate for the bundled integer landmarks.
+    rounded_sites = {rounded_point(point) for point in points}
+    # Every nonvirtual Voronoi center should be one of the unique bundled sites.
+    if set(centers) != rounded_sites:
+        raise RuntimeError("Validation failed: Voronoi centers differ from sites")
+    # Every Delaunay vertex should also correspond to one bundled site.
+    if any(vertex not in rounded_sites for triangle in triangles for vertex in triangle):
+        raise RuntimeError("Validation failed: triangle has a non-site vertex")
+    # The bundled integer landmarks should never produce a degenerate raster triangle.
+    if any(triangle_area(triangle) <= 0 for triangle in triangles):
+        raise RuntimeError("Validation failed: triangle has nonpositive area")
+
+    # Keep the expected values together so failures identify the precise invariant.
+    expected = GeometryMetrics(
+        width=EXPECTED_WIDTH,
+        height=EXPECTED_HEIGHT,
+        point_records=EXPECTED_POINT_RECORDS,
+        unique_points=EXPECTED_UNIQUE_POINTS,
+        duplicate_points=EXPECTED_DUPLICATE_POINTS,
+        triangles=EXPECTED_TRIANGLES,
+        unique_edges=EXPECTED_UNIQUE_EDGES,
+        boundary_edges=EXPECTED_BOUNDARY_EDGES,
+        interior_edges=EXPECTED_INTERIOR_EDGES,
+        voronoi_facets=EXPECTED_VORONOI_FACETS,
+        triangle_area=EXPECTED_TRIANGLE_AREA,
+    )
+    # Dataclass equality gives an exact comparison for these integer/half-pixel metrics.
+    if metrics != expected:
+        raise RuntimeError(f"Validation failed: expected {expected}, got {metrics}")
+    # Euler's formula provides an independent planar-triangulation topology check.
+    faces_including_exterior = metrics.triangles + 1
+    if metrics.unique_points - metrics.unique_edges + faces_including_exterior != 2:
+        raise RuntimeError("Validation failed: Euler characteristic is not 2")
+
+
+def validate_rendered_images(
+    source: np.ndarray,
+    delaunay_image: np.ndarray,
+    voronoi_image: np.ndarray,
+) -> None:
+    """Confirm validation generated meaningful visual content, not blank files."""
+
+    # Removing all triangle/point drawing must make the regression fail.
+    if np.array_equal(delaunay_image, source):
+        raise RuntimeError("Validation failed: Delaunay output equals the input")
+    # A blank Voronoi canvas indicates that facet drawing did not run.
+    if not np.any(voronoi_image):
+        raise RuntimeError("Validation failed: Voronoi output is blank")
+    # Multiple distinct BGR colors prove that more than one flat fill was rendered.
+    unique_colors = np.unique(voronoi_image.reshape(-1, 3), axis=0)
+    if len(unique_colors) < 3:
+        raise RuntimeError("Validation failed: Voronoi output lacks color variation")
+
+
+def write_image(path: Path, image: np.ndarray) -> None:
+    """Write an output image and fail if the encoder or destination rejects it."""
+
+    # cv2.imwrite returns False instead of raising for several write failures.
+    if not cv2.imwrite(str(path), image):
+        raise OSError(f"Could not write output image: {path}")
+    # Decode the file again so validation covers the actual artifact on disk.
+    decoded = cv2.imread(str(path), cv2.IMREAD_COLOR)
+    if decoded is None or decoded.size == 0:
+        raise OSError(f"Could not read generated output image: {path}")
+    # Output dimensions and channel layout must match the rendered array.
+    if decoded.shape != image.shape:
+        raise OSError(
+            f"Generated output shape mismatch for {path}: "
+            f"{decoded.shape} != {image.shape}"
+        )
+
+
+def ensure_output_paths_are_safe(
+    image_path: Path,
+    points_path: Path,
+    output_dir: Path,
+) -> None:
+    """Reject output paths that resolve to either input file."""
+
+    # resolve(strict=False) normalizes missing outputs and follows existing symlinks.
+    input_paths = {
+        image_path.expanduser().resolve(),
+        points_path.expanduser().resolve(),
+    }
+    # Both documented output filenames must be checked before either is written.
+    output_paths = (
+        (output_dir / "delaunay.png").expanduser().resolve(),
+        (output_dir / "voronoi.png").expanduser().resolve(),
+    )
+    # Stop before mkdir or imwrite can replace a source image or landmark file.
+    for output_path in output_paths:
+        for input_path in input_paths:
+            # Normalized equality handles the ordinary and symlinked path cases.
+            paths_match = output_path == input_path
+            # samefile additionally detects existing hard links and case aliases.
+            if not paths_match and output_path.exists() and input_path.exists():
+                paths_match = output_path.samefile(input_path)
+            if paths_match:
+                raise ValueError(
+                    f"Output path would overwrite an input file: {output_path}"
+                )
+
+
+def build_subdivision(
+    rect: tuple[int, int, int, int],
+    points: Sequence[tuple[float, float]],
+    image: np.ndarray,
+    display: bool,
+    animate: bool,
+    animation_delay_ms: int,
+) -> cv2.Subdiv2D:
+    """Insert points and optionally display progressive triangulation."""
+
+    # Construct the subdivision over the exact image rectangle.
+    subdiv = cv2.Subdiv2D(rect)
+    # Insert each unique site once in its source order.
+    for point in points:
+        # Subdiv2D returns an existing vertex ID for a duplicate, already filtered above.
+        subdiv.insert(point)
+        # Animation is deliberately opt-in so automated and remote runs never block.
+        if display and animate:
+            # Render the partial triangulation on a fresh image copy.
+            frame = image.copy()
+            # Canonical collection keeps the animation independent of API ordering.
+            partial_triangles = collect_triangles(subdiv, rect)
+            # White lines remain visible against the portrait.
+            draw_delaunay(frame, partial_triangles, (255, 255, 255))
+            # Display the progressive result in the tutorial window.
+            cv2.imshow("Delaunay Triangulation", frame)
+            # A positive delay lets the window process events between insertions.
+            cv2.waitKey(animation_delay_ms)
+    # Return the completed subdivision for final geometry and Voronoi extraction.
+    return subdiv
+
+
+def run(
+    image_path: Path,
+    points_path: Path,
+    output_dir: Path,
+    display: bool = False,
+    animate: bool = False,
+    animation_delay_ms: int = 100,
+    validate: bool = False,
+) -> GeometryMetrics:
+    """Run the complete Delaunay/Voronoi example and return its metrics."""
+
+    # Resolve every intended artifact before reading or writing user-controlled paths.
+    ensure_output_paths_are_safe(image_path, points_path, output_dir)
+    # Read the color image without depending on the caller's current directory.
+    image = cv2.imread(str(image_path), cv2.IMREAD_COLOR)
+    if image is None or image.size == 0:
+        raise FileNotFoundError(f"Could not read input image: {image_path}")
+    # This visualization expects an ordinary three-channel BGR input.
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise ValueError(f"Expected a three-channel image: {image_path}")
+
+    # Build the OpenCV half-open rectangle from the decoded image dimensions.
+    height, width = image.shape[:2]
+    rect = (0, 0, width, height)
+    # Parse and explicitly de-duplicate the landmark records.
+    points, point_records = load_points(points_path, rect)
+    # Insert the sites, optionally rendering the progressive triangulation.
+    subdiv = build_subdivision(
+        rect,
+        points,
+        image,
+        display,
+        animate,
+        animation_delay_ms,
+    )
+    # Extract canonical geometry only after every site has been inserted.
+    triangles = collect_triangles(subdiv, rect)
+    # Extract all nonvirtual Voronoi facets and their generating sites.
+    facets, centers = collect_voronoi(subdiv)
+
+    # Draw the final triangulation on a copy of the original image.
+    delaunay_image = image.copy()
+    draw_delaunay(delaunay_image, triangles, (255, 255, 255))
+    # Overlay the unique landmark sites in red.
+    for point in points:
+        draw_point(delaunay_image, point, (0, 0, 255))
+
+    # Start the Voronoi visualization from a black canvas of the same size/type.
+    voronoi_image = np.zeros_like(image)
+    # Fill and outline every returned Voronoi facet deterministically.
+    draw_voronoi(voronoi_image, facets, centers)
+
+    # Calculate validation metrics before writing or displaying outputs.
+    metrics = calculate_metrics(
+        image,
+        point_records,
+        points,
+        triangles,
+        facets,
+    )
+    # The validation flag activates the bundled-data regression contract.
+    if validate:
+        validate_metrics(metrics, points, triangles, centers)
+        validate_rendered_images(image, delaunay_image, voronoi_image)
+
+    # Create the output directory explicitly for reliable CLI behavior.
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # Lossless PNG output avoids codec-dependent JPEG artifacts.
+    write_image(output_dir / "delaunay.png", delaunay_image)
+    # Verify the Voronoi artifact through the same write/read path.
+    write_image(output_dir / "voronoi.png", voronoi_image)
+
+    # Display remains optional because headless environments may have no window backend.
+    if display:
+        # Show the completed triangulation.
+        cv2.imshow("Delaunay Triangulation", delaunay_image)
+        # Show its dual Voronoi diagram beside it.
+        cv2.imshow("Voronoi Diagram", voronoi_image)
+        # Wait for one key before closing both windows.
+        cv2.waitKey(0)
+        # Release GUI resources cleanly after the user dismisses the example.
+        cv2.destroyAllWindows()
+
+    # Return the metrics so tests exercise the real implementation.
+    return metrics
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the command-line interface shared by interactive and test runs."""
+
+    # Resolve bundled assets relative to this file, never the working directory.
+    source_dir = Path(__file__).resolve().parent
+    # A focused description keeps --help useful for tutorial readers.
+    parser = argparse.ArgumentParser(
+        description="Render Delaunay triangulation and Voronoi diagrams."
+    )
+    # Permit callers to replace the bundled portrait.
+    parser.add_argument(
+        "--image",
+        type=Path,
+        default=source_dir / "obama.jpg",
+        help="input image (default: bundled obama.jpg)",
+    )
+    # Permit callers to replace the bundled x/y landmark file.
+    parser.add_argument(
+        "--points",
+        type=Path,
+        default=source_dir / "obama.txt",
+        help="two-column landmark file (default: bundled obama.txt)",
+    )
+    # Keep generated artifacts out of the tracked source directory by default.
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=source_dir / "output",
+        help="directory for delaunay.png and voronoi.png",
+    )
+    # Provide both positive and negative display flags for explicit automation.
+    display_group = parser.add_mutually_exclusive_group()
+    display_group.add_argument(
+        "--display",
+        dest="display",
+        action="store_true",
+        help="open interactive result windows",
+    )
+    display_group.add_argument(
+        "--no-display",
+        dest="display",
+        action="store_false",
+        help="do not open GUI windows (default)",
+    )
+    # Headless execution is the safe default on servers and in CI.
+    parser.set_defaults(display=False)
+    # Progressive insertion is useful pedagogically but intentionally opt-in.
+    animation_group = parser.add_mutually_exclusive_group()
+    animation_group.add_argument(
+        "--animate",
+        dest="animate",
+        action="store_true",
+        help="animate point insertion when --display is enabled",
+    )
+    animation_group.add_argument(
+        "--no-animation",
+        dest="animate",
+        action="store_false",
+        help="disable insertion animation (default)",
+    )
+    # Static output is the reproducible default.
+    parser.set_defaults(animate=False)
+    # Expose the animation delay without hardcoding it in the rendering loop.
+    parser.add_argument(
+        "--animation-delay-ms",
+        type=int,
+        default=100,
+        help="delay between animated insertions in milliseconds",
+    )
+    # Validation checks stable topology rather than undocumented output ordering.
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="check the bundled 512x697 regression data",
+    )
+    # Return the configured parser to both main and tests.
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse CLI arguments, run the example, and report concise metrics."""
+
+    # Build the parser once so validation errors use consistent CLI formatting.
+    parser = build_parser()
+    # Parse an injected sequence in tests or sys.argv in normal execution.
+    args = parser.parse_args(argv)
+    # Animation without a display would do invisible work and usually signals a typo.
+    if args.animate and not args.display:
+        parser.error("--animate requires --display")
+    # OpenCV waitKey expects a positive delay for progressive animation.
+    if args.animation_delay_ms <= 0:
+        parser.error("--animation-delay-ms must be positive")
+
+    # Convert runtime errors into a controlled nonzero CLI result.
+    try:
+        metrics = run(
+            image_path=args.image,
+            points_path=args.points,
+            output_dir=args.output_dir,
+            display=args.display,
+            animate=args.animate,
+            animation_delay_ms=args.animation_delay_ms,
+            validate=args.validate,
+        )
+    except (cv2.error, OSError, RuntimeError, ValueError) as error:
+        # Print no traceback for expected input, output, or validation failures.
+        print(f"error: {error}", file=sys.stderr)
+        # Exit code two denotes invalid input or an unusable runtime environment.
+        return 2
+
+    # Report the exact library under test before the geometry summary.
+    print(f"OpenCV version: {cv2.__version__}")
+    # Keep the summary compact enough for both readers and CTest logs.
+    print(
+        "Geometry: "
+        f"{metrics.point_records} records, "
+        f"{metrics.unique_points} unique points, "
+        f"{metrics.triangles} triangles, "
+        f"{metrics.voronoi_facets} Voronoi facets"
+    )
+    # Emit the success marker only after geometry and output verification pass.
+    if args.validate:
+        print("DELAUNAY_VALIDATION_OK")
+    # Zero signals successful rendering and validation.
+    return 0
+
+
+if __name__ == "__main__":
+    # Propagate the explicit CLI status to the shell and test harness.
+    raise SystemExit(main())

--- a/Delaunay/requirements.txt
+++ b/Delaunay/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.23,<3
+opencv-python>=4.8,<6

--- a/Delaunay/tests/check_cpp_failures.cmake
+++ b/Delaunay/tests/check_cpp_failures.cmake
@@ -1,0 +1,175 @@
+# Exercise C++ failure paths that must not mutate user-controlled inputs.
+
+foreach(required_variable DELAUNAY_EXE SOURCE_DIR TEST_ROOT)
+  if(NOT DEFINED ${required_variable})
+    message(FATAL_ERROR "${required_variable} is required")
+  endif()
+endforeach()
+
+# Start from a clean build-local directory on every CTest run.
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY "${TEST_ROOT}")
+
+# Run one CLI case that must fail and verify its diagnostic.
+function(expect_cli_failure case_name expected_pattern)
+  execute_process(
+    COMMAND "${DELAUNAY_EXE}" ${ARGN}
+    RESULT_VARIABLE case_result
+    OUTPUT_VARIABLE case_stdout
+    ERROR_VARIABLE case_stderr
+  )
+  if(case_result EQUAL 0)
+    message(FATAL_ERROR "${case_name} unexpectedly succeeded")
+  endif()
+  if(NOT case_stderr MATCHES "${expected_pattern}")
+    message(
+      FATAL_ERROR
+      "${case_name} did not report '${expected_pattern}': ${case_stderr}"
+    )
+  endif()
+endfunction()
+
+# Put the input image exactly where delaunay.png would normally be written.
+set(collision_dir "${TEST_ROOT}/collision")
+file(MAKE_DIRECTORY "${collision_dir}")
+file(COPY "${SOURCE_DIR}/obama.jpg" DESTINATION "${collision_dir}")
+file(RENAME
+  "${collision_dir}/obama.jpg"
+  "${collision_dir}/delaunay.png"
+)
+file(COPY "${SOURCE_DIR}/obama.txt" DESTINATION "${collision_dir}")
+
+# Hash the source so the test proves that a rejected run did not overwrite it.
+file(SHA256 "${collision_dir}/delaunay.png" collision_hash_before)
+execute_process(
+  COMMAND
+    "${DELAUNAY_EXE}"
+    --image "${collision_dir}/delaunay.png"
+    --points "${collision_dir}/obama.txt"
+    --output-dir "${collision_dir}"
+    --no-display
+  RESULT_VARIABLE collision_result
+  OUTPUT_VARIABLE collision_stdout
+  ERROR_VARIABLE collision_stderr
+)
+if(collision_result EQUAL 0)
+  message(FATAL_ERROR "Input/output collision unexpectedly succeeded")
+endif()
+if(NOT collision_stderr MATCHES "would overwrite an input file")
+  message(
+    FATAL_ERROR
+    "Collision failure did not report the safety guard: ${collision_stderr}"
+  )
+endif()
+file(SHA256 "${collision_dir}/delaunay.png" collision_hash_after)
+if(NOT collision_hash_before STREQUAL collision_hash_after)
+  message(FATAL_ERROR "The colliding input image was modified")
+endif()
+
+# Different pathnames can still reference one inode through a hard link.
+set(hardlink_dir "${TEST_ROOT}/hardlink")
+file(MAKE_DIRECTORY "${hardlink_dir}")
+file(COPY "${SOURCE_DIR}/obama.jpg" DESTINATION "${hardlink_dir}")
+file(RENAME
+  "${hardlink_dir}/obama.jpg"
+  "${hardlink_dir}/source.jpg"
+)
+file(
+  CREATE_LINK
+  "${hardlink_dir}/source.jpg"
+  "${hardlink_dir}/delaunay.png"
+  RESULT hardlink_result
+)
+if(NOT hardlink_result STREQUAL "0")
+  message(FATAL_ERROR "Could not create hard-link collision: ${hardlink_result}")
+endif()
+file(SHA256 "${hardlink_dir}/source.jpg" hardlink_hash_before)
+execute_process(
+  COMMAND
+    "${DELAUNAY_EXE}"
+    --image "${hardlink_dir}/source.jpg"
+    --points "${SOURCE_DIR}/obama.txt"
+    --output-dir "${hardlink_dir}"
+    --no-display
+  RESULT_VARIABLE hardlink_run_result
+  OUTPUT_VARIABLE hardlink_stdout
+  ERROR_VARIABLE hardlink_stderr
+)
+if(hardlink_run_result EQUAL 0)
+  message(FATAL_ERROR "Hard-link input/output collision unexpectedly succeeded")
+endif()
+if(NOT hardlink_stderr MATCHES "would overwrite an input file")
+  message(
+    FATAL_ERROR
+    "Hard-link failure did not report the safety guard: ${hardlink_stderr}"
+  )
+endif()
+file(SHA256 "${hardlink_dir}/source.jpg" hardlink_hash_after)
+if(NOT hardlink_hash_before STREQUAL hardlink_hash_after)
+  message(FATAL_ERROR "The hard-linked input image was modified")
+endif()
+
+# Fractional sites are rejected because this example models integer image pixels.
+set(fractional_dir "${TEST_ROOT}/fractional")
+file(MAKE_DIRECTORY "${fractional_dir}")
+file(
+  WRITE "${fractional_dir}/points.txt"
+  "10 20\n20 30\n40.5 50\n"
+)
+execute_process(
+  COMMAND
+    "${DELAUNAY_EXE}"
+    --image "${SOURCE_DIR}/obama.jpg"
+    --points "${fractional_dir}/points.txt"
+    --output-dir "${fractional_dir}/output"
+    --no-display
+  RESULT_VARIABLE fractional_result
+  OUTPUT_VARIABLE fractional_stdout
+  ERROR_VARIABLE fractional_stderr
+)
+if(fractional_result EQUAL 0)
+  message(FATAL_ERROR "Fractional landmark input unexpectedly succeeded")
+endif()
+if(NOT fractional_stderr MATCHES "coordinates must be integers")
+  message(
+    FATAL_ERROR
+    "Fractional failure did not report the integer contract: "
+    "${fractional_stderr}"
+  )
+endif()
+
+# A nonexistent image must fail before any geometry or output work begins.
+expect_cli_failure(
+  "Missing image input"
+  "Could not read input image"
+  --image "${TEST_ROOT}/missing-image.jpg"
+  --points "${SOURCE_DIR}/obama.txt"
+  --output-dir "${TEST_ROOT}/missing-output"
+  --no-display
+)
+
+# Each non-comment landmark record must contain exactly one x/y pair.
+set(malformed_dir "${TEST_ROOT}/malformed")
+file(MAKE_DIRECTORY "${malformed_dir}")
+file(WRITE "${malformed_dir}/points.txt" "10 20 30\n")
+expect_cli_failure(
+  "Malformed landmark input"
+  "expected two coordinates"
+  --image "${SOURCE_DIR}/obama.jpg"
+  --points "${malformed_dir}/points.txt"
+  --output-dir "${malformed_dir}/output"
+  --no-display
+)
+
+# Pixel coordinates use half-open image bounds, so x == width is invalid.
+set(outside_dir "${TEST_ROOT}/outside")
+file(MAKE_DIRECTORY "${outside_dir}")
+file(WRITE "${outside_dir}/points.txt" "10 20\n20 30\n512 40\n")
+expect_cli_failure(
+  "Out-of-bounds landmark input"
+  "point is outside the image rectangle"
+  --image "${SOURCE_DIR}/obama.jpg"
+  --points "${outside_dir}/points.txt"
+  --output-dir "${outside_dir}/output"
+  --no-display
+)

--- a/Delaunay/tests/check_cpp_regression.cmake
+++ b/Delaunay/tests/check_cpp_regression.cmake
@@ -1,0 +1,59 @@
+# Run the real C++ CLI and verify its exact build-local artifact set.
+
+foreach(required_variable DELAUNAY_EXE TEST_ROOT)
+  if(NOT DEFINED ${required_variable})
+    message(FATAL_ERROR "${required_variable} is required")
+  endif()
+endforeach()
+
+# Remove stale artifacts so they cannot survive unnoticed between CTest runs.
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY "${TEST_ROOT}")
+set(output_dir "${TEST_ROOT}/output")
+
+# Execute the bundled-data validation through the compiled entry point.
+execute_process(
+  COMMAND
+    "${DELAUNAY_EXE}"
+    --no-display
+    --no-animation
+    --validate
+    --output-dir "${output_dir}"
+  RESULT_VARIABLE run_result
+  OUTPUT_VARIABLE run_stdout
+  ERROR_VARIABLE run_stderr
+)
+if(NOT run_result EQUAL 0)
+  message(
+    FATAL_ERROR
+    "Delaunay regression failed (${run_result}): "
+    "${run_stdout}${run_stderr}"
+  )
+endif()
+if(NOT run_stdout MATCHES "DELAUNAY_VALIDATION_OK")
+  message(FATAL_ERROR "Delaunay validation marker is missing: ${run_stdout}")
+endif()
+
+# The tutorial promises exactly two PNG artifacts and no stale extras.
+file(
+  GLOB output_entries
+  LIST_DIRECTORIES true
+  RELATIVE "${output_dir}"
+  "${output_dir}/*"
+)
+list(SORT output_entries)
+set(expected_entries "delaunay.png;voronoi.png")
+if(NOT "${output_entries}" STREQUAL "${expected_entries}")
+  message(
+    FATAL_ERROR
+    "Unexpected output set: ${output_entries}; expected ${expected_entries}"
+  )
+endif()
+
+# The executable already decodes and checks shape/type; also require nonempty files.
+foreach(filename delaunay.png voronoi.png)
+  file(SIZE "${output_dir}/${filename}" output_size)
+  if(output_size EQUAL 0)
+    message(FATAL_ERROR "Generated output is empty: ${filename}")
+  endif()
+endforeach()

--- a/Delaunay/tests/test_delaunay.py
+++ b/Delaunay/tests/test_delaunay.py
@@ -1,0 +1,319 @@
+"""Regression tests for the real Delaunay Python command-line example."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import cv2
+
+
+# Resolve the project independently of the directory from which unittest runs.
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+# Exercise the tracked script instead of duplicating its implementation in tests.
+SCRIPT_PATH = PROJECT_DIR / "delaunay.py"
+
+
+def load_example_module():
+    """Load the example module from its tracked path for focused helper tests."""
+
+    # Create an import specification without requiring the folder to be a package.
+    specification = importlib.util.spec_from_file_location(
+        "delaunay_example",
+        SCRIPT_PATH,
+    )
+    # A missing loader indicates a broken or unreadable script path.
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    # Construct the module object that the loader will populate.
+    module = importlib.util.module_from_spec(specification)
+    # Dataclass evaluation expects the in-progress module to be discoverable.
+    sys.modules[specification.name] = module
+    # Execute definitions without invoking the script's __main__ block.
+    specification.loader.exec_module(module)
+    # Return the real implementation for helper-level boundary checks.
+    return module
+
+
+class DelaunayCliTests(unittest.TestCase):
+    """Validate rendering, error handling, and working-directory independence."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Import the tracked implementation once for focused helper checks."""
+
+        # Keep the module on the test class to avoid repeated import side effects.
+        cls.example = load_example_module()
+
+    def run_cli(
+        self,
+        *arguments: str,
+        cwd: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the real CLI with the current exact OpenCV installation."""
+
+        # sys.executable ensures the subprocess uses the version under test.
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *arguments],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_bundled_cli_from_unrelated_directory(self) -> None:
+        """The validated example should not depend on the caller's directory."""
+
+        # Temporary directories keep generated files out of the repository.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            # Separate the unrelated working directory from the artifact directory.
+            working_dir = root / "working"
+            output_dir = root / "output"
+            # Create only the working directory; the program must create output itself.
+            working_dir.mkdir()
+            # Run the complete headless validation path.
+            result = self.run_cli(
+                "--no-display",
+                "--no-animation",
+                "--validate",
+                "--output-dir",
+                str(output_dir),
+                cwd=working_dir,
+            )
+
+            # Surface captured output if the real entry point fails.
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=result.stdout + result.stderr,
+            )
+            # The marker appears only after geometry and output checks pass.
+            self.assertIn("DELAUNAY_VALIDATION_OK", result.stdout)
+            # The CLI reports the exact library used by this test environment.
+            self.assertIn(f"OpenCV version: {cv2.__version__}", result.stdout)
+            # Only the two documented artifacts should be generated.
+            self.assertEqual(
+                {path.name for path in output_dir.iterdir()},
+                {"delaunay.png", "voronoi.png"},
+            )
+
+            # Decode each artifact to test the files rather than in-memory arrays.
+            for filename in ("delaunay.png", "voronoi.png"):
+                image = cv2.imread(
+                    str(output_dir / filename),
+                    cv2.IMREAD_COLOR,
+                )
+                # A missing or corrupt PNG would decode as None.
+                self.assertIsNotNone(image)
+                # Bundled outputs must preserve the source image dimensions.
+                self.assertEqual(image.shape, (697, 512, 3))
+
+    def test_repeated_runs_are_deterministic(self) -> None:
+        """The shared palette should remove the old random Voronoi output."""
+
+        # Use one temporary root with separate outputs for two complete executions.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            # Create an unrelated current directory once for both executions.
+            working_dir = root / "working"
+            working_dir.mkdir()
+            # Run the real CLI twice with identical inputs and independent destinations.
+            for run_number in (1, 2):
+                result = self.run_cli(
+                    "--no-display",
+                    "--no-animation",
+                    "--validate",
+                    "--output-dir",
+                    str(root / f"output-{run_number}"),
+                    cwd=working_dir,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg=result.stdout + result.stderr,
+                )
+
+            # Lossless outputs should repeat byte-for-byte in one environment.
+            for filename in ("delaunay.png", "voronoi.png"):
+                first = (root / "output-1" / filename).read_bytes()
+                second = (root / "output-2" / filename).read_bytes()
+                self.assertEqual(first, second)
+
+    def test_missing_image_fails_cleanly(self) -> None:
+        """A missing image should return a controlled error without a traceback."""
+
+        # Keep the nonexistent path and unused output destination isolated.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            # Run from the temporary directory to exercise absolute default assets.
+            result = self.run_cli(
+                "--image",
+                str(root / "missing.jpg"),
+                "--output-dir",
+                str(root / "output"),
+                "--no-display",
+                cwd=root,
+            )
+            # Runtime input errors use the documented nonzero status.
+            self.assertEqual(result.returncode, 2)
+            # The message identifies the exact unusable input.
+            self.assertIn("Could not read input image", result.stderr)
+            # Expected failures remain concise for tutorial users.
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_invalid_points_fail_cleanly(self) -> None:
+        """Invalid point records should be rejected before Subdiv2D insertion."""
+
+        # Build two focused invalid files in an isolated directory.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            # A third column violates the two-coordinate file contract.
+            malformed = root / "malformed.txt"
+            malformed.write_text("10 20 30\n", encoding="utf-8")
+            # x == width is outside OpenCV's half-open 512-pixel rectangle.
+            outside = root / "outside.txt"
+            outside.write_text(
+                "10 20\n20 30\n512 40\n",
+                encoding="utf-8",
+            )
+            # Fractional coordinates are outside this raster tutorial's contract.
+            fractional = root / "fractional.txt"
+            fractional.write_text(
+                "10 20\n20 30\n40.5 50\n",
+                encoding="utf-8",
+            )
+
+            # Exercise parse, bounds, and integer-contract failures through the CLI.
+            cases = (
+                (malformed, "expected two coordinates"),
+                (outside, "is outside"),
+                (fractional, "coordinates must be integers"),
+            )
+            for points_path, message in cases:
+                result = self.run_cli(
+                    "--points",
+                    str(points_path),
+                    "--output-dir",
+                    str(root / points_path.stem),
+                    "--no-display",
+                    cwd=root,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(message, result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+
+    def test_outputs_cannot_overwrite_inputs(self) -> None:
+        """Both documented output names must be protected from input collision."""
+
+        # Check the image and point-file collision paths independently.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            cases = (
+                ("image", "delaunay.png"),
+                ("points", "voronoi.png"),
+            )
+            for input_kind, output_name in cases:
+                with self.subTest(input_kind=input_kind):
+                    # Give each case a fresh output directory.
+                    case_dir = root / input_kind
+                    case_dir.mkdir()
+                    # Start with the normal bundled inputs.
+                    image_path = PROJECT_DIR / "obama.jpg"
+                    points_path = PROJECT_DIR / "obama.txt"
+                    # Copy one input onto the output filename being tested.
+                    colliding_path = case_dir / output_name
+                    if input_kind == "image":
+                        shutil.copyfile(image_path, colliding_path)
+                        image_path = colliding_path
+                    else:
+                        shutil.copyfile(points_path, colliding_path)
+                        points_path = colliding_path
+                    # Preserve the exact source bytes for the no-overwrite assertion.
+                    before = colliding_path.read_bytes()
+
+                    # The safety check must run before either output is written.
+                    result = self.run_cli(
+                        "--image",
+                        str(image_path),
+                        "--points",
+                        str(points_path),
+                        "--output-dir",
+                        str(case_dir),
+                        "--no-display",
+                        cwd=root,
+                    )
+                    self.assertEqual(result.returncode, 2)
+                    self.assertIn(
+                        "Output path would overwrite an input file",
+                        result.stderr,
+                    )
+                    # The colliding input remains byte-for-byte unchanged.
+                    self.assertEqual(colliding_path.read_bytes(), before)
+
+            # Existing hard links use different pathnames for the same input inode.
+            hardlink_dir = root / "hardlink"
+            hardlink_dir.mkdir()
+            source_image = hardlink_dir / "source.jpg"
+            shutil.copyfile(PROJECT_DIR / "obama.jpg", source_image)
+            linked_output = hardlink_dir / "delaunay.png"
+            os.link(source_image, linked_output)
+            before = source_image.read_bytes()
+            result = self.run_cli(
+                "--image",
+                str(source_image),
+                "--points",
+                str(PROJECT_DIR / "obama.txt"),
+                "--output-dir",
+                str(hardlink_dir),
+                "--no-display",
+                cwd=root,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn(
+                "Output path would overwrite an input file",
+                result.stderr,
+            )
+            # Neither pathname may expose mutated source bytes after rejection.
+            self.assertEqual(source_image.read_bytes(), before)
+            self.assertEqual(linked_output.read_bytes(), before)
+
+    def test_rectangle_uses_half_open_boundaries(self) -> None:
+        """The Python helper should match cv::Rect for nonzero origins."""
+
+        # Left/top is included.
+        self.assertTrue(self.example.rect_contains((10, 20, 5, 7), (10, 20)))
+        # The last representable interior coordinate is included.
+        self.assertTrue(
+            self.example.rect_contains((10, 20, 5, 7), (14.999, 26.999))
+        )
+        # Right and bottom boundaries are excluded.
+        self.assertFalse(self.example.rect_contains((10, 20, 5, 7), (15, 25)))
+        self.assertFalse(self.example.rect_contains((10, 20, 5, 7), (12, 27)))
+
+    def test_animation_requires_display(self) -> None:
+        """Invisible animation should be rejected as a command-line error."""
+
+        # Use an unrelated directory even though parsing should stop before I/O.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            # The mutually meaningful combination is --display --animate.
+            result = self.run_cli(
+                "--animate",
+                "--no-display",
+                cwd=root,
+            )
+            # argparse exits with two for an invalid command-line combination.
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--animate requires --display", result.stderr)
+
+
+if __name__ == "__main__":
+    # Support direct execution as well as unittest discovery.
+    unittest.main()


### PR DESCRIPTION
## What changed

- Modernized the Python and C++ Delaunay/Voronoi examples for OpenCV 4.14 and OpenCV 5.
- Added the OpenCV 5 `geometry` module/header handling and a C++17 CMake build.
- Added equivalent headless CLIs, deterministic Voronoi coloring, input validation, output-collision protection, and geometry validation.
- Added Python unit tests and CTest regression/failure-safety coverage.
- Rewrote the project README with exact setup, run, test, compatibility, and output guidance.

## Why

OpenCV 5 moves `cv::Subdiv2D` into the geometry module for C++ builds. The older tutorial also depended on an interactive working directory and randomized output, which made it difficult to validate reliably.

## Validation

Tested on macOS arm64 with Python 3.14.3, NumPy 2.4.2, CMake 3.29.3, and Apple Clang 21.0.0.

- Python + OpenCV 4.14.0: 7/7 unit tests passed; direct validated CLI passed.
- Python + OpenCV 5.0.0: 7/7 unit tests passed; direct validated CLI passed.
- C++ Release + OpenCV 4.14.0: strict-warning build; 2/2 CTests passed; direct validated CLI passed.
- C++ Release + OpenCV 5.0.0: strict-warning build with `opencv_geometry`; 2/2 CTests passed; direct validated CLI passed.
- Stable geometry agreed in all four cells: 68 records, 66 unique sites, 110 triangles, and 66 Voronoi facets.
- Both generated PNG files matched byte-for-byte across versions and languages on the tested system.
