### PR TITLE
Harden OpenCV 5 YOLO26 C++ companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 
 | Blog Post | Code|
 | ------------- |:-------------|
-| [OpenCV 5 in C++: How To Detect, Pose & Segment Objects](https://learnopencv.com/opencv-5-in-c-how-to-detect-pose-segment-objects/) | [Code](https://github.com/spmallick/learnopencv/tree/master/opencv5-yolo26-football-cpp) |
+| [Object Detection with OpenCV 5 in C++: YOLO26 Pose and Segmentation](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/opencv5-yolo26-football-cpp) |
 | [Object Tracking using OpenCV (C++/Python)](https://learnopencv.com/object-tracking-using-opencv-cpp-python/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/tracking) |
 | [Read, Write and Display a Video using OpenCV](https://learnopencv.com/read-write-and-display-a-video-using-opencv-cpp-python/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/VideoReadWriteDisplay) |
 | [Histogram of Oriented Gradients Explained Using OpenCV](https://learnopencv.com/histogram-of-oriented-gradients/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/Histogram-of-Oriented-Gradients) |

--- a/opencv5-yolo26-football-cpp/.gitignore
+++ b/opencv5-yolo26-football-cpp/.gitignore
@@ -1,0 +1,10 @@
+/build/
+/models/
+/outputs/
+/opencv5_src/
+/opencv5_build/
+/opencv5_install/
+/yolo26*.onnx
+/yolo26*.pt
+__pycache__/
+*.py[cod]

--- a/opencv5-yolo26-football-cpp/CMakeLists.txt
+++ b/opencv5-yolo26-football-cpp/CMakeLists.txt
@@ -11,17 +11,31 @@ project(opencv5_yolo26_football_cpp LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 5 REQUIRED COMPONENTS core dnn imgcodecs imgproc videoio)
+if(OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+  message(FATAL_ERROR "This project supports OpenCV 5.x, not ${OpenCV_VERSION}")
+endif()
 find_package(Threads REQUIRED)
 message(STATUS "OpenCV version: ${OpenCV_VERSION}")
 
 add_library(yolo26_dnn STATIC src/yolo26_dnn.cpp)
 target_include_directories(yolo26_dnn PUBLIC src ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(yolo26_dnn PUBLIC ${OpenCV_LIBS})
+
+function(enable_strict_warnings target)
+  if(MSVC)
+    target_compile_options(${target} PRIVATE /W4 /WX)
+  else()
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  endif()
+endfunction()
+
+enable_strict_warnings(yolo26_dnn)
 
 set(DEMOS
   detect_image        # single-image object detection
@@ -34,4 +48,5 @@ set(DEMOS
 foreach(demo ${DEMOS})
   add_executable(${demo} src/${demo}.cpp)
   target_link_libraries(${demo} PRIVATE yolo26_dnn ${OpenCV_LIBS} Threads::Threads)
+  enable_strict_warnings(${demo})
 endforeach()

--- a/opencv5-yolo26-football-cpp/README.md
+++ b/opencv5-yolo26-football-cpp/README.md
@@ -1,10 +1,12 @@
-# OpenCV 5 in C++: How To Detect, Pose & Segment Objects
+# [Object Detection with OpenCV 5 in C++: YOLO26 Pose and Segmentation](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/)
 
-**This repository contains the code for the LearnOpenCV blog post [OpenCV 5 in C++: How To Detect, Pose & Segment Objects](https://learnopencv.com/opencv-5-in-c-how-to-detect-pose-segment-objects/).**
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/opencv5-yolo26-football-cpp-2026.07.28/opencv5-yolo26-football-cpp.zip)
 
-[![OpenCV 5 in C++: How To Detect, Pose & Segment Objects](opencv5-cpp-football-vision-thumbnail.jpg)](https://learnopencv.com/opencv-5-in-c-how-to-detect-pose-segment-objects/)
+[SHA-256 checksum](https://github.com/spmallick/learnopencv/releases/download/opencv5-yolo26-football-cpp-2026.07.28/opencv5-yolo26-football-cpp.zip.sha256)
 
-Companion code for the [LearnOpenCV post](https://learnopencv.com/opencv-5-in-c-how-to-detect-pose-segment-objects/) on running **YOLO26** through the **OpenCV 5 DNN module** in **C++**, on the **CPU**. This is Part 2 of the series (Part 1 was Python). Here everything is C++, and the same NMS-free pipeline is extended from plain object detection to **team splitting, pose estimation and instance segmentation**.
+[![Object Detection with OpenCV 5 in C++ using YOLO26 for pose and segmentation](opencv5-cpp-football-vision-thumbnail.jpg)](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/)
+
+Companion code for the [LearnOpenCV post](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/) on running **YOLO26** through the **OpenCV 5 DNN module** in **C++**, on the **CPU**. This is Part 2 of the series (Part 1 was Python). Here everything is C++, and the same NMS-free pipeline is extended from plain object detection to **team splitting, pose estimation and instance segmentation**.
 
 Everything runs on the **CPU only**. There is no CUDA and no GPU requirement, so
 you can build and run all of it on an ordinary laptop. No PyTorch or Python is
@@ -21,6 +23,45 @@ ONNX.
 | `CMakeLists.txt` | Build config for the demos | Builds the six executables |
 | `build_opencv5.sh` | Builds OpenCV 5 from source | The C++ dev files are not on pip yet |
 | `reproduce.sh` | Regenerates every blog result | One command, from `assets/` to annotated outputs |
+| `requirements.txt` | Pinned export dependencies | Recreates the tested ONNX export environment |
+
+### Standalone ZIP contents
+
+```text
+opencv5-yolo26-football-cpp/
+├── .gitignore
+├── CMakeLists.txt
+├── README.md
+├── requirements.txt
+├── build_opencv5.sh
+├── reproduce.sh
+├── opencv5-cpp-football-vision-thumbnail.jpg
+├── assets/
+│   ├── images/
+│   │   ├── aerial_duel.jpg
+│   │   ├── goal_celebration.jpg
+│   │   ├── match_broadcast.jpg
+│   │   ├── player_duel.jpg
+│   │   └── team_lineup.jpg
+│   └── videos/
+│       ├── ball_closeup.mp4
+│       ├── halftime_dancers.mp4
+│       ├── match_play.mp4
+│       └── stadium_wide.mp4
+├── scripts/
+│   ├── export_variants.py
+│   └── export_yolo26_onnx.py
+└── src/
+    ├── benchmark_engines.cpp
+    ├── cli.hpp
+    ├── detect_image.cpp
+    ├── detect_pose.cpp
+    ├── detect_seg.cpp
+    ├── detect_teams.cpp
+    ├── detect_video.cpp
+    ├── yolo26_dnn.cpp
+    └── yolo26_dnn.hpp
+```
 
 ### `src/` (the C++ code)
 
@@ -64,7 +105,7 @@ All of the above are in `.gitignore`.
 
 - A **C++17** compiler, **CMake**, and **Ninja**
 - The **FFmpeg development libraries** (for reading/writing MP4)
-- **Python 3** with `ultralytics`, `onnx`, `onnxslim` (only to export the models)
+- **Python 3** with the packages pinned in `requirements.txt` (only to export the models)
 
 On MSYS2 (Windows): `pacman -S mingw-w64-ucrt-x86_64-{cmake,ninja,ffmpeg}`
 On Debian/Ubuntu: `apt install cmake ninja-build libavcodec-dev libavformat-dev libswscale-dev`
@@ -81,7 +122,7 @@ cmake --build build
 
 # 3. Reproduce every result. First run auto-exports the models, then runs
 #    each demo on assets/ and writes annotated results into outputs/.
-pip install ultralytics onnx onnxslim
+python3 -m pip install -r requirements.txt
 ./reproduce.sh
 ```
 
@@ -116,7 +157,8 @@ build/benchmark_engines --model models/yolo26n_640.onnx --imgsz 640 \
 ```
 
 `--engine` takes `auto` (default), `new`, or `classic`. `--imgsz` must match the
-exported model, since the ONNX input shape is static.
+exported model, since the ONNX input shape is static. The pose demo also accepts
+`--kpt-conf` (default `0.30`) for the keypoint drawing threshold.
 
 ## Notes
 

--- a/opencv5-yolo26-football-cpp/build_opencv5.sh
+++ b/opencv5-yolo26-football-cpp/build_opencv5.sh
@@ -9,13 +9,22 @@
 # (needed for MP4 read/write):
 #   MSYS2 : pacman -S mingw-w64-ucrt-x86_64-{cmake,ninja,ffmpeg}
 #   Debian: apt install cmake ninja-build libavcodec-dev libavformat-dev libswscale-dev
-set -e
+set -euo pipefail
 
 SRC=opencv5_src
 BUILD=opencv5_build
 INSTALL="$(pwd)/opencv5_install"
 
-[ -d "$SRC" ] || git clone --depth 1 --branch 5.0.0 https://github.com/opencv/opencv.git "$SRC"
+if [ ! -d "$SRC/.git" ]; then
+  git clone --depth 1 --branch 5.0.0 https://github.com/opencv/opencv.git "$SRC"
+else
+  expected_commit=$(git -C "$SRC" rev-list -n 1 5.0.0)
+  actual_commit=$(git -C "$SRC" rev-parse HEAD)
+  if [ "$actual_commit" != "$expected_commit" ]; then
+    echo "$SRC is not checked out at OpenCV 5.0.0" >&2
+    exit 1
+  fi
+fi
 
 cmake -G Ninja -B "$BUILD" \
   -DCMAKE_BUILD_TYPE=Release \

--- a/opencv5-yolo26-football-cpp/reproduce.sh
+++ b/opencv5-yolo26-football-cpp/reproduce.sh
@@ -10,8 +10,8 @@
 #      (Ultralytics downloads the nano weights), then runs every demo.
 #
 # The models/ and outputs/ folders are generated here, never committed.
-set -e
-PY=${PYTHON:-python}
+set -euo pipefail
+PY=${PYTHON:-python3}
 BIN=build
 A=assets
 M=models
@@ -30,42 +30,48 @@ if [ ! -f "$DET640" ] || [ ! -f "$DET1280" ] || [ ! -f "$SEG" ] || [ ! -f "$POSE
   "$PY" scripts/export_yolo26_onnx.py --imgsz 1280
   "$PY" scripts/export_variants.py            # yolo26n-seg + yolo26n-pose
 fi
+for model in "$DET640" "$DET1280" "$SEG" "$POSE"; do
+    [ -s "$model" ] || {
+        echo "model export did not create a nonempty file: $model" >&2
+        exit 1
+    }
+done
 
 echo "== Object detection (images) =="
-$BIN/detect_image --model $DET1280 --imgsz 1280 --engine new --conf 0.25 \
+"$BIN/detect_image" --model "$DET1280" --imgsz 1280 --engine new --conf 0.25 \
     --source "$A/images/team_lineup.jpg"   --out "$O/detection_germany.jpg"
-$BIN/detect_image --model $DET1280 --imgsz 1280 --engine new --conf 0.25 \
+"$BIN/detect_image" --model "$DET1280" --imgsz 1280 --engine new --conf 0.25 \
     --source "$A/images/match_broadcast.jpg"  --out "$O/detection_broadcast.jpg"
-$BIN/detect_image --model $DET1280 --imgsz 1280 --engine new --conf 0.25 \
+"$BIN/detect_image" --model "$DET1280" --imgsz 1280 --engine new --conf 0.25 \
     --source "$A/images/player_duel.jpg"             --out "$O/detection_duel_limitation.jpg"
 
 echo "== Object detection (video) =="
-$BIN/detect_video --model $DET640 --imgsz 640 --engine new \
+"$BIN/detect_video" --model "$DET640" --imgsz 640 --engine new \
     --source "$A/videos/match_play.mp4"   --out "$O/detection_football.mp4"
 
 echo "== Detection on wide stadium footage =="
-$BIN/detect_video --model $DET640 --imgsz 640 --engine new --conf 0.25 \
+"$BIN/detect_video" --model "$DET640" --imgsz 640 --engine new --conf 0.25 \
     --source "$A/videos/stadium_wide.mp4"      --out "$O/detection_stadium.mp4"
 
 echo "== Team split (jersey colour) =="
-$BIN/detect_teams --model $DET640 --imgsz 640 --teams 2 --minh 0.08 \
+"$BIN/detect_teams" --model "$DET640" --imgsz 640 --teams 2 --minh 0.08 \
     --source "$A/videos/stadium_wide.mp4"          --out "$O/team_split_stadium.mp4"
 
 echo "== Pose / keypoints =="
-$BIN/detect_pose --model $POSE --conf 0.30 \
+"$BIN/detect_pose" --model "$POSE" --conf 0.30 \
     --source "$A/images/aerial_duel.jpg"      --out "$O/pose_header.jpg"
-Y26_PERSON_LABEL=Dancer $BIN/detect_pose --model $POSE \
+Y26_PERSON_LABEL=Dancer "$BIN/detect_pose" --model "$POSE" \
     --source "$A/videos/halftime_dancers.mp4"          --out "$O/pose_dancers.mp4"
 
 echo "== Instance segmentation =="
-$BIN/detect_seg --model $SEG --conf 0.35 \
+"$BIN/detect_seg" --model "$SEG" --conf 0.35 \
     --source "$A/images/goal_celebration.jpg"      --out "$O/seg_celebration.jpg"
-$BIN/detect_seg --model $SEG --conf 0.30 \
+"$BIN/detect_seg" --model "$SEG" --conf 0.30 \
     --source "$A/images/player_duel.jpg"             --out "$O/seg_duel.jpg"
 # the halftime performers read better as "dancer" than "player"
-Y26_PERSON_LABEL=Dancer $BIN/detect_seg --model $SEG --conf 0.35 \
+Y26_PERSON_LABEL=Dancer "$BIN/detect_seg" --model "$SEG" --conf 0.35 \
     --source "$A/videos/halftime_dancers.mp4"          --out "$O/seg_dancers.mp4"
-$BIN/detect_seg --model $SEG --conf 0.35 \
+"$BIN/detect_seg" --model "$SEG" --conf 0.35 \
     --source "$A/videos/ball_closeup.mp4"     --out "$O/seg_ball_closeup.mp4"
 
 echo "== Web-safe re-encode =="

--- a/opencv5-yolo26-football-cpp/requirements.txt
+++ b/opencv5-yolo26-football-cpp/requirements.txt
@@ -1,0 +1,3 @@
+ultralytics==8.4.27
+onnx==1.20.1
+onnxslim==0.1.90

--- a/opencv5-yolo26-football-cpp/scripts/export_variants.py
+++ b/opencv5-yolo26-football-cpp/scripts/export_variants.py
@@ -3,7 +3,7 @@ Export YOLO26 segmentation and pose variants to ONNX for OpenCV 5 DNN.
 Static shape, opset 12, no embedded NMS (same recipe as Part 1's detector).
 Prints the ONNX input/output tensor shapes so we know how to parse them in C++.
 """
-import sys, shutil
+import shutil
 from pathlib import Path
 from ultralytics import YOLO
 
@@ -30,17 +30,23 @@ def shapes(onnx_path):
     print("  outputs:", [(vi.name, sh(vi)) for vi in m.graph.output])
 
 
-for weights, tag in VARIANTS:
-    print(f"\n=== {weights} ===")
-    try:
-        model = YOLO(weights)   # auto-downloads
+def main():
+    for weights, tag in VARIANTS:
+        print(f"\n=== {weights} ===")
+        model_path = MODELS / weights
+        model = YOLO(str(model_path) if model_path.exists() else weights)
         out = model.export(format="onnx", opset=12, imgsz=IMGSZ,
                            dynamic=False, simplify=True, nms=False)
         out = Path(out)
         tagged = MODELS / f"yolo26n_{tag}_{IMGSZ}.onnx"
         if out.resolve() != tagged.resolve():
-            shutil.copy(out, tagged)
+            shutil.move(out, tagged)
+        downloaded_weights = Path(weights)
+        if not model_path.exists() and downloaded_weights.exists():
+            shutil.move(downloaded_weights, model_path)
         print("exported:", tagged)
         shapes(tagged)
-    except Exception as e:
-        print("  FAILED:", type(e).__name__, e)
+
+
+if __name__ == "__main__":
+    main()

--- a/opencv5-yolo26-football-cpp/scripts/export_yolo26_onnx.py
+++ b/opencv5-yolo26-football-cpp/scripts/export_yolo26_onnx.py
@@ -31,7 +31,8 @@ def main():
     args = ap.parse_args()
 
     weights = MODELS_DIR / MODEL_NAME
-    # Ultralytics downloads the weights automatically if missing.
+    # Ultralytics downloads the weights automatically if missing. Move the
+    # downloaded file into models/ after export so the project root stays clean.
     model = YOLO(str(weights) if weights.exists() else MODEL_NAME)
 
     onnx_path = model.export(
@@ -47,7 +48,10 @@ def main():
     # Give the file a size-tagged name (in models/) so 640 and 1280 coexist.
     tagged = MODELS_DIR / f"yolo26n_{args.imgsz}.onnx"
     if onnx_path.resolve() != tagged.resolve():
-        shutil.copy(onnx_path, tagged)
+        shutil.move(onnx_path, tagged)
+    downloaded_weights = Path(MODEL_NAME)
+    if not weights.exists() and downloaded_weights.exists():
+        shutil.move(downloaded_weights, weights)
     print("Exported ONNX:", tagged)
     onnx_path = tagged
 

--- a/opencv5-yolo26-football-cpp/src/benchmark_engines.cpp
+++ b/opencv5-yolo26-football-cpp/src/benchmark_engines.cpp
@@ -6,7 +6,7 @@
 // the new graph engine against the classic layer engine, in C++.
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   benchmark_engines --model models/yolo26n_640.onnx --imgsz 640 \
+//   benchmark_engines --model models/yolo26n_640.onnx --imgsz 640
 //                     --source assets/images/team_lineup.jpg --runs 40
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"
@@ -38,6 +38,10 @@ int main(int argc, char** argv) {
     const std::string model  = cli.get("model", "models/yolo26n_640.onnx");
     const std::string source = cli.get("source", "assets/images/team_lineup.jpg");
     const int runs           = cli.geti("runs", 40);
+    if (runs <= 0) {
+        std::cerr << "--runs must be positive\n";
+        return 1;
+    }
 
     cv::Mat img = cv::imread(source);
     if (img.empty()) {

--- a/opencv5-yolo26-football-cpp/src/detect_image.cpp
+++ b/opencv5-yolo26-football-cpp/src/detect_image.cpp
@@ -5,8 +5,8 @@
 // optimized, times a clean pass, draws the detections, and writes the result.
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   detect_image --model models/yolo26n_640.onnx --imgsz 640 \
-//                --source assets/images/team_lineup.jpg --engine auto \
+//   detect_image --model models/yolo26n_640.onnx --imgsz 640
+//                --source assets/images/team_lineup.jpg --engine auto
 //                --out outputs/image_detected.jpg
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"

--- a/opencv5-yolo26-football-cpp/src/detect_pose.cpp
+++ b/opencv5-yolo26-football-cpp/src/detect_pose.cpp
@@ -6,7 +6,7 @@
 // 17 keypoints x (x, y, confidence). Works on an image or a video (auto-detected).
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   detect_pose --model models/yolo26n_pose_640.onnx --imgsz 640 \
+//   detect_pose --model models/yolo26n_pose_640.onnx --imgsz 640
 //               --source assets/images/aerial_duel.jpg --out outputs/pose.jpg
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"
@@ -22,6 +22,7 @@ int main(int argc, char** argv) {
     const std::string source = cli.get("source", "assets/images/aerial_duel.jpg");
     const std::string engine = cli.get("engine", "auto");
     const float conf         = cli.getf("conf", 0.30f);
+    const float kpt_conf     = cli.getf("kpt-conf", 0.30f);
     const std::string out    = cli.get("out", "outputs/pose.jpg");
 
     cv::dnn::Net net = y26::build_net(model, engine);
@@ -31,8 +32,11 @@ int main(int argc, char** argv) {
     if (!img.empty()) {
         y26::detect_pose(net, img, imgsz, conf);               // warm-up
         auto poses = y26::detect_pose(net, img, imgsz, conf);
-        y26::draw_pose(img, poses);
-        cv::imwrite(out, img);
+        y26::draw_pose(img, poses, false, kpt_conf);
+        if (!cv::imwrite(out, img)) {
+            std::cerr << "could not write output: " << out << "\n";
+            return 1;
+        }
         std::cout << "poses=" << poses.size() << "  saved " << out << "\n";
         return 0;
     }
@@ -43,13 +47,21 @@ int main(int argc, char** argv) {
     const int W = (int)cap.get(cv::CAP_PROP_FRAME_WIDTH);
     const int H = (int)cap.get(cv::CAP_PROP_FRAME_HEIGHT);
     cv::VideoWriter writer(out, cv::VideoWriter::fourcc('m','p','4','v'), fps, {W, H});
+    if (!writer.isOpened()) {
+        std::cerr << "could not open writer: " << out << "\n";
+        return 1;
+    }
 
     cv::Mat frame; int n = 0;
     while (cap.read(frame)) {
         auto poses = y26::detect_pose(net, frame, imgsz, conf);
-        y26::draw_pose(frame, poses);
+        y26::draw_pose(frame, poses, false, kpt_conf);
         writer.write(frame);
         ++n;
+    }
+    if (n == 0) {
+        std::cerr << "video contained no readable frames: " << source << "\n";
+        return 1;
     }
     std::cout << "processed " << n << " frames, saved " << out << "\n";
     return 0;

--- a/opencv5-yolo26-football-cpp/src/detect_seg.cpp
+++ b/opencv5-yolo26-football-cpp/src/detect_seg.cpp
@@ -8,7 +8,7 @@
 // Works on an image or a video (auto-detected).
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   detect_seg --model models/yolo26n_seg_640.onnx --imgsz 640 \
+//   detect_seg --model models/yolo26n_seg_640.onnx --imgsz 640
 //              --source assets/images/goal_celebration.jpg --out outputs/seg.jpg
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"
@@ -26,6 +26,10 @@ int main(int argc, char** argv) {
     const float conf         = cli.getf("conf", 0.30f);
     const float alpha        = cli.getf("alpha", 0.5f);
     const std::string out    = cli.get("out", "outputs/seg.jpg");
+    if (alpha < 0.0f || alpha > 1.0f) {
+        std::cerr << "--alpha must be between 0 and 1\n";
+        return 1;
+    }
 
     cv::dnn::Net net = y26::build_net(model, engine);
     y26::ensure_parent_dir(out);
@@ -35,7 +39,10 @@ int main(int argc, char** argv) {
         y26::detect_seg(net, img, imgsz, conf);              // warm-up
         auto segs = y26::detect_seg(net, img, imgsz, conf);
         y26::draw_seg(img, segs, alpha);
-        cv::imwrite(out, img);
+        if (!cv::imwrite(out, img)) {
+            std::cerr << "could not write output: " << out << "\n";
+            return 1;
+        }
         std::cout << "instances=" << segs.size() << "  saved " << out << "\n";
         return 0;
     }
@@ -46,6 +53,10 @@ int main(int argc, char** argv) {
     const int W = (int)cap.get(cv::CAP_PROP_FRAME_WIDTH);
     const int H = (int)cap.get(cv::CAP_PROP_FRAME_HEIGHT);
     cv::VideoWriter writer(out, cv::VideoWriter::fourcc('m','p','4','v'), fps, {W, H});
+    if (!writer.isOpened()) {
+        std::cerr << "could not open writer: " << out << "\n";
+        return 1;
+    }
 
     cv::Mat frame; int n = 0;
     while (cap.read(frame)) {
@@ -53,6 +64,10 @@ int main(int argc, char** argv) {
         y26::draw_seg(frame, segs, alpha);
         writer.write(frame);
         ++n;
+    }
+    if (n == 0) {
+        std::cerr << "video contained no readable frames: " << source << "\n";
+        return 1;
     }
     std::cout << "processed " << n << " frames, saved " << out << "\n";
     return 0;

--- a/opencv5-yolo26-football-cpp/src/detect_teams.cpp
+++ b/opencv5-yolo26-football-cpp/src/detect_teams.cpp
@@ -15,8 +15,8 @@
 // image or a video (auto-detected).
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   detect_teams --model models/yolo26n_640.onnx --imgsz 640 \
-//                --source assets/videos/stadium_wide.mp4 --teams 2 \
+//   detect_teams --model models/yolo26n_640.onnx --imgsz 640
+//                --source assets/videos/stadium_wide.mp4 --teams 2
 //                --out outputs/team_split.mp4
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"
@@ -140,6 +140,10 @@ int main(int argc, char** argv) {
     const int teams          = cli.geti("teams", 2);
     const float minh         = cli.getf("minh", 0.12f);
     const std::string out    = cli.get("out", "outputs/team_split.mp4");
+    if (teams < 2 || teams > 4) {
+        std::cerr << "--teams must be between 2 and 4\n";
+        return 1;
+    }
 
     cv::dnn::Net net = y26::build_net(model, engine);
     y26::ensure_parent_dir(out);
@@ -148,7 +152,10 @@ int main(int argc, char** argv) {
     cv::Mat img = cv::imread(source);
     if (!img.empty()) {
         process(net, img, imgsz, conf, teams, minh);
-        cv::imwrite(out, img);
+        if (!cv::imwrite(out, img)) {
+            std::cerr << "could not write output: " << out << "\n";
+            return 1;
+        }
         std::cout << "saved " << out << "\n";
         return 0;
     }
@@ -159,9 +166,17 @@ int main(int argc, char** argv) {
     const int W = (int)cap.get(cv::CAP_PROP_FRAME_WIDTH);
     const int H = (int)cap.get(cv::CAP_PROP_FRAME_HEIGHT);
     cv::VideoWriter writer(out, cv::VideoWriter::fourcc('m', 'p', '4', 'v'), fps, {W, H});
+    if (!writer.isOpened()) {
+        std::cerr << "could not open writer: " << out << "\n";
+        return 1;
+    }
 
     cv::Mat frame; int n = 0;
     while (cap.read(frame)) { process(net, frame, imgsz, conf, teams, minh); writer.write(frame); ++n; }
+    if (n == 0) {
+        std::cerr << "video contained no readable frames: " << source << "\n";
+        return 1;
+    }
     std::cout << "processed " << n << " frames, saved " << out << "\n";
     return 0;
 }

--- a/opencv5-yolo26-football-cpp/src/detect_video.cpp
+++ b/opencv5-yolo26-football-cpp/src/detect_video.cpp
@@ -6,8 +6,8 @@
 // window to keep demo clips short.
 //
 // Usage (run from the repo root; no args needed for a default demo run):
-//   detect_video --model models/yolo26n_640.onnx --imgsz 640 \
-//                --source assets/videos/match_play.mp4 --start 0 --end 12 \
+//   detect_video --model models/yolo26n_640.onnx --imgsz 640
+//                --source assets/videos/match_play.mp4 --start 0 --end 12
 //                --out outputs/video_detected.mp4
 #include "yolo26_dnn.hpp"
 #include "cli.hpp"
@@ -90,6 +90,11 @@ int main(int argc, char** argv) {
     const double wall = std::chrono::duration<double>(wall1 - wall0).count();
 
     const int n = idx - start_f;
+    if (n == 0) {
+        std::cerr << "video contained no readable frames in the requested range: "
+                  << source << "\n";
+        return 1;
+    }
     std::cout << "processed " << n << " frames | detect avg "
               << (total_ms / std::max(n, 1)) << " ms/frame | detect-only "
               << (1000.0 * n / std::max(total_ms, 1.0)) << " FPS\n";

--- a/opencv5-yolo26-football-cpp/src/yolo26_dnn.cpp
+++ b/opencv5-yolo26-football-cpp/src/yolo26_dnn.cpp
@@ -3,6 +3,7 @@
 
 #include <opencv2/imgproc.hpp>
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <stdexcept>
@@ -28,7 +29,8 @@ const std::vector<std::string> COCO_NAMES = {
 cv::dnn::Net build_net(const std::string& onnx_path, const std::string& engine) {
     int eng = cv::dnn::ENGINE_AUTO;
     std::string e = engine;
-    std::transform(e.begin(), e.end(), e.begin(), ::tolower);
+    std::transform(e.begin(), e.end(), e.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     if (e == "auto")         eng = cv::dnn::ENGINE_AUTO;
     else if (e == "new")     eng = cv::dnn::ENGINE_NEW;
     else if (e == "classic") eng = cv::dnn::ENGINE_CLASSIC;
@@ -49,6 +51,11 @@ void ensure_parent_dir(const std::string& path) {
 
 cv::Mat letterbox(const cv::Mat& img, int size, float& r, int& dw, int& dh,
                   const cv::Scalar& color) {
+    if (img.empty())
+        throw std::invalid_argument("letterbox input image must not be empty");
+    if (size <= 0)
+        throw std::invalid_argument("letterbox size must be positive");
+
     const int h = img.rows, w = img.cols;
     r = std::min(static_cast<float>(size) / h, static_cast<float>(size) / w);
     const int nw = static_cast<int>(std::round(w * r));
@@ -75,6 +82,10 @@ std::vector<Detection> detect(cv::dnn::Net& net, const cv::Mat& img,
                                           /*swapRB=*/true, /*crop=*/false);
     net.setInput(blob);
     cv::Mat out = net.forward();          // shape [1, 300, 6]
+    if (out.dims != 3 || out.type() != CV_32F || out.size[2] < 6)
+        throw std::runtime_error("unexpected detection output; expected [1,N,6] float tensor");
+    if (!out.isContinuous())
+        out = out.clone();
 
     // The output is [1, N, 6]; read N (rows) and 6 (cols) from the shape so the
     // parser does not care whether N is 300 or something else.
@@ -189,13 +200,19 @@ static const int SKELETON[][2] = {
 };
 
 std::vector<PoseDetection> detect_pose(cv::dnn::Net& net, const cv::Mat& img,
-                                       int size, float conf_thres, float kpt_thres) {
+                                       int size, float conf_thres) {
     float r; int dw, dh;
     cv::Mat padded = letterbox(img, size, r, dw, dh);
     cv::Mat blob = cv::dnn::blobFromImage(padded, 1.0 / 255.0, cv::Size(size, size),
                                           cv::Scalar(), true, false);
     net.setInput(blob);
     cv::Mat out = net.forward();            // [1, 300, 57]
+    if (out.dims != 3 || out.type() != CV_32F || out.size[2] < 9 ||
+        (out.size[2] - 6) % 3 != 0)
+        throw std::runtime_error(
+            "unexpected pose output; expected [1,N,6+3*K] float tensor");
+    if (!out.isContinuous())
+        out = out.clone();
 
     const int rows = out.size[out.dims - 2];
     const int cols = out.size[out.dims - 1];   // 57
@@ -218,11 +235,11 @@ std::vector<PoseDetection> detect_pose(cv::dnn::Net& net, const cv::Mat& img,
         }
         res.push_back(std::move(d));
     }
-    (void)kpt_thres;
     return res;
 }
 
-void draw_pose(cv::Mat& img, const std::vector<PoseDetection>& poses, bool skeleton_only) {
+void draw_pose(cv::Mat& img, const std::vector<PoseDetection>& poses,
+               bool skeleton_only, float kpt_thres) {
     int box_th, font_th; double font;
     visual_scale(img, box_th, font, font_th);
     const int limb_th = std::max(2, box_th);
@@ -237,13 +254,13 @@ void draw_pose(cv::Mat& img, const std::vector<PoseDetection>& poses, bool skele
         for (auto& e : SKELETON) {
             const auto& a = d.kpts[e[0]];
             const auto& b = d.kpts[e[1]];
-            if (a.conf < 0.3f || b.conf < 0.3f) continue;
+            if (a.conf < kpt_thres || b.conf < kpt_thres) continue;
             cv::line(img, {cvRound(a.x), cvRound(a.y)}, {cvRound(b.x), cvRound(b.y)},
                      col, limb_th, cv::LINE_AA);
         }
         // joints
         for (const auto& k : d.kpts) {
-            if (k.conf < 0.3f) continue;
+            if (k.conf < kpt_thres) continue;
             cv::circle(img, {cvRound(k.x), cvRound(k.y)}, rad, cv::Scalar(255, 255, 255),
                        cv::FILLED, cv::LINE_AA);
             cv::circle(img, {cvRound(k.x), cvRound(k.y)}, rad, col, std::max(1, box_th - 1),
@@ -278,6 +295,15 @@ std::vector<SegDetection> detect_seg(cv::dnn::Net& net, const cv::Mat& img,
         else if (o.dims == 4) proto = o;
     }
     if (dets.empty() || proto.empty()) return {};
+    if (dets.type() != CV_32F || proto.type() != CV_32F ||
+        dets.size[2] < 7 || proto.size[1] <= 0 ||
+        dets.size[2] < 6 + proto.size[1])
+        throw std::runtime_error(
+            "unexpected segmentation outputs; expected [1,N,6+M] and [1,M,H,W]");
+    if (!dets.isContinuous())
+        dets = dets.clone();
+    if (!proto.isContinuous())
+        proto = proto.clone();
 
     const int rows = dets.size[1];
     const int cols = dets.size[2];       // 38

--- a/opencv5-yolo26-football-cpp/src/yolo26_dnn.hpp
+++ b/opencv5-yolo26-football-cpp/src/yolo26_dnn.hpp
@@ -88,12 +88,11 @@ struct PoseDetection {
 };
 
 std::vector<PoseDetection> detect_pose(cv::dnn::Net& net, const cv::Mat& img,
-                                       int size = 640, float conf_thres = 0.30f,
-                                       float kpt_thres = 0.30f);
+                                       int size = 640, float conf_thres = 0.30f);
 // skeleton_only = true draws just limbs + joints (no box/label), which is what
 // you want when overlaying pose on top of segmentation masks.
 void draw_pose(cv::Mat& img, const std::vector<PoseDetection>& poses,
-               bool skeleton_only = false);
+               bool skeleton_only = false, float kpt_thres = 0.30f);
 
 // ---------------------------------------------------------------------------
 // Instance segmentation.  YOLO26-seg ONNX has two outputs:


### PR DESCRIPTION
## Summary
- enforce exact OpenCV 5 components and strict C++ warnings
- validate YOLO26 output shapes, CLI inputs, and media writes
- make model export and full reproduction fail fast and reproducible
- add pinned export requirements and ignore generated artifacts
- update the companion/root README title, canonical article URL, and versioned download link

## Verification
- strict GCC 13.3 build against exact OpenCV 5.0.0
- all six executables built with warnings as errors
- full image/video reproduction suite passed
- negative CLI validation tests passed
- generated outputs checked for dimensions, frame counts, and visual correctness