### PR TITLE
Restore project README download buttons

### DIFF
--- a/Colorization/README.md
+++ b/Colorization/README.md
@@ -2,6 +2,8 @@
 
 [![CNN Image Colorization with OpenCV](readme-images/cnn-colorization-opencv-featured-2026.jpg)](https://learnopencv.com/convolutional-neural-network-based-image-colorization-using-opencv/)
 
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/colorization-opencv-2026.07.25/colorization-opencv-2026.07.25.zip)
+
 This folder accompanies
 [CNN-Based Image Colorization with OpenCV](https://learnopencv.com/convolutional-neural-network-based-image-colorization-using-opencv/).
 The refreshed C++ and Python implementations use one verified ONNX export of

--- a/Monocular SLAM for Robotics implementation in python/README.md
+++ b/Monocular SLAM for Robotics implementation in python/README.md
@@ -2,6 +2,8 @@
 
 [![Monocular SLAM in Python with OpenCV](readme-images/monocular-slam-opencv-featured-2026.jpg)](https://learnopencv.com/monocular-slam-in-python/)
 
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/monocular-slam-opencv-2026.07.25/monocular-slam-opencv-2026.07.25.zip)
+
 This is the companion implementation for
 [Monocular SLAM in Python](https://learnopencv.com/monocular-slam-in-python/).
 It is an educational monocular visual-odometry front end: ORB descriptors,

--- a/Optical-Flow-in-OpenCV/README.md
+++ b/Optical-Flow-in-OpenCV/README.md
@@ -2,6 +2,8 @@
 
 [![Optical Flow in OpenCV](readme-images/optical-flow-opencv-featured-2026.jpg)](https://learnopencv.com/optical-flow-in-opencv/)
 
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/optical-flow-opencv-2026.07.25/optical-flow-opencv-2026.07.25.zip)
+
 This folder accompanies
 [Optical Flow in OpenCV](https://learnopencv.com/optical-flow-in-opencv/).
 The Python and C++ demos share four algorithm names and support interactive or

--- a/QRCode-OpenCV/README.md
+++ b/QRCode-OpenCV/README.md
@@ -2,6 +2,8 @@
 
 [![OpenCV QR Code Scanner](readme-images/qr-code-scanner-opencv-featured-2026.jpg)](https://learnopencv.com/opencv-qr-code-scanner-c-and-python/)
 
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/qr-code-scanner-opencv-2026.07.25/qr-code-scanner-opencv-2026.07.25.zip)
+
 This folder accompanies
 [OpenCV QR Code Scanner in C++ and Python](https://learnopencv.com/opencv-qr-code-scanner-c-and-python/).
 Both implementations use `cv::QRCodeDetector` / `cv2.QRCodeDetector` to

--- a/SnakeGame/README.md
+++ b/SnakeGame/README.md
@@ -2,6 +2,8 @@
 
 [![Snake Game with OpenCV and Python](readme-images/snake-game-opencv-featured-2026.jpg)](https://learnopencv.com/snake-game-with-opencv-python/)
 
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/snake-game-opencv-2026.07.25/snake-game-opencv-2026.07.25.zip)
+
 This folder accompanies
 [Snake Game with OpenCV and Python](https://learnopencv.com/snake-game-with-opencv-python/).
 The game engine is now separate from OpenCV rendering, so movement, growth,


### PR DESCRIPTION
## What changed

Restores the standard 200-pixel LearnOpenCV **Download Code** image button near the top of the five refreshed project READMEs:

- Monocular SLAM
- OpenCV QR Code Scanner
- Optical Flow in OpenCV
- CNN-Based Image Colorization
- Snake Game with OpenCV

Each button points to the corresponding immutable `2026.07.25` GitHub Release ZIP.

## Why

The OpenCV 5 refresh modernized these READMEs but accidentally replaced their graphical download controls with text-only release sections. This follow-up restores the established LearnOpenCV README affordance while retaining the versioned, tested archives.

## Validation

- `git diff --check` passes.
- Diff is limited to 10 inserted lines across the five README files.
- Shared button image returns HTTP 200.
- All five release ZIP links follow redirects and return HTTP 200.
- No code, tests, root README entries, featured images, or Big Vision footers changed.