### PR TITLE
Link refreshed README titles and thumbnails

### DIFF
--- a/FaceAverage/README.md
+++ b/FaceAverage/README.md
@@ -1,9 +1,11 @@
-# Average Face with OpenCV
+# [Average Face with OpenCV](https://learnopencv.com/average-face-opencv-c-python-tutorial/)
 
 Companion code for [Average Face with OpenCV: C++ and Python Tutorial](https://learnopencv.com/average-face-opencv-c-python-tutorial/).
 
 <p align="center">
-  <img src="readme-images/average-face-opencv-2026.jpg" alt="Several aligned faces merging into an average face with a landmark mesh" width="100%">
+  <a href="https://learnopencv.com/average-face-opencv-c-python-tutorial/">
+    <img src="readme-images/average-face-opencv-2026.jpg" alt="Several aligned faces merging into an average face with a landmark mesh" width="100%">
+  </a>
 </p>
 
 [<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/average-face-opencv-2026.07.25/average-face-opencv-2026.07.25.zip)

--- a/HeadPose/README.md
+++ b/HeadPose/README.md
@@ -1,9 +1,11 @@
-# Head Pose Estimation with OpenCV
+# [Head Pose Estimation with OpenCV](https://learnopencv.com/head-pose-estimation-using-opencv-and-dlib/)
 
 Companion code for [Head Pose Estimation with OpenCV](https://learnopencv.com/head-pose-estimation-using-opencv-and-dlib/).
 
 <p align="center">
-  <img src="readme-images/head-pose-estimation-opencv-2026.jpg" alt="Head pose estimation with facial landmarks, a 3D pose axis, and a camera model" width="100%">
+  <a href="https://learnopencv.com/head-pose-estimation-using-opencv-and-dlib/">
+    <img src="readme-images/head-pose-estimation-opencv-2026.jpg" alt="Head pose estimation with facial landmarks, a 3D pose axis, and a camera model" width="100%">
+  </a>
 </p>
 
 [<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/head-pose-opencv-2026.07.25/head-pose-opencv-2026.07.25.zip)

--- a/ImageAlignment/README.md
+++ b/ImageAlignment/README.md
@@ -1,9 +1,11 @@
-# Image Alignment with ECC in OpenCV
+# [Image Alignment with ECC in OpenCV](https://learnopencv.com/image-alignment-ecc-in-opencv-c-python/)
 
 Companion code for [Image Alignment with ECC in OpenCV: C++ and Python](https://learnopencv.com/image-alignment-ecc-in-opencv-c-python/).
 
 <p align="center">
-  <img src="readme-images/image-alignment-ecc-opencv-2026.jpg" alt="Offset architectural images converging through ECC registration" width="100%">
+  <a href="https://learnopencv.com/image-alignment-ecc-in-opencv-c-python/">
+    <img src="readme-images/image-alignment-ecc-opencv-2026.jpg" alt="Offset architectural images converging through ECC registration" width="100%">
+  </a>
 </p>
 
 [<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/image-alignment-ecc-opencv-2026.07.25/image-alignment-ecc-opencv-2026.07.25.zip)


### PR DESCRIPTION
## What changed

- Linked each refreshed project README title to its canonical LearnOpenCV article.
- Linked each featured thumbnail to the same canonical article.
- Preserved the existing immutable Download Code release links and the remainder of each README.

## Why

Readers should be able to open the original tutorial by clicking either the project title or its featured thumbnail.

## Validation

- `git diff --check`
- Verified the three README link patterns locally.
- Confirmed all three canonical LearnOpenCV article URLs resolve successfully.