### PR TITLE
Update Delaunay companion README

### DIFF
--- a/Delaunay/README.md
+++ b/Delaunay/README.md
@@ -5,7 +5,35 @@ This folder contains the Python and C++ examples for the LearnOpenCV article
 The examples insert facial landmarks into `Subdiv2D`, render the Delaunay
 triangulation, and render its dual Voronoi diagram.
 
-<p align="center"><img src="https://learnopencv.com/wp-content/uploads/2015/11/opencv-delaunay-vornoi-subdiv-example.jpg" alt="Delaunay triangulation and Voronoi diagram"></p>
+<p align="center">
+  <a href="https://learnopencv.com/delaunay-triangulation-and-voronoi-diagram-using-opencv-c-python/">
+    <img src="https://cdn.learnopencv.com/wp-content/uploads/2026/07/25000838/delaunay-voronoi-opencv-featured-2026.jpg" alt="Delaunay triangulation and Voronoi diagrams with OpenCV" width="900">
+  </a>
+</p>
+
+## Download the standalone project
+
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/delaunay-opencv-2026.07.24/Delaunay.zip)
+
+The immutable, versioned bundle has a published
+[SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/delaunay-opencv-2026.07.24/Delaunay.zip.sha256).
+The ZIP contains exactly one top-level `Delaunay/` directory with the eleven
+files shown in the project layout below.
+
+On macOS or Linux, download and verify both files before extracting the project:
+
+```bash
+curl --fail --location --remote-name \
+  https://github.com/spmallick/learnopencv/releases/download/delaunay-opencv-2026.07.24/Delaunay.zip
+curl --fail --location --remote-name \
+  https://github.com/spmallick/learnopencv/releases/download/delaunay-opencv-2026.07.24/Delaunay.zip.sha256
+shasum -a 256 -c Delaunay.zip.sha256
+unzip Delaunay.zip
+cd Delaunay
+```
+
+The expected SHA-256 digest for `Delaunay.zip` is
+`50a00efbe8b864db47a054d22ab2ffd2b9dcd0fa59a4e0d94e80ec8cfa617c8e`.
 
 ## OpenCV 4.14 and OpenCV 5 compatibility
 


### PR DESCRIPTION
## What changed

- replaces the stale 2015 Delaunay hero with the current 1600×900 article thumbnail
- links the hero to the canonical LearnOpenCV article
- adds the standard immutable standalone ZIP, checksum, verification commands, and expected SHA-256
- keeps the documented 11-file project/release layout and BigVision footer unchanged

## Why

The OpenCV 5 article and code release were published, but the project-folder README still used the old hero image and did not expose the verified standalone release in the current companion README format.

## Validation

- new thumbnail, article, download button, ZIP, and checksum URLs all return HTTP 200
- thumbnail is 1600×900 and matches SHA-256 `379a2e8058beee243d5b7f769031545321744fcb82a047f78ac8a69d7e225fe9`
- public ZIP and checksum agree on SHA-256 `50a00efbe8b864db47a054d22ab2ffd2b9dcd0fa59a4e0d94e80ec8cfa617c8e`
- current folder and release tag each contain the documented 11 files
- Python regressions pass 7/7
- `git diff --check` passes
- BigVision footer remains byte-identical
