### PR TITLE
Modernize OpenCV object tracking examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 
 | Blog Post | Code|
 | ------------- |:-------------|
-| [Object Detection with OpenCV 5 in C++: YOLO26 Pose and Segmentation](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/opencv5-yolo26-football-cpp) |
 | [Object Tracking using OpenCV (C++/Python)](https://learnopencv.com/object-tracking-using-opencv-cpp-python/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/tracking) |
+| [Object Detection with OpenCV 5 in C++: YOLO26 Pose and Segmentation](https://learnopencv.com/opencv-5-cpp-object-detection-yolo26/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/opencv5-yolo26-football-cpp) |
 | [Read, Write and Display a Video using OpenCV](https://learnopencv.com/read-write-and-display-a-video-using-opencv-cpp-python/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/VideoReadWriteDisplay) |
 | [Histogram of Oriented Gradients Explained Using OpenCV](https://learnopencv.com/histogram-of-oriented-gradients/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/Histogram-of-Oriented-Gradients) |
 | [Edge Detection Using OpenCV](https://learnopencv.com/edge-detection-using-opencv/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/Edge-Detection-OpenCV) |

--- a/tracking/CMakeLists.txt
+++ b/tracking/CMakeLists.txt
@@ -1,16 +1,31 @@
 cmake_minimum_required(VERSION 3.16)
 project(object_tracking_opencv LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(OpenCV REQUIRED
-    COMPONENTS core highgui imgcodecs imgproc video videoio
+    COMPONENTS core dnn highgui imgcodecs imgproc video videoio
     OPTIONAL_COMPONENTS tracking
+)
+if(OpenCV_VERSION VERSION_LESS 4 OR OpenCV_VERSION VERSION_GREATER_EQUAL 6)
+    message(FATAL_ERROR
+        "This example supports OpenCV 4.x and 5.x, not ${OpenCV_VERSION}"
+    )
+endif()
+
+set(
+    TRACKING_MODELS_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/models"
+    CACHE PATH
+    "Directory containing the verified ONNX tracker models"
 )
 
 add_executable(object_tracker tracker.cpp)
-target_compile_features(object_tracker PRIVATE cxx_std_17)
 target_link_libraries(object_tracker PRIVATE ${OpenCV_LIBS})
 target_compile_options(object_tracker PRIVATE
-    $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wall;-Wextra;-Wpedantic>
+    $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:-Wall;-Wextra;-Wpedantic;-Werror>
 )
 
 include(CTest)
@@ -24,4 +39,53 @@ if(BUILD_TESTING)
             --max-frames=5
             --snapshot=${CMAKE_CURRENT_BINARY_DIR}/tracking-smoke.png
     )
+
+    if(
+        EXISTS "${TRACKING_MODELS_DIR}/dasiamrpn_model.onnx"
+        AND EXISTS "${TRACKING_MODELS_DIR}/dasiamrpn_kernel_cls1.onnx"
+        AND EXISTS "${TRACKING_MODELS_DIR}/dasiamrpn_kernel_r1.onnx"
+    )
+        add_test(
+            NAME tracking_dasiamrpn_smoke
+            COMMAND object_tracker
+                --input=${CMAKE_CURRENT_SOURCE_DIR}/videos/chaplin.mp4
+                --tracker=DASIAMRPN
+                --models-dir=${TRACKING_MODELS_DIR}
+                --bbox=287,23,86,320
+                --max-frames=5
+                --snapshot=${CMAKE_CURRENT_BINARY_DIR}/tracking-dasiamrpn.png
+        )
+        set_tests_properties(tracking_dasiamrpn_smoke PROPERTIES TIMEOUT 300)
+    endif()
+
+    if(
+        EXISTS "${TRACKING_MODELS_DIR}/nanotrack_backbone_sim.onnx"
+        AND EXISTS "${TRACKING_MODELS_DIR}/nanotrack_head_sim.onnx"
+    )
+        add_test(
+            NAME tracking_nano_smoke
+            COMMAND object_tracker
+                --input=${CMAKE_CURRENT_SOURCE_DIR}/videos/chaplin.mp4
+                --tracker=NANO
+                --models-dir=${TRACKING_MODELS_DIR}
+                --bbox=287,23,86,320
+                --max-frames=5
+                --snapshot=${CMAKE_CURRENT_BINARY_DIR}/tracking-nano.png
+        )
+        set_tests_properties(tracking_nano_smoke PROPERTIES TIMEOUT 300)
+    endif()
+
+    if(EXISTS "${TRACKING_MODELS_DIR}/object_tracking_vittrack_2023sep.onnx")
+        add_test(
+            NAME tracking_vit_smoke
+            COMMAND object_tracker
+                --input=${CMAKE_CURRENT_SOURCE_DIR}/videos/chaplin.mp4
+                --tracker=VIT
+                --models-dir=${TRACKING_MODELS_DIR}
+                --bbox=250,15,180,340
+                --max-frames=5
+                --snapshot=${CMAKE_CURRENT_BINARY_DIR}/tracking-vit.png
+        )
+        set_tests_properties(tracking_vit_smoke PROPERTIES TIMEOUT 300)
+    endif()
 endif()

--- a/tracking/README.md
+++ b/tracking/README.md
@@ -2,20 +2,60 @@
 
 [<img src="https://learnopencv.com/wp-content/uploads/2017/02/real-time-face-tracking.gif" alt="A bounding box follows Charlie Chaplin through a video.">](https://learnopencv.com/object-tracking-using-opencv-cpp-python/)
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/object-tracking-opencv-2026.07.27/tracking-2026.07.27.zip)
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/object-tracking-opencv-2026.07.29/tracking-2026.07.29.zip)
 
-This refreshed companion project demonstrates OpenCV's current single-object tracking API in Python 3 and C++17. It is headless by default, validates every input, and emits a machine-readable summary for tests and automation.
+[Verify the standalone ZIP with its SHA-256 checksum.](https://github.com/spmallick/learnopencv/releases/download/object-tracking-opencv-2026.07.29/tracking-2026.07.29.zip.sha256)
+
+This refreshed companion project demonstrates OpenCV's current single-object tracking API in Python 3 and C++17. It keeps the classic MIL, KCF, and CSRT paths and adds the model-backed DaSiamRPN, NanoTrack v2, and VitTrack APIs. It is headless by default, validates every input, and emits a machine-readable summary for tests and automation.
+
+Run every command below from this `tracking/` directory. In the LearnOpenCV
+repository, start with `cd tracking`; the standalone release extracts to the
+same top-level `tracking/` directory.
+
+## Requirements
+
+- Python 3.10 or newer; the publication matrix used Python 3.14.
+- OpenCV 4.14.0 or 5.0.0 with the `video` and `dnn` modules. OpenCV 4.13.0
+  remains covered by an additional regression run.
+- CMake 3.16 or newer and a C++17 compiler for the native example.
+- `ffmpeg` and `ffprobe` only when rendering comparison MP4s.
 
 ## Compatibility
 
-| Capability | OpenCV 4 | OpenCV 5 |
+| Capability | Tested exact OpenCV 4.14 builds | Tested exact OpenCV 5.0 builds |
 |---|---|---|
-| MIL tracker | Supported; default | Supported; default |
-| CSRT and KCF | Available with an OpenCV contrib build | Removed from the 5.0 API surface |
+| MIL tracker | Available; default | Available; default |
+| CSRT and KCF | Present in the tested 4.14 contrib Python build; capability-gated in C++ | Absent from the exact 5.0 builds tested here; other contrib-enabled builds and bindings may expose them |
+| DaSiamRPN | Available when the `video` and `dnn` modules plus three ONNX files are present | Same |
+| NanoTrack v2 | Available when the `video` and `dnn` modules plus two ONNX files are present | Same |
+| VitTrack | Available in OpenCV 4.9+ when the `video` and `dnn` modules plus one ONNX file are present | Same |
 | Interactive ROI | `--select-roi` | `--select-roi` |
 | Headless fixed box | `--bbox=x,y,width,height` | `--bbox=x,y,width,height` |
 
-The Python factory checks both the OpenCV 5 class-based `TrackerMIL.create()` API and OpenCV 4 factory functions. The C++ source conditionally includes the OpenCV 4 contrib tracking header while keeping MIL available through the main video module.
+The Python factory checks the tracker factories and classes actually exposed by the installed package. The C++ source conditionally includes the contrib tracking header whenever it is available. MIL and the three model-backed trackers live in the main `video` module; the model-backed implementations also require `dnn`. This capability check is more reliable than assuming that every package with the same major version contains the same trackers.
+
+## Download the DNN tracker models
+
+Classic MIL, KCF, and CSRT do not need external models. Download one model set or all three from immutable upstream revisions:
+
+```bash
+python download_models.py --tracker nano
+python download_models.py --tracker vit
+python download_models.py --tracker dasiamrpn
+
+# Or fetch all six files:
+python download_models.py --tracker all
+```
+
+The downloader writes to `models/` by default, streams into a temporary file, and checks both the exact size and SHA-256 digest before replacing anything. It can also target another directory with `--models-dir /path/to/models`; pass the same directory to `tracker.py` or `object_tracker`.
+
+| Tracker | Required local files | Total download |
+|---|---|---:|
+| DaSiamRPN | `dasiamrpn_model.onnx`, `dasiamrpn_kernel_cls1.onnx`, `dasiamrpn_kernel_r1.onnx` | 154.35 MiB |
+| NanoTrack v2 | `nanotrack_backbone_sim.onnx`, `nanotrack_head_sim.onnx` | 1.70 MiB |
+| VitTrack | `object_tracking_vittrack_2023sep.onnx` | 0.68 MiB |
+
+The DaSiamRPN and VitTrack files come from pinned revisions of the [OpenCV Model Zoo](https://github.com/opencv/opencv_zoo). NanoTrack v2 comes from the model directory referenced by OpenCV's [TrackerNano API](https://docs.opencv.org/4.x/d8/d69/classcv_1_1TrackerNano.html). Review the upstream model licenses before redistributing the binaries.
 
 ## Run the Python example
 
@@ -27,24 +67,171 @@ python tracker.py --tracker MIL --max-frames 60 \
 
 The included Chaplin clip uses the tested initial box `287,23,86,320`. For another video, either pass `--bbox` or add `--select-roi --display`.
 
+After downloading the models, run each deep-learning tracker with the same CLI:
+
+```bash
+python tracker.py --tracker DASIAMRPN --models-dir models \
+  --bbox 287,23,86,320 --max-frames 60 --output dasiamrpn.avi
+
+python tracker.py --tracker NANO --models-dir models \
+  --bbox 287,23,86,320 --max-frames 60 --output nano.avi
+
+# VitTrack is more stable on this clip when the initial box covers the full body.
+python tracker.py --tracker VIT --models-dir models \
+  --bbox 250,15,180,340 --max-frames 60 --output vit.avi
+```
+
+These are still single-object trackers, not detectors. You must provide the initial target box. A successful update or high internal score does not prove that the box still covers the correct identity.
+
+## Render a tracker comparison video
+
+`render_tracker_comparison.py` initializes every requested tracker on the same
+source frame and ROI. By default, it creates a 1280x720 H.264 MP4 with a
+side-by-side section followed by one full-screen replay per tracker. Pass
+`--together-only` to keep only the simultaneous comparison grid, with no title
+card or sequential replays. Every run also creates a JSON file containing the
+exact source-frame range, input fingerprint, trajectories, and output
+verification.
+
+The bundled Charlie Chaplin comparison uses `videos/chaplin.mp4`. Its SHA-256
+is `ce6154a3a0223861cdc6b1a0301e650e55cff7132e586845924699b9ea6162dc`;
+the source is 640x360 at OpenCV's reported 29.719556780471343 fps. Although
+the container header reports 172 frames, exactly 150 frames decode, numbered
+0 through 149. The comparison shows the turn away from the camera, rear view,
+return, and left-edge boundary clipping without claiming that a returned box
+still covers the target correctly.
+
+The classic single-tracker example keeps its tested narrow ROI
+`287,23,86,320` unchanged. This comparison alone uses the wider full-body ROI
+`250,15,180,340` as a fair shared initialization for all four trackers,
+consistent with the documented VitTrack guidance above.
+
+```bash
+python render_tracker_comparison.py \
+  --input videos/chaplin.mp4 \
+  --output charlie-chaplin-opencv5-four-trackers.mp4 \
+  --models-dir models \
+  --trackers MIL,DASIAMRPN,NANO,VIT \
+  --start-frame 0 --end-frame 149 \
+  --bbox 250,15,180,340 \
+  --scene-title "Charlie Chaplin Comparison" \
+  --together-only
+```
+
+The verified street result uses [street footage by tiburi on
+Pixabay](https://pixabay.com/videos/street-walk-urban-city-walking-5025/),
+saved locally as `pixabay-street-5025-182666664-large.mp4`. The exact source is
+1920x1080, 30000/1001 fps, and 330 frames; its SHA-256 is
+`f4a7be9346410b79dc0b526ab4ec5c0c58589865b48136d2b3f7adbd240f50d7`.
+This is intentionally a limitation example: people and bicycles occlude the
+selected pedestrian, and all four single-object trackers have limited success
+once the target becomes ambiguous.
+
+```bash
+python render_tracker_comparison.py \
+  --input pixabay-street-5025-182666664-large.mp4 \
+  --output street-scene-opencv5-four-trackers.mp4 \
+  --models-dir models \
+  --trackers MIL,DASIAMRPN,NANO,VIT \
+  --start-frame 0 --end-frame 329 \
+  --bbox 351,321,57,249 \
+  --scene-title "Street Occlusion Limitation" \
+  --together-only
+```
+
+The verified car result uses [racing footage by DistillVideos on
+Pixabay](https://pixabay.com/videos/car-racing-motor-sports-action-74/),
+saved locally as `pixabay-car-74.mp4`. The exact source is 1280x720,
+24000/1001 fps, and 907 frames; its SHA-256 is
+`cc789c74e0c007d531ea872f76b243187edf984a3eeaa4074b9534679b03f82c`.
+This is also a limitation example: fast motion and rapid appearance,
+viewpoint, and scale changes challenge the trackers during the original
+65-frame sequence.
+
+```bash
+python render_tracker_comparison.py \
+  --input pixabay-car-74.mp4 \
+  --output race-car-opencv5-four-trackers.mp4 \
+  --models-dir models \
+  --trackers MIL,DASIAMRPN,NANO,VIT \
+  --start-frame 256 --end-frame 320 \
+  --bbox 734,420,300,100 \
+  --scene-title "Race Car Motion Limitation" \
+  --together-only
+```
+
+Each command places MIL, DaSiamRPN, NanoTrack, and VitTrack in the same 2x2
+panel for exactly the selected source frames. Both frame arguments are
+zero-based and inclusive; omit `--end-frame` to use the rest of a video. Run
+`python render_tracker_comparison.py --help` for encoding and overwrite
+options. The renderer requires `ffmpeg` and `ffprobe`. Its status labels
+distinguish the initial ROI, an update that returned a box, a returned box that
+extends off frame, and an update that returned no box. A returned box is not a
+claim that the tracker still covers the correct object.
+
 ## Build and run C++17
 
 ```bash
-cmake -S . -B build -DBUILD_TESTING=ON
+cmake -S . -B build -DBUILD_TESTING=ON \
+  -DTRACKING_MODELS_DIR="$PWD/models"
 cmake --build build --parallel
 ./build/object_tracker --tracker=MIL --max-frames=60 \
   --output=tracked.avi --snapshot=tracked.png
 ctest --test-dir build --output-on-failure
 ```
 
+To select a particular OpenCV installation, pass its package directory:
+
+```bash
+cmake -S . -B build-opencv-5 \
+  -DOpenCV_DIR=/path/to/opencv-5/lib/cmake/opencv5 \
+  -DBUILD_TESTING=ON \
+  -DTRACKING_MODELS_DIR="$PWD/models"
+```
+
+Use `--tracker=DASIAMRPN`, `--tracker=NANO`, or `--tracker=VIT` and add `--models-dir=models` to run the C++ model-backed paths. CMake requires OpenCV's `dnn` component so a build that cannot load these networks fails during configuration instead of later in the tutorial.
+
 ## Tests
 
 ```bash
 python -m pip install -r requirements-test.txt
 python -m pytest tests -q
+
+# Include the downloaded-model integration tests:
+TRACKING_MODELS_DIR="$PWD/models" python -m pytest tests -q
 ```
 
-The smoke tests validate parsing, missing-input errors, tracker creation, five successful updates on the bundled video, the annotated output video, and the saved result frame. The project was tested with Python OpenCV 4.13 and exact OpenCV 5.0.0, plus exact native C++ OpenCV 4.13.0 and exact 5.0.0.
+The offline tests validate parsing, missing-input and missing-model errors, all six pinned model records, atomic download behavior, classic tracker creation, five successful updates on the bundled video, the annotated output video, and the saved result frame. When `TRACKING_MODELS_DIR` is set, the suite also creates DaSiamRPN, NanoTrack, and VitTrack and processes five real updates with each one.
+
+With the verified model directory enabled, all 17 Python tests passed on exact OpenCV 4.14.0 and 5.0.0, with an additional 4.13.0 regression run. The suite includes coverage for the four-panel-only timeline and failure-injection coverage that verifies the comparison renderer restores the prior MP4/JSON pair when final installation is interrupted. The native C++ build and all four CTests (MIL plus the three model-backed trackers) also passed against exact OpenCV 4.14.0 and 5.0.0 builds containing `dnn`, with the same four CTests repeated on 4.13.0.
+
+## Standalone release contents
+
+The immutable release ZIP contains exactly these 15 tracked files under one
+top-level `tracking/` directory. ONNX models, caches, generated videos, and
+build products are not included.
+
+```text
+tracking/
+├── .gitignore
+├── CMakeLists.txt
+├── README.md
+├── download_models.py
+├── models/
+│   ├── .gitignore
+│   └── README.md
+├── render_tracker_comparison.py
+├── requirements-test.txt
+├── requirements.txt
+├── tests/
+│   ├── test_download_models.py
+│   ├── test_render_tracker_comparison.py
+│   └── test_tracker.py
+├── tracker.cpp
+├── tracker.py
+└── videos/
+    └── chaplin.mp4
+```
 
 
 ---

--- a/tracking/download_models.py
+++ b/tracking/download_models.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Download and verify the ONNX files used by OpenCV's DNN trackers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+
+
+MODELS_DIR = Path(__file__).resolve().parent / "models"
+DOWNLOAD_TIMEOUT_SECONDS = 60
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+
+# Every URL is pinned to an upstream revision. Exact byte counts and SHA-256
+# digests are checked before a temporary download can replace a model file.
+MODEL_GROUPS = {
+    "dasiamrpn": {
+        "dasiamrpn_model.onnx": (
+            "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+            "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+            "models/object_tracking_dasiamrpn/"
+            "object_tracking_dasiamrpn_model_2021nov.onnx",
+            "e88370b85cbad914a5eb414d9d9e0820f87fd0cd89b65205a766174206c35719",
+            91040894,
+        ),
+        "dasiamrpn_kernel_cls1.onnx": (
+            "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+            "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+            "models/object_tracking_dasiamrpn/"
+            "object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx",
+            "d85b03e2aeded6cc9be945dfdc3ed6b8f4151f101e485037b6c5d5b36a6c4204",
+            23603598,
+        ),
+        "dasiamrpn_kernel_r1.onnx": (
+            "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+            "fef72f8fa7c52eaf116d3df358d24e6e959ada0e/"
+            "models/object_tracking_dasiamrpn/"
+            "object_tracking_dasiamrpn_kernel_r1_2021nov.onnx",
+            "082c85d231b88b97a1b2a50e73b640a332c5d98d7c1d80b5da9ab534fa7a9e5b",
+            47206788,
+        ),
+    },
+    "nano": {
+        "nanotrack_backbone_sim.onnx": (
+            "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/"
+            "248663fde6bf7c40190cf10ee396d5662919ecd3/"
+            "NanoTrack/models/nanotrackv2/nanotrack_backbone_sim.onnx",
+            "530bdd0cd00f19afab79a863e71ba71e3312395a5dc9151af675082bdaaa2fc4",
+            1056849,
+        ),
+        "nanotrack_head_sim.onnx": (
+            "https://raw.githubusercontent.com/HonglinChu/SiamTrackers/"
+            "248663fde6bf7c40190cf10ee396d5662919ecd3/"
+            "NanoTrack/models/nanotrackv2/nanotrack_head_sim.onnx",
+            "0d8c0637be849f092cc7236cae02e55c8b9455ebe37ba50601d6115db4247cd9",
+            726198,
+        ),
+    },
+    "vit": {
+        "object_tracking_vittrack_2023sep.onnx": (
+            "https://media.githubusercontent.com/media/opencv/opencv_zoo/"
+            "47534e27c9851bb1128ccc0102f1145e27f23f98/"
+            "models/object_tracking_vittrack/"
+            "object_tracking_vittrack_2023sep.onnx",
+            "2990f0b7cd44d92afa48cd97db6de7be113fc1d9594fddb74e2725c10478e91d",
+            714726,
+        ),
+    },
+}
+
+
+def sha256_of(path: Path) -> str:
+    """Return a file's SHA-256 digest without loading it all into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(DOWNLOAD_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_one(
+    name: str,
+    url: str,
+    expected_sha: str,
+    expected_size: int,
+    *,
+    force: bool,
+    models_dir: Path,
+) -> bool:
+    """Atomically download and verify one model."""
+    destination = models_dir / name
+    if destination.exists() and not force:
+        try:
+            existing_size = destination.stat().st_size
+            existing_sha = (
+                sha256_of(destination) if existing_size == expected_size else None
+            )
+        except OSError as error:
+            print(f"[warn] cannot verify existing {name}: {error}")
+        else:
+            if existing_size == expected_size and existing_sha == expected_sha:
+                print(f"[skip] {name} already verified")
+                return True
+            print(f"[warn] {name} is invalid; downloading a verified replacement")
+
+    temporary_path: Path | None = None
+    print(f"[get ] {name}")
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=models_dir,
+            prefix=f".{name}.",
+            suffix=".part",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "LearnOpenCV-model-downloader/1.0"}
+        )
+        with urllib.request.urlopen(
+            request, timeout=DOWNLOAD_TIMEOUT_SECONDS
+        ) as response:
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    advertised_size = int(content_length)
+                except ValueError:
+                    advertised_size = None
+                if advertised_size is not None and advertised_size > expected_size:
+                    print(
+                        f"[fail] {name}: server advertised {advertised_size} bytes; "
+                        f"expected {expected_size}"
+                    )
+                    return False
+
+            downloaded_size = 0
+            with temporary_path.open("wb") as output:
+                while True:
+                    chunk = response.read(DOWNLOAD_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    downloaded_size += len(chunk)
+                    if downloaded_size > expected_size:
+                        print(
+                            f"[fail] {name}: response exceeded "
+                            f"{expected_size} bytes"
+                        )
+                        return False
+                    output.write(chunk)
+
+        if downloaded_size != expected_size:
+            print(
+                f"[fail] {name}: received {downloaded_size} bytes; "
+                f"expected {expected_size}"
+            )
+            return False
+        actual_sha = sha256_of(temporary_path)
+        if actual_sha != expected_sha:
+            print(f"[fail] {name}: checksum mismatch ({actual_sha})")
+            return False
+        temporary_path.replace(destination)
+    except (OSError, urllib.error.URLError) as error:
+        print(f"[fail] {name}: {error}")
+        return False
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError as error:
+                print(f"[warn] cannot remove partial file {temporary_path}: {error}")
+
+    print(f"[ ok ] {name} sha256={expected_sha}")
+    return True
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tracker",
+        choices=("all", *MODEL_GROUPS),
+        default="all",
+        help="download one tracker model set or all three (default: all)",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=MODELS_DIR,
+        help=f"destination directory (default: {MODELS_DIR})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="download again even when a verified file is already present",
+    )
+    return parser
+
+
+def main() -> int:
+    arguments = build_parser().parse_args()
+    try:
+        arguments.models_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        print(f"[fail] cannot create {arguments.models_dir}: {error}")
+        return 1
+
+    groups = MODEL_GROUPS if arguments.tracker == "all" else {
+        arguments.tracker: MODEL_GROUPS[arguments.tracker]
+    }
+    results = []
+    for files in groups.values():
+        for name, (url, expected_sha, expected_size) in files.items():
+            results.append(
+                download_one(
+                    name,
+                    url,
+                    expected_sha,
+                    expected_size,
+                    force=arguments.force,
+                    models_dir=arguments.models_dir,
+                )
+            )
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tracking/models/.gitignore
+++ b/tracking/models/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/tracking/models/README.md
+++ b/tracking/models/README.md
@@ -1,0 +1,5 @@
+# Tracker models
+
+Run `python download_models.py --tracker all` from the parent directory to
+download the six checksum-pinned ONNX files used by DaSiamRPN, NanoTrack v2,
+and VitTrack. The model binaries are intentionally ignored by Git.

--- a/tracking/render_tracker_comparison.py
+++ b/tracking/render_tracker_comparison.py
@@ -1,0 +1,1460 @@
+#!/usr/bin/env python3
+"""Render a reproducible OpenCV tracker comparison as a publishable MP4.
+
+The selected source-frame range is inclusive. Every tracker is initialized on
+the same first frame and bounding box. By default, the output first shows the
+trackers together, then replays the same source frames once per tracker. Pass
+``--together-only`` to emit only the simultaneous comparison grid.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Iterator, Sequence
+
+import cv2
+import numpy as np
+
+from tracker import (
+    DEFAULT_MODELS_DIR,
+    MODEL_TRACKER_FILES,
+    create_tracker,
+    parse_bbox,
+)
+
+
+OUTPUT_WIDTH = 1280
+OUTPUT_HEIGHT = 720
+SUPPORTED_TRACKERS = ("MIL", "DASIAMRPN", "NANO", "VIT")
+TRACKER_ALIASES = {
+    "MIL": "MIL",
+    "DASIAMRPN": "DASIAMRPN",
+    "DA_SIAM_RPN": "DASIAMRPN",
+    "NANO": "NANO",
+    "NANOTRACK": "NANO",
+    "NANOTRACKV2": "NANO",
+    "VIT": "VIT",
+    "VITTRACK": "VIT",
+}
+DISPLAY_NAMES = {
+    "MIL": "MIL",
+    "DASIAMRPN": "DaSiamRPN",
+    "NANO": "NanoTrack",
+    "VIT": "VitTrack",
+}
+# BGR values used for both the panel accent and the tracked bounding box.
+TRACKER_COLORS = {
+    "MIL": (235, 178, 52),
+    "DASIAMRPN": (45, 133, 245),
+    "NANO": (94, 204, 92),
+    "VIT": (216, 105, 196),
+}
+BACKGROUND = (22, 27, 34)
+PANEL_BACKGROUND = (11, 16, 22)
+TEXT = (244, 246, 248)
+MUTED_TEXT = (174, 183, 194)
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    path: Path
+    width: int
+    height: int
+    fps: float
+    reported_frame_count: int | None
+    start_frame: int
+    end_frame: int
+    selected_frame_count: int
+    frame_hashes: tuple[str, ...]
+    selected_sequence_sha256: str
+    file_sha256: str
+
+
+@dataclass
+class TrackResult:
+    name: str
+    entries: list[dict[str, Any]]
+    box_returned_updates: int
+    update_count: int
+    mean_tracking_ms: float | None
+
+
+def parse_trackers(value: str) -> tuple[str, ...]:
+    """Parse a comma-separated tracker list and normalize documented aliases."""
+    raw_names = [item.strip() for item in value.split(",") if item.strip()]
+    if not raw_names:
+        raise argparse.ArgumentTypeError("Provide at least one tracker")
+
+    normalized: list[str] = []
+    for raw_name in raw_names:
+        key = raw_name.upper().replace("-", "").replace(" ", "")
+        name = TRACKER_ALIASES.get(key)
+        if name is None:
+            choices = ", ".join(SUPPORTED_TRACKERS)
+            raise argparse.ArgumentTypeError(
+                f"Unsupported tracker '{raw_name}'. Choose from: {choices}"
+            )
+        if name in normalized:
+            raise argparse.ArgumentTypeError(
+                f"Tracker '{DISPLAY_NAMES[name]}' was listed more than once"
+            )
+        normalized.append(name)
+
+    if len(normalized) > 4:
+        raise argparse.ArgumentTypeError("At most four trackers can be compared")
+    return tuple(normalized)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def model_file_provenance(
+    tracker_names: Sequence[str], models_dir: Path
+) -> list[dict[str, Any]]:
+    """Fingerprint every ONNX file used by the requested tracker set."""
+    records: list[dict[str, Any]] = []
+    for tracker_name in tracker_names:
+        for filename in MODEL_TRACKER_FILES.get(tracker_name, ()):
+            path = models_dir / filename
+            if not path.is_file():
+                raise FileNotFoundError(
+                    f"{DISPLAY_NAMES[tracker_name]} model is missing: {path}"
+                )
+            records.append(
+                {
+                    "tracker": tracker_name,
+                    "filename": filename,
+                    "size_bytes": path.stat().st_size,
+                    "sha256": _sha256_file(path),
+                }
+            )
+    return records
+
+
+def _frame_digest(frame: np.ndarray) -> str:
+    return hashlib.blake2b(memoryview(frame), digest_size=16).hexdigest()
+
+
+def _valid_fps(value: float) -> bool:
+    return math.isfinite(value) and value > 0
+
+
+def inspect_source(
+    input_path: Path,
+    start_frame: int,
+    end_frame: int | None,
+    bbox: tuple[int, int, int, int],
+) -> SourceInfo:
+    """Decode and fingerprint the exact selected source-frame sequence."""
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Input video does not exist: {input_path}")
+    if start_frame < 0:
+        raise ValueError("--start-frame must be zero or greater")
+    if end_frame is not None and end_frame < start_frame:
+        raise ValueError("--end-frame must be greater than or equal to --start-frame")
+
+    capture = cv2.VideoCapture(str(input_path))
+    if not capture.isOpened():
+        raise RuntimeError(f"OpenCV could not open the input video: {input_path}")
+
+    frame_hashes: list[str] = []
+    sequence_digest = hashlib.sha256()
+    width = height = 0
+    last_decoded = -1
+    try:
+        fps = float(capture.get(cv2.CAP_PROP_FPS))
+        if not _valid_fps(fps):
+            raise RuntimeError(
+                f"The input video reports an invalid frame rate ({fps!r})"
+            )
+        reported_count_value = float(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+        reported_frame_count = (
+            int(round(reported_count_value))
+            if math.isfinite(reported_count_value) and reported_count_value > 0
+            else None
+        )
+
+        frame_index = 0
+        while True:
+            ok, frame = capture.read()
+            if not ok or frame is None:
+                break
+            last_decoded = frame_index
+
+            current_height, current_width = frame.shape[:2]
+            if width == 0:
+                width, height = current_width, current_height
+            elif (current_width, current_height) != (width, height):
+                raise RuntimeError(
+                    "The source frame size changes inside the selected video"
+                )
+
+            if frame_index >= start_frame and (
+                end_frame is None or frame_index <= end_frame
+            ):
+                digest = _frame_digest(frame)
+                frame_hashes.append(digest)
+                sequence_digest.update(bytes.fromhex(digest))
+
+            if end_frame is not None and frame_index >= end_frame:
+                break
+            frame_index += 1
+    finally:
+        capture.release()
+
+    if last_decoded < start_frame or not frame_hashes:
+        raise RuntimeError(
+            f"The source ended at frame {last_decoded}; frame {start_frame} "
+            "could not be decoded"
+        )
+    if end_frame is not None and last_decoded < end_frame:
+        raise RuntimeError(
+            f"The requested inclusive end frame is {end_frame}, but decoding "
+            f"stopped at frame {last_decoded}"
+        )
+
+    actual_end = start_frame + len(frame_hashes) - 1
+    x, y, box_width, box_height = bbox
+    if (
+        x < 0
+        or y < 0
+        or box_width <= 0
+        or box_height <= 0
+        or x + box_width > width
+        or y + box_height > height
+    ):
+        raise ValueError(
+            f"Initial bounding box {bbox} lies outside the {width}x{height} "
+            f"frame at source frame {start_frame}"
+        )
+
+    return SourceInfo(
+        path=input_path,
+        width=width,
+        height=height,
+        fps=fps,
+        reported_frame_count=reported_frame_count,
+        start_frame=start_frame,
+        end_frame=actual_end,
+        selected_frame_count=len(frame_hashes),
+        frame_hashes=tuple(frame_hashes),
+        selected_sequence_sha256=sequence_digest.hexdigest(),
+        file_sha256=_sha256_file(input_path),
+    )
+
+
+def selected_frames(source: SourceInfo) -> Iterator[tuple[int, int, np.ndarray]]:
+    """Yield the fingerprint-verified selected frames from a fresh decoder."""
+    capture = cv2.VideoCapture(str(source.path))
+    if not capture.isOpened():
+        raise RuntimeError(f"OpenCV could not reopen input video: {source.path}")
+
+    selected_offset = 0
+    try:
+        for frame_index in range(source.end_frame + 1):
+            ok, frame = capture.read()
+            if not ok or frame is None:
+                raise RuntimeError(
+                    f"Decoding failed at source frame {frame_index}; expected "
+                    f"frames through {source.end_frame}"
+                )
+            if frame_index < source.start_frame:
+                continue
+
+            if frame.shape[:2] != (source.height, source.width):
+                raise RuntimeError(
+                    f"Frame {frame_index} changed size during a repeated decode"
+                )
+            digest = _frame_digest(frame)
+            expected = source.frame_hashes[selected_offset]
+            if digest != expected:
+                raise RuntimeError(
+                    f"Frame {frame_index} decoded inconsistently across passes"
+                )
+            yield selected_offset, frame_index, frame
+            selected_offset += 1
+    finally:
+        capture.release()
+
+    if selected_offset != source.selected_frame_count:
+        raise RuntimeError(
+            f"Decoded {selected_offset} selected frames; expected "
+            f"{source.selected_frame_count}"
+        )
+
+
+def _finite_bbox(values: Sequence[float]) -> tuple[float, float, float, float]:
+    if len(values) != 4:
+        raise RuntimeError(f"Tracker returned a {len(values)}-value bounding box")
+    bbox = tuple(float(value) for value in values)
+    if not all(math.isfinite(value) for value in bbox):
+        raise RuntimeError(f"Tracker returned a non-finite bounding box: {bbox}")
+    if bbox[2] <= 0 or bbox[3] <= 0:
+        raise RuntimeError(f"Tracker returned a non-positive bounding box: {bbox}")
+    return bbox
+
+
+def _tracking_score(tracker_instance: Any) -> float | None:
+    getter = getattr(tracker_instance, "getTrackingScore", None)
+    if getter is None:
+        return None
+    try:
+        score = float(getter())
+    except (AttributeError, TypeError, ValueError, cv2.error):
+        return None
+    return score if math.isfinite(score) else None
+
+
+def _json_bbox(bbox: Sequence[float] | None) -> list[float] | None:
+    if bbox is None:
+        return None
+    return [round(float(value), 3) for value in bbox]
+
+
+def _bbox_outside_source(
+    bbox: Sequence[float], frame_width: int, frame_height: int
+) -> bool:
+    x, y, width, height = bbox
+    return (
+        x < 0
+        or y < 0
+        or x + width > frame_width
+        or y + height > frame_height
+    )
+
+
+def track_source(
+    source: SourceInfo,
+    tracker_name: str,
+    bbox: tuple[int, int, int, int],
+    models_dir: Path,
+) -> TrackResult:
+    """Track one target and retain a result for every selected source frame."""
+    try:
+        tracker_instance = create_tracker(tracker_name, models_dir)
+    except (FileNotFoundError, RuntimeError, ValueError, cv2.error) as exc:
+        raise RuntimeError(
+            f"Could not create {DISPLAY_NAMES[tracker_name]}: {exc}"
+        ) from exc
+
+    entries: list[dict[str, Any]] = []
+    box_returned_updates = 0
+    update_count = 0
+    elapsed_total = 0.0
+    try:
+        for offset, frame_index, frame in selected_frames(source):
+            if offset == 0:
+                try:
+                    initialized = tracker_instance.init(frame, bbox)
+                except cv2.error as exc:
+                    raise RuntimeError(
+                        f"{DISPLAY_NAMES[tracker_name]} initialization raised "
+                        f"an OpenCV error at source frame {frame_index}: {exc}"
+                    ) from exc
+                if initialized is False:
+                    raise RuntimeError(
+                        f"{DISPLAY_NAMES[tracker_name]} initialization failed "
+                        f"at source frame {frame_index}"
+                    )
+                initial_bbox = _finite_bbox(bbox)
+                score = _tracking_score(tracker_instance)
+                entries.append(
+                    {
+                        "source_frame": frame_index,
+                        "phase": "initialization",
+                        "box_returned": None,
+                        "bbox_xywh": _json_bbox(initial_bbox),
+                        "bbox_off_frame": False,
+                        "tracking_score": (
+                            round(score, 6) if score is not None else None
+                        ),
+                        "tracking_ms": None,
+                    }
+                )
+                continue
+
+            started = perf_counter()
+            try:
+                found, updated_bbox = tracker_instance.update(frame)
+            except cv2.error as exc:
+                raise RuntimeError(
+                    f"{DISPLAY_NAMES[tracker_name]} update raised an OpenCV "
+                    f"error at source frame {frame_index}: {exc}"
+                ) from exc
+            elapsed_ms = 1000.0 * (perf_counter() - started)
+            elapsed_total += elapsed_ms
+            update_count += 1
+
+            current_bbox = _finite_bbox(updated_bbox) if found else None
+            if found:
+                box_returned_updates += 1
+            score = _tracking_score(tracker_instance)
+            entries.append(
+                {
+                    "source_frame": frame_index,
+                    "phase": "update",
+                    "box_returned": bool(found),
+                    "bbox_xywh": _json_bbox(current_bbox),
+                    "bbox_off_frame": (
+                        _bbox_outside_source(
+                            current_bbox, source.width, source.height
+                        )
+                        if current_bbox is not None
+                        else None
+                    ),
+                    "tracking_score": (
+                        round(score, 6) if score is not None else None
+                    ),
+                    "tracking_ms": round(elapsed_ms, 3),
+                }
+            )
+    finally:
+        del tracker_instance
+        gc.collect()
+
+    if len(entries) != source.selected_frame_count:
+        raise RuntimeError(
+            f"{DISPLAY_NAMES[tracker_name]} produced {len(entries)} results; "
+            f"expected {source.selected_frame_count}"
+        )
+    return TrackResult(
+        name=tracker_name,
+        entries=entries,
+        box_returned_updates=box_returned_updates,
+        update_count=update_count,
+        mean_tracking_ms=(
+            elapsed_total / update_count if update_count > 0 else None
+        ),
+    )
+
+
+def _put_text(
+    image: np.ndarray,
+    text: str,
+    origin: tuple[int, int],
+    *,
+    scale: float,
+    color: tuple[int, int, int] = TEXT,
+    thickness: int = 1,
+) -> None:
+    cv2.putText(
+        image,
+        text,
+        origin,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        scale,
+        color,
+        thickness,
+        cv2.LINE_AA,
+    )
+
+
+def _contain_frame(
+    canvas: np.ndarray,
+    frame: np.ndarray,
+    rect: tuple[int, int, int, int],
+) -> tuple[float, int, int, int, int]:
+    x, y, width, height = rect
+    canvas[y : y + height, x : x + width] = PANEL_BACKGROUND
+    frame_height, frame_width = frame.shape[:2]
+    scale = min(width / frame_width, height / frame_height)
+    render_width = max(1, int(round(frame_width * scale)))
+    render_height = max(1, int(round(frame_height * scale)))
+    resized = cv2.resize(
+        frame,
+        (render_width, render_height),
+        interpolation=cv2.INTER_AREA if scale < 1 else cv2.INTER_LINEAR,
+    )
+    render_x = x + (width - render_width) // 2
+    render_y = y + (height - render_height) // 2
+    canvas[
+        render_y : render_y + render_height,
+        render_x : render_x + render_width,
+    ] = resized
+    return scale, render_x, render_y, render_width, render_height
+
+
+def _draw_panel(
+    canvas: np.ndarray,
+    frame: np.ndarray,
+    rect: tuple[int, int, int, int],
+    tracker_name: str,
+    entry: dict[str, Any],
+    *,
+    compact: bool,
+) -> None:
+    x, y, width, height = rect
+    color = TRACKER_COLORS[tracker_name]
+    scale, render_x, render_y, render_width, render_height = _contain_frame(
+        canvas, frame, rect
+    )
+    cv2.rectangle(
+        canvas,
+        (x + 1, y + 1),
+        (x + width - 2, y + height - 2),
+        color,
+        2,
+        cv2.LINE_AA,
+    )
+
+    bbox = entry["bbox_xywh"]
+    box_available = entry["phase"] == "initialization" or entry["box_returned"]
+    if box_available and bbox is not None:
+        box_x, box_y, box_width, box_height = bbox
+        left = int(round(render_x + box_x * scale))
+        top = int(round(render_y + box_y * scale))
+        right = int(round(render_x + (box_x + box_width) * scale))
+        bottom = int(round(render_y + (box_y + box_height) * scale))
+        image_left = render_x
+        image_top = render_y
+        image_right = render_x + render_width - 1
+        image_bottom = render_y + render_height - 1
+        left = max(image_left, min(image_right, left))
+        right = max(image_left, min(image_right, right))
+        top = max(image_top, min(image_bottom, top))
+        bottom = max(image_top, min(image_bottom, bottom))
+        if right > left and bottom > top:
+            cv2.rectangle(
+                canvas,
+                (left, top),
+                (right, bottom),
+                color,
+                4 if not compact else 3,
+                cv2.LINE_AA,
+            )
+
+    header_height = 42 if compact else 54
+    overlay = canvas.copy()
+    cv2.rectangle(
+        overlay,
+        (x + 2, y + 2),
+        (x + width - 3, y + header_height),
+        (5, 8, 12),
+        -1,
+    )
+    cv2.addWeighted(overlay, 0.78, canvas, 0.22, 0, canvas)
+    cv2.rectangle(
+        canvas,
+        (x + 2, y + 2),
+        (x + 9, y + header_height),
+        color,
+        -1,
+    )
+    label_scale = 0.68 if compact else 0.9
+    _put_text(
+        canvas,
+        DISPLAY_NAMES[tracker_name],
+        (x + 20, y + (29 if compact else 37)),
+        scale=label_scale,
+        thickness=2,
+    )
+    # OpenCV's Boolean only says that an update returned a box; the box can
+    # still drift to the wrong object, which the video intentionally exposes.
+    if entry["phase"] == "initialization":
+        status = "INITIAL ROI"
+    elif not entry["box_returned"]:
+        status = "NO BOX"
+    elif entry["bbox_off_frame"]:
+        status = "BOX OFF FRAME"
+    else:
+        status = "BOX RETURNED"
+    status_scale = 0.43 if compact else 0.58
+    status_size = cv2.getTextSize(
+        status, cv2.FONT_HERSHEY_SIMPLEX, status_scale, 1
+    )[0]
+    _put_text(
+        canvas,
+        status,
+        (x + width - status_size[0] - 16, y + (28 if compact else 36)),
+        scale=status_scale,
+        color=(
+            (106, 190, 255)
+            if entry["bbox_off_frame"]
+            else (
+                (178, 225, 186)
+                if box_available
+                else (126, 126, 245)
+            )
+        ),
+        thickness=1,
+    )
+    frame_label = f"Source frame {entry['source_frame']}"
+    _put_text(
+        canvas,
+        frame_label,
+        (x + 14, y + height - 13),
+        scale=0.42 if compact else 0.55,
+        color=MUTED_TEXT,
+        thickness=1,
+    )
+
+
+def _grid_rectangles(count: int) -> tuple[tuple[int, int, int, int], ...]:
+    if count == 1:
+        return ((0, 0, OUTPUT_WIDTH, OUTPUT_HEIGHT),)
+    if count == 2:
+        return ((0, 180, 640, 360), (640, 180, 640, 360))
+    if count == 3:
+        return (
+            (320, 0, 640, 360),
+            (0, 360, 640, 360),
+            (640, 360, 640, 360),
+        )
+    if count == 4:
+        return (
+            (0, 0, 640, 360),
+            (640, 0, 640, 360),
+            (0, 360, 640, 360),
+            (640, 360, 640, 360),
+        )
+    raise ValueError("The comparison layout supports one to four trackers")
+
+
+def _title_card(
+    title: str,
+    subtitle: str,
+    tracker_names: Sequence[str],
+) -> np.ndarray:
+    canvas = np.full(
+        (OUTPUT_HEIGHT, OUTPUT_WIDTH, 3), BACKGROUND, dtype=np.uint8
+    )
+    cv2.rectangle(canvas, (0, 0), (OUTPUT_WIDTH, 10), (52, 180, 235), -1)
+    cv2.rectangle(
+        canvas,
+        (96, 196),
+        (1184, 520),
+        (29, 35, 43),
+        -1,
+        cv2.LINE_AA,
+    )
+    title_scale = 1.35 if len(title) < 38 else 1.05
+    title_size = cv2.getTextSize(
+        title, cv2.FONT_HERSHEY_SIMPLEX, title_scale, 2
+    )[0]
+    _put_text(
+        canvas,
+        title,
+        ((OUTPUT_WIDTH - title_size[0]) // 2, 310),
+        scale=title_scale,
+        thickness=2,
+    )
+    subtitle_scale = 0.65
+    subtitle_size = cv2.getTextSize(
+        subtitle, cv2.FONT_HERSHEY_SIMPLEX, subtitle_scale, 1
+    )[0]
+    _put_text(
+        canvas,
+        subtitle,
+        ((OUTPUT_WIDTH - subtitle_size[0]) // 2, 365),
+        scale=subtitle_scale,
+        color=MUTED_TEXT,
+        thickness=1,
+    )
+
+    if tracker_names:
+        total_width = sum(
+            cv2.getTextSize(
+                DISPLAY_NAMES[name],
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.55,
+                1,
+            )[0][0]
+            + 48
+            for name in tracker_names
+        )
+        cursor = (OUTPUT_WIDTH - total_width) // 2
+        for tracker_name in tracker_names:
+            color = TRACKER_COLORS[tracker_name]
+            cv2.circle(canvas, (cursor + 9, 418), 7, color, -1, cv2.LINE_AA)
+            _put_text(
+                canvas,
+                DISPLAY_NAMES[tracker_name],
+                (cursor + 25, 424),
+                scale=0.55,
+                thickness=1,
+            )
+            cursor += (
+                cv2.getTextSize(
+                    DISPLAY_NAMES[tracker_name],
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.55,
+                    1,
+                )[0][0]
+                + 48
+            )
+    return canvas
+
+
+class H264Writer:
+    """Stream BGR frames to ffmpeg and atomically finalize an H.264 MP4."""
+
+    def __init__(
+        self,
+        output_path: Path,
+        fps: float,
+        *,
+        crf: int,
+        preset: str,
+    ) -> None:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            raise RuntimeError("ffmpeg is required to create the H.264 MP4")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = tempfile.NamedTemporaryFile(
+            prefix=f".{output_path.stem}.",
+            suffix=".partial.mp4",
+            dir=output_path.parent,
+            delete=False,
+        )
+        temporary.close()
+        self.output_path = output_path
+        self.temporary_path = Path(temporary.name)
+        self.frames_written = 0
+        command = [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "bgr24",
+            "-video_size",
+            f"{OUTPUT_WIDTH}x{OUTPUT_HEIGHT}",
+            "-framerate",
+            f"{fps:.12g}",
+            "-i",
+            "pipe:0",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
+            str(self.temporary_path),
+        ]
+        self.process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, frame: np.ndarray) -> None:
+        if frame.shape != (OUTPUT_HEIGHT, OUTPUT_WIDTH, 3):
+            raise ValueError(
+                f"Output frame has shape {frame.shape}; expected "
+                f"({OUTPUT_HEIGHT}, {OUTPUT_WIDTH}, 3)"
+            )
+        if frame.dtype != np.uint8:
+            raise ValueError("Output frames must use uint8 pixels")
+        if self.process.stdin is None:
+            raise RuntimeError("ffmpeg input pipe is unavailable")
+        try:
+            written = self.process.stdin.write(
+                np.ascontiguousarray(frame).tobytes()
+            )
+        except BrokenPipeError as exc:
+            stderr = (
+                self.process.stderr.read().decode("utf-8", "replace")
+                if self.process.stderr is not None
+                else ""
+            )
+            raise RuntimeError(f"ffmpeg stopped while encoding: {stderr}") from exc
+        expected = OUTPUT_WIDTH * OUTPUT_HEIGHT * 3
+        if written != expected:
+            raise RuntimeError(
+                f"ffmpeg accepted {written} frame bytes; expected {expected}"
+            )
+        self.frames_written += 1
+
+    def finish(self) -> Path:
+        if self.process.stdin is not None:
+            self.process.stdin.close()
+        stderr = (
+            self.process.stderr.read().decode("utf-8", "replace")
+            if self.process.stderr is not None
+            else ""
+        )
+        return_code = self.process.wait()
+        if return_code != 0:
+            self.temporary_path.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"ffmpeg failed with exit code {return_code}: {stderr.strip()}"
+            )
+        if not self.temporary_path.is_file() or self.temporary_path.stat().st_size == 0:
+            self.temporary_path.unlink(missing_ok=True)
+            raise RuntimeError("ffmpeg reported success but produced no video")
+        return self.temporary_path
+
+    def abort(self) -> None:
+        if self.process.poll() is None:
+            if self.process.stdin is not None:
+                self.process.stdin.close()
+            self.process.terminate()
+            self.process.wait()
+        self.temporary_path.unlink(missing_ok=True)
+
+
+def render_video(
+    source: SourceInfo,
+    results: Sequence[TrackResult],
+    output_path: Path,
+    scene_title: str,
+    title_seconds: float,
+    crf: int,
+    preset: str,
+    together_only: bool = False,
+) -> tuple[Path, list[dict[str, Any]], int]:
+    """Encode the simultaneous grid, optionally followed by solo replays."""
+    title_frame_count = (
+        0 if together_only else int(round(title_seconds * source.fps))
+    )
+    if not together_only and title_seconds > 0 and title_frame_count < 1:
+        title_frame_count = 1
+    rectangles = _grid_rectangles(len(results))
+    sections: list[dict[str, Any]] = []
+    timeline_frame = 0
+    writer = H264Writer(output_path, source.fps, crf=crf, preset=preset)
+
+    def write_card(
+        title: str, subtitle: str, names: Sequence[str], section_name: str
+    ) -> None:
+        nonlocal timeline_frame
+        if title_frame_count == 0:
+            return
+        start = timeline_frame
+        card = _title_card(title, subtitle, names)
+        for _ in range(title_frame_count):
+            writer.write(card)
+            timeline_frame += 1
+        sections.append(
+            {
+                "kind": "title",
+                "name": section_name,
+                "output_start_frame": start,
+                "output_end_frame": timeline_frame - 1,
+            }
+        )
+
+    try:
+        all_names = [result.name for result in results]
+        write_card(
+            f"{scene_title}: Trackers Together",
+            (
+                f"Same source frames {source.start_frame}-{source.end_frame} "
+                "| Same initial ROI"
+            ),
+            all_names,
+            "together-title",
+        )
+        together_start = timeline_frame
+        for offset, _, frame in selected_frames(source):
+            canvas = np.full(
+                (OUTPUT_HEIGHT, OUTPUT_WIDTH, 3), BACKGROUND, dtype=np.uint8
+            )
+            for rect, result in zip(rectangles, results):
+                _draw_panel(
+                    canvas,
+                    frame,
+                    rect,
+                    result.name,
+                    result.entries[offset],
+                    compact=len(results) > 1,
+                )
+            writer.write(canvas)
+            timeline_frame += 1
+        sections.append(
+            {
+                "kind": "together",
+                "trackers": all_names,
+                "output_start_frame": together_start,
+                "output_end_frame": timeline_frame - 1,
+                "source_start_frame": source.start_frame,
+                "source_end_frame": source.end_frame,
+            }
+        )
+
+        if not together_only:
+            for result in results:
+                write_card(
+                    f"{scene_title}: {DISPLAY_NAMES[result.name]}",
+                    (
+                        f"Source frames {source.start_frame}-{source.end_frame} "
+                        "| Full-screen replay"
+                    ),
+                    [result.name],
+                    f"{result.name.lower()}-title",
+                )
+                tracker_start = timeline_frame
+                for offset, _, frame in selected_frames(source):
+                    canvas = np.full(
+                        (OUTPUT_HEIGHT, OUTPUT_WIDTH, 3),
+                        BACKGROUND,
+                        dtype=np.uint8,
+                    )
+                    _draw_panel(
+                        canvas,
+                        frame,
+                        (0, 0, OUTPUT_WIDTH, OUTPUT_HEIGHT),
+                        result.name,
+                        result.entries[offset],
+                        compact=False,
+                    )
+                    writer.write(canvas)
+                    timeline_frame += 1
+                sections.append(
+                    {
+                        "kind": "single",
+                        "tracker": result.name,
+                        "output_start_frame": tracker_start,
+                        "output_end_frame": timeline_frame - 1,
+                        "source_start_frame": source.start_frame,
+                        "source_end_frame": source.end_frame,
+                    }
+                )
+
+        temporary_path = writer.finish()
+    except BaseException:
+        writer.abort()
+        raise
+
+    if writer.frames_written != timeline_frame:
+        temporary_path.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"Encoder received {writer.frames_written} frames, but the timeline "
+            f"contains {timeline_frame}"
+        )
+    return temporary_path, sections, timeline_frame
+
+
+def _top_level_mp4_atoms(path: Path) -> list[tuple[str, int]]:
+    atoms: list[tuple[str, int]] = []
+    file_size = path.stat().st_size
+    with path.open("rb") as stream:
+        offset = 0
+        while offset + 8 <= file_size:
+            stream.seek(offset)
+            header = stream.read(8)
+            size, atom_type_bytes = struct.unpack(">I4s", header)
+            header_size = 8
+            if size == 1:
+                extended = stream.read(8)
+                if len(extended) != 8:
+                    raise RuntimeError("The encoded MP4 has a truncated atom header")
+                size = struct.unpack(">Q", extended)[0]
+                header_size = 16
+            elif size == 0:
+                size = file_size - offset
+            if size < header_size or offset + size > file_size:
+                raise RuntimeError("The encoded MP4 has an invalid top-level atom")
+            atom_type = atom_type_bytes.decode("ascii", "replace")
+            atoms.append((atom_type, offset))
+            offset += size
+    return atoms
+
+
+def verify_encoded_video(
+    path: Path, expected_frames: int, expected_fps: float
+) -> dict[str, Any]:
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError("ffprobe is required to verify the encoded MP4")
+    completed = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-count_frames",
+            "-show_streams",
+            "-of",
+            "json",
+            str(path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"ffprobe could not verify the MP4: {completed.stderr}")
+    try:
+        probe = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("ffprobe returned invalid JSON") from exc
+    streams = probe.get("streams", [])
+    video_streams = [
+        stream for stream in streams if stream.get("codec_type") == "video"
+    ]
+    audio_streams = [
+        stream for stream in streams if stream.get("codec_type") == "audio"
+    ]
+    if len(video_streams) != 1 or audio_streams:
+        raise RuntimeError(
+            "The output must contain exactly one video stream and no audio"
+        )
+    video = video_streams[0]
+    checks = {
+        "codec_name": video.get("codec_name"),
+        "pixel_format": video.get("pix_fmt"),
+        "width": int(video.get("width", 0)),
+        "height": int(video.get("height", 0)),
+    }
+    if checks != {
+        "codec_name": "h264",
+        "pixel_format": "yuv420p",
+        "width": OUTPUT_WIDTH,
+        "height": OUTPUT_HEIGHT,
+    }:
+        raise RuntimeError(f"Unexpected encoded stream properties: {checks}")
+
+    decoded_frames_raw = video.get("nb_read_frames")
+    if decoded_frames_raw in (None, "N/A"):
+        raise RuntimeError("ffprobe did not report the decoded frame count")
+    decoded_frames = int(decoded_frames_raw)
+    if decoded_frames != expected_frames:
+        raise RuntimeError(
+            f"The output contains {decoded_frames} frames; expected "
+            f"{expected_frames}"
+        )
+
+    rate_text = video.get("avg_frame_rate", "0/0")
+    numerator_text, denominator_text = rate_text.split("/", maxsplit=1)
+    denominator = float(denominator_text)
+    encoded_fps = float(numerator_text) / denominator if denominator else 0.0
+    if not math.isclose(encoded_fps, expected_fps, rel_tol=1e-5, abs_tol=1e-3):
+        raise RuntimeError(
+            f"The encoded frame rate is {encoded_fps}; expected {expected_fps}"
+        )
+
+    atoms = _top_level_mp4_atoms(path)
+    atom_positions = {name: offset for name, offset in atoms}
+    if "moov" not in atom_positions or "mdat" not in atom_positions:
+        raise RuntimeError("The encoded MP4 is missing its moov or mdat atom")
+    if atom_positions["moov"] > atom_positions["mdat"]:
+        raise RuntimeError("The MP4 was not finalized for fast-start playback")
+
+    return {
+        **checks,
+        "fps": encoded_fps,
+        "decoded_frame_count": decoded_frames,
+        "faststart": True,
+        "file_size_bytes": path.stat().st_size,
+        "sha256": _sha256_file(path),
+    }
+
+
+def _stage_json(path: Path, payload: dict[str, Any]) -> Path:
+    """Write and sync JSON beside its destination without installing it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=f".{path.stem}.",
+        suffix=".partial.json",
+        dir=path.parent,
+        delete=False,
+    )
+    temporary_path = Path(temporary.name)
+    try:
+        with temporary:
+            json.dump(payload, temporary, indent=2)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.chmod(temporary_path, 0o644)
+        return temporary_path
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _install_output_pair(
+    staged_video: Path,
+    output_path: Path,
+    staged_json: Path,
+    json_path: Path,
+    *,
+    overwrite: bool,
+) -> None:
+    """Install a staged MP4/JSON pair and restore the prior pair on failure."""
+    staged_pairs = (
+        (staged_video, output_path),
+        (staged_json, json_path),
+    )
+    backups: list[tuple[Path, Path]] = []
+    installed: list[Path] = []
+
+    try:
+        for staged, final in staged_pairs:
+            if not staged.is_file():
+                raise FileNotFoundError(f"Staged output is missing: {staged}")
+            final.parent.mkdir(parents=True, exist_ok=True)
+            if final.exists() and not final.is_file():
+                raise ValueError(f"Output path is not a regular file: {final}")
+            if final.exists() and not overwrite:
+                raise FileExistsError(
+                    f"Output already exists: {final} "
+                    "(pass --overwrite to replace it)"
+                )
+
+        for _, final in staged_pairs:
+            if not final.exists():
+                continue
+            backup_file = tempfile.NamedTemporaryFile(
+                prefix=f".{final.name}.",
+                suffix=".rollback-backup",
+                dir=final.parent,
+                delete=False,
+            )
+            backup_file.close()
+            backup_path = Path(backup_file.name)
+            try:
+                os.replace(final, backup_path)
+            except BaseException:
+                backup_path.unlink(missing_ok=True)
+                raise
+            backups.append((final, backup_path))
+
+        for staged, final in staged_pairs:
+            os.replace(staged, final)
+            installed.append(final)
+            os.chmod(final, 0o644)
+    except BaseException as install_error:
+        backup_by_final = {final: backup for final, backup in backups}
+        rollback_errors: list[str] = []
+
+        # New outputs that had no predecessor must disappear on rollback.
+        for final in reversed(installed):
+            if final in backup_by_final:
+                continue
+            try:
+                final.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(f"remove {final}: {exc}")
+
+        # Replacing a new file with its backup is itself atomic.
+        for final, backup in reversed(backups):
+            try:
+                if not backup.is_file():
+                    raise FileNotFoundError(f"backup disappeared: {backup}")
+                os.replace(backup, final)
+            except OSError as exc:
+                rollback_errors.append(
+                    f"restore {final} from {backup}: {exc}"
+                )
+
+        for staged, _ in staged_pairs:
+            try:
+                staged.unlink(missing_ok=True)
+            except OSError as exc:
+                rollback_errors.append(f"remove staged file {staged}: {exc}")
+
+        if rollback_errors:
+            details = "; ".join(rollback_errors)
+            raise RuntimeError(
+                "Output-pair installation failed and rollback was incomplete: "
+                f"{details}"
+            ) from install_error
+        raise
+
+    cleanup_errors: list[str] = []
+    for _, backup in backups:
+        try:
+            backup.unlink(missing_ok=True)
+        except OSError as exc:
+            cleanup_errors.append(f"{backup}: {exc}")
+    if cleanup_errors:
+        raise RuntimeError(
+            "The new output pair is installed, but rollback-backup cleanup "
+            f"failed: {'; '.join(cleanup_errors)}"
+        )
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    input_path = args.input.expanduser().resolve()
+    output_path = args.output.expanduser().resolve()
+    json_path = (
+        args.json_output.expanduser().resolve()
+        if args.json_output is not None
+        else output_path.with_suffix(".json")
+    )
+    models_dir = args.models_dir.expanduser().resolve()
+
+    if output_path.suffix.lower() != ".mp4":
+        raise ValueError("--output must use an .mp4 filename")
+    if output_path == json_path:
+        raise ValueError("The MP4 and JSON output paths must be different")
+    for path in (output_path, json_path):
+        if path == input_path or (
+            path.exists() and input_path.exists() and os.path.samefile(path, input_path)
+        ):
+            raise ValueError(
+                f"Refusing to overwrite the source video with an output: {path}"
+            )
+    for path in (output_path, json_path):
+        if path.exists() and not path.is_file():
+            raise ValueError(f"Output path is not a regular file: {path}")
+        if path.exists() and not args.overwrite:
+            raise FileExistsError(
+                f"Output already exists: {path} (pass --overwrite to replace it)"
+            )
+    if not 0 <= args.crf <= 51:
+        raise ValueError("--crf must be between 0 and 51")
+    if not math.isfinite(args.title_seconds) or args.title_seconds < 0:
+        raise ValueError("--title-seconds must be zero or greater")
+
+    source = inspect_source(
+        input_path, args.start_frame, args.end_frame, args.bbox
+    )
+    model_files = model_file_provenance(args.trackers, models_dir)
+    results = [
+        track_source(source, name, args.bbox, models_dir)
+        for name in args.trackers
+    ]
+    if model_file_provenance(args.trackers, models_dir) != model_files:
+        raise RuntimeError("A tracker model file changed while tracking was running")
+    scene_title = args.scene_title or input_path.stem.replace("_", " ").title()
+    temporary_video, sections, output_frame_count = render_video(
+        source,
+        results,
+        output_path,
+        scene_title,
+        args.title_seconds,
+        args.crf,
+        args.preset,
+        together_only=args.together_only,
+    )
+    staged_json: Path | None = None
+    try:
+        verification = verify_encoded_video(
+            temporary_video, output_frame_count, source.fps
+        )
+        metadata: dict[str, Any] = {
+            "schema_version": 1,
+            "opencv_version": cv2.__version__,
+            "source": {
+                "filename": source.path.name,
+                "file_sha256": source.file_sha256,
+                "width": source.width,
+                "height": source.height,
+                "fps": source.fps,
+                "reported_frame_count": source.reported_frame_count,
+                "selected_start_frame_inclusive": source.start_frame,
+                "selected_end_frame_inclusive": source.end_frame,
+                "selected_frame_count": source.selected_frame_count,
+                "selected_sequence_sha256": source.selected_sequence_sha256,
+                "initial_bbox_xywh": list(args.bbox),
+            },
+            "models": {
+                "files": model_files,
+            },
+            "trackers": [
+                {
+                    "name": result.name,
+                    "display_name": DISPLAY_NAMES[result.name],
+                    "color_rgb": list(reversed(TRACKER_COLORS[result.name])),
+                    "update_count": result.update_count,
+                    "box_returned_updates": result.box_returned_updates,
+                    "box_return_rate": (
+                        result.box_returned_updates / result.update_count
+                        if result.update_count
+                        else None
+                    ),
+                    "mean_tracking_ms": (
+                        round(result.mean_tracking_ms, 3)
+                        if result.mean_tracking_ms is not None
+                        else None
+                    ),
+                    "trajectory": result.entries,
+                }
+                for result in results
+            ],
+            "output": {
+                "filename": output_path.name,
+                "scene_title": scene_title,
+                "width": OUTPUT_WIDTH,
+                "height": OUTPUT_HEIGHT,
+                "fps": source.fps,
+                "frame_count": output_frame_count,
+                "title_seconds": (
+                    0.0 if args.together_only else args.title_seconds
+                ),
+                "layout": (
+                    "together-only"
+                    if args.together_only
+                    else "together-and-sequential"
+                ),
+                "sections": sections,
+                "verification": verification,
+            },
+        }
+        os.chmod(temporary_video, 0o644)
+        staged_json = _stage_json(json_path, metadata)
+        _install_output_pair(
+            temporary_video,
+            output_path,
+            staged_json,
+            json_path,
+            overwrite=args.overwrite,
+        )
+    except BaseException:
+        temporary_video.unlink(missing_ok=True)
+        if staged_json is not None:
+            staged_json.unlink(missing_ok=True)
+        raise
+
+    return {
+        "video": str(output_path),
+        "json": str(json_path),
+        "trackers": [DISPLAY_NAMES[result.name] for result in results],
+        "source_frames": [
+            source.start_frame,
+            source.end_frame,
+        ],
+        "output_frames": output_frame_count,
+        "verification": verification,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--input", type=Path, required=True, help="source video")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="final 1280x720 H.264 MP4",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="trajectory/result JSON (defaults beside the MP4)",
+    )
+    parser.add_argument(
+        "--trackers",
+        type=parse_trackers,
+        default=parse_trackers("MIL,DASIAMRPN,NANO,VIT"),
+        help=(
+            "comma-separated list using MIL, DaSiamRPN, NanoTrack, and/or "
+            "VitTrack"
+        ),
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=DEFAULT_MODELS_DIR,
+        help="directory containing the verified ONNX tracker models",
+    )
+    parser.add_argument(
+        "--bbox",
+        type=parse_bbox,
+        required=True,
+        help="initial x,y,width,height on --start-frame",
+    )
+    parser.add_argument(
+        "--start-frame",
+        type=int,
+        default=0,
+        help="first source frame to include (zero-based and inclusive)",
+    )
+    parser.add_argument(
+        "--end-frame",
+        type=int,
+        help="last source frame to include (inclusive); omit to use the rest",
+    )
+    parser.add_argument(
+        "--scene-title",
+        help="short title shown on section cards",
+    )
+    parser.add_argument(
+        "--title-seconds",
+        type=float,
+        default=1.0,
+        help=(
+            "duration of each title card; use 0 to disable "
+            "(ignored with --together-only)"
+        ),
+    )
+    parser.add_argument(
+        "--together-only",
+        action="store_true",
+        help=(
+            "emit only the simultaneous comparison grid, with no title cards "
+            "or full-screen replays"
+        ),
+    )
+    parser.add_argument(
+        "--crf",
+        type=int,
+        default=20,
+        help="libx264 quality setting (lower is higher quality)",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=(
+            "ultrafast",
+            "superfast",
+            "veryfast",
+            "faster",
+            "fast",
+            "medium",
+            "slow",
+        ),
+        default="medium",
+        help="libx264 encoding preset",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="replace existing MP4/JSON outputs",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        summary = run(args)
+    except (
+        FileExistsError,
+        FileNotFoundError,
+        OSError,
+        RuntimeError,
+        ValueError,
+        cv2.error,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tracking/tests/test_download_models.py
+++ b/tracking/tests/test_download_models.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import sys
+from unittest import mock
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_DIR))
+
+import download_models
+
+
+class FakeResponse:
+    def __init__(self, payload: bytes, advertised_size: int | None = None):
+        self.payload = payload
+        self.offset = 0
+        self.headers = {}
+        if advertised_size is not None:
+            self.headers["Content-Length"] = str(advertised_size)
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def read(self, size: int) -> bytes:
+        chunk = self.payload[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_manifest_has_all_six_pinned_models() -> None:
+    assert set(download_models.MODEL_GROUPS) == {"dasiamrpn", "nano", "vit"}
+    entries = {
+        filename: values
+        for group in download_models.MODEL_GROUPS.values()
+        for filename, values in group.items()
+    }
+    assert len(entries) == 6
+    for url, expected_sha, expected_size in entries.values():
+        assert url.startswith("https://")
+        assert len(expected_sha) == 64
+        assert expected_size > 0
+
+
+def test_valid_download_is_verified_and_replaced(tmp_path: Path) -> None:
+    payload = b"verified-model-payload"
+    response = FakeResponse(payload, len(payload))
+    with mock.patch.object(
+        download_models.urllib.request, "urlopen", return_value=response
+    ):
+        success = download_models.download_one(
+            "model.onnx",
+            "https://example.invalid/model.onnx",
+            _digest(payload),
+            len(payload),
+            force=True,
+            models_dir=tmp_path,
+        )
+    assert success
+    assert (tmp_path / "model.onnx").read_bytes() == payload
+    assert not list(tmp_path.glob(".*.part"))
+
+
+def test_oversized_download_does_not_replace_existing_file(
+    tmp_path: Path,
+) -> None:
+    expected = b"expected"
+    destination = tmp_path / "model.onnx"
+    destination.write_bytes(b"existing")
+    response = FakeResponse(expected + b"extra")
+    with mock.patch.object(
+        download_models.urllib.request, "urlopen", return_value=response
+    ):
+        success = download_models.download_one(
+            destination.name,
+            "https://example.invalid/model.onnx",
+            _digest(expected),
+            len(expected),
+            force=True,
+            models_dir=tmp_path,
+        )
+    assert not success
+    assert destination.read_bytes() == b"existing"
+    assert not list(tmp_path.glob(".*.part"))

--- a/tracking/tests/test_render_tracker_comparison.py
+++ b/tracking/tests/test_render_tracker_comparison.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_DIR))
+
+import render_tracker_comparison as renderer
+from render_tracker_comparison import (
+    SourceInfo,
+    TrackResult,
+    _install_output_pair,
+    render_video,
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _inject_json_install_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    staged_json: Path,
+    final_json: Path,
+) -> None:
+    real_replace = os.replace
+
+    def failing_replace(source: os.PathLike[str], destination: os.PathLike[str]) -> None:
+        if Path(source) == staged_json and Path(destination) == final_json:
+            raise OSError("injected JSON install failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+
+def test_pair_install_replaces_both_outputs_and_sets_public_modes(
+    tmp_path: Path,
+) -> None:
+    final_video = tmp_path / "result.mp4"
+    final_json = tmp_path / "result.json"
+    staged_video = tmp_path / ".new-video.mp4"
+    staged_json = tmp_path / ".new-result.json"
+    final_video.write_bytes(b"old-video")
+    final_json.write_bytes(b"old-json")
+    final_video.chmod(0o640)
+    final_json.chmod(0o600)
+    staged_video.write_bytes(b"new-video")
+    staged_json.write_bytes(b"new-json")
+
+    _install_output_pair(
+        staged_video,
+        final_video,
+        staged_json,
+        final_json,
+        overwrite=True,
+    )
+
+    assert final_video.read_bytes() == b"new-video"
+    assert final_json.read_bytes() == b"new-json"
+    assert _mode(final_video) == 0o644
+    assert _mode(final_json) == 0o644
+    assert not staged_video.exists()
+    assert not staged_json.exists()
+    assert not any(
+        "rollback-backup" in path.name for path in tmp_path.iterdir()
+    )
+
+
+def test_pair_install_restores_existing_pair_when_json_install_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final_video = tmp_path / "result.mp4"
+    final_json = tmp_path / "result.json"
+    staged_video = tmp_path / ".new-video.mp4"
+    staged_json = tmp_path / ".new-result.json"
+    final_video.write_bytes(b"old-video")
+    final_json.write_bytes(b"old-json")
+    final_video.chmod(0o640)
+    final_json.chmod(0o600)
+    staged_video.write_bytes(b"new-video")
+    staged_json.write_bytes(b"new-json")
+    _inject_json_install_failure(monkeypatch, staged_json, final_json)
+
+    with pytest.raises(OSError, match="injected JSON install failure"):
+        _install_output_pair(
+            staged_video,
+            final_video,
+            staged_json,
+            final_json,
+            overwrite=True,
+        )
+
+    assert final_video.read_bytes() == b"old-video"
+    assert final_json.read_bytes() == b"old-json"
+    assert _mode(final_video) == 0o640
+    assert _mode(final_json) == 0o600
+    assert not staged_video.exists()
+    assert not staged_json.exists()
+    assert not any(
+        "rollback-backup" in path.name for path in tmp_path.iterdir()
+    )
+
+
+def test_pair_install_removes_partial_new_output_when_no_pair_existed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final_video = tmp_path / "result.mp4"
+    final_json = tmp_path / "result.json"
+    staged_video = tmp_path / ".new-video.mp4"
+    staged_json = tmp_path / ".new-result.json"
+    staged_video.write_bytes(b"new-video")
+    staged_json.write_bytes(b"new-json")
+    _inject_json_install_failure(monkeypatch, staged_json, final_json)
+
+    with pytest.raises(OSError, match="injected JSON install failure"):
+        _install_output_pair(
+            staged_video,
+            final_video,
+            staged_json,
+            final_json,
+            overwrite=True,
+        )
+
+    assert not final_video.exists()
+    assert not final_json.exists()
+    assert not staged_video.exists()
+    assert not staged_json.exists()
+
+
+def test_together_only_emits_one_grid_frame_per_selected_source_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = SourceInfo(
+        path=tmp_path / "source.mp4",
+        width=128,
+        height=72,
+        fps=30.0,
+        reported_frame_count=2,
+        start_frame=10,
+        end_frame=11,
+        selected_frame_count=2,
+        frame_hashes=("first", "second"),
+        selected_sequence_sha256="sequence",
+        file_sha256="source",
+    )
+    frames = [
+        np.zeros((72, 128, 3), dtype=np.uint8),
+        np.full((72, 128, 3), 32, dtype=np.uint8),
+    ]
+    results = [
+        TrackResult(
+            name=name,
+            entries=[
+                {
+                    "source_frame": 10,
+                    "phase": "initialization",
+                    "box_returned": None,
+                    "bbox_xywh": [10.0, 10.0, 20.0, 20.0],
+                    "bbox_off_frame": False,
+                },
+                {
+                    "source_frame": 11,
+                    "phase": "update",
+                    "box_returned": True,
+                    "bbox_xywh": [11.0, 10.0, 20.0, 20.0],
+                    "bbox_off_frame": False,
+                },
+            ],
+            box_returned_updates=1,
+            update_count=1,
+            mean_tracking_ms=1.0,
+        )
+        for name in ("MIL", "DASIAMRPN", "NANO", "VIT")
+    ]
+
+    def fake_selected_frames(requested_source: SourceInfo):
+        assert requested_source is source
+        for offset, frame in enumerate(frames):
+            yield offset, source.start_frame + offset, frame
+
+    writers = []
+
+    class FakeWriter:
+        def __init__(
+            self,
+            output_path: Path,
+            fps: float,
+            *,
+            crf: int,
+            preset: str,
+        ) -> None:
+            assert fps == source.fps
+            assert crf == 20
+            assert preset == "medium"
+            self.output_path = output_path
+            self.frames_written = 0
+            self.frames: list[np.ndarray] = []
+            writers.append(self)
+
+        def write(self, frame: np.ndarray) -> None:
+            self.frames.append(frame.copy())
+            self.frames_written += 1
+
+        def finish(self) -> Path:
+            staged = self.output_path.with_name(".staged.mp4")
+            staged.write_bytes(b"video")
+            return staged
+
+        def abort(self) -> None:
+            pass
+
+    monkeypatch.setattr(renderer, "selected_frames", fake_selected_frames)
+    monkeypatch.setattr(renderer, "H264Writer", FakeWriter)
+
+    staged, sections, frame_count = render_video(
+        source,
+        results,
+        tmp_path / "comparison.mp4",
+        "Limitations",
+        title_seconds=5.0,
+        crf=20,
+        preset="medium",
+        together_only=True,
+    )
+
+    assert staged.read_bytes() == b"video"
+    assert frame_count == source.selected_frame_count == 2
+    assert sections == [
+        {
+            "kind": "together",
+            "trackers": ["MIL", "DASIAMRPN", "NANO", "VIT"],
+            "output_start_frame": 0,
+            "output_end_frame": 1,
+            "source_start_frame": 10,
+            "source_end_frame": 11,
+        }
+    ]
+    assert len(writers) == 1
+    assert len(writers[0].frames) == source.selected_frame_count

--- a/tracking/tests/test_tracker.py
+++ b/tracking/tests/test_tracker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -9,7 +10,14 @@ import pytest
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_DIR))
 
-from tracker import _checked_bbox, create_tracker, parse_bbox, run_tracking
+from tracker import (
+    MODEL_TRACKER_FILES,
+    TRACKER_NAMES,
+    _checked_bbox,
+    create_tracker,
+    parse_bbox,
+    run_tracking,
+)
 
 
 def test_bbox_parser() -> None:
@@ -25,8 +33,17 @@ def test_bbox_parser() -> None:
 def test_supported_tracker_is_available() -> None:
     tracker = create_tracker("MIL")
     assert tracker is not None
+    assert {"DASIAMRPN", "NANO", "VIT"}.issubset(TRACKER_NAMES)
     with pytest.raises(ValueError):
         create_tracker("BOOSTING")
+
+
+@pytest.mark.parametrize("tracker_name", MODEL_TRACKER_FILES)
+def test_model_tracker_reports_missing_files(
+    tracker_name: str, tmp_path: Path
+) -> None:
+    with pytest.raises(FileNotFoundError, match="download_models.py"):
+        create_tracker(tracker_name, tmp_path)
 
 
 def test_headless_tracking_smoke(tmp_path: Path) -> None:
@@ -49,6 +66,44 @@ def test_headless_tracking_smoke(tmp_path: Path) -> None:
     image = cv2.imread(str(snapshot))
     assert image is not None
     assert image.shape[:2] == (360, 640)
+
+
+@pytest.mark.parametrize(
+    ("tracker_name", "bbox"),
+    (
+        ("DASIAMRPN", (287, 23, 86, 320)),
+        ("NANO", (287, 23, 86, 320)),
+        ("VIT", (250, 15, 180, 340)),
+    ),
+)
+def test_model_tracker_smoke(
+    tracker_name: str,
+    bbox: tuple[int, int, int, int],
+    tmp_path: Path,
+) -> None:
+    configured_dir = os.environ.get("TRACKING_MODELS_DIR")
+    if not configured_dir:
+        pytest.skip("set TRACKING_MODELS_DIR to run model-backed smoke tests")
+    models_dir = Path(configured_dir)
+    missing = [
+        filename
+        for filename in MODEL_TRACKER_FILES[tracker_name]
+        if not (models_dir / filename).is_file()
+    ]
+    if missing:
+        pytest.skip(f"missing {tracker_name} models: {', '.join(missing)}")
+
+    summary = run_tracking(
+        PROJECT_DIR / "videos" / "chaplin.mp4",
+        bbox,
+        tracker_name=tracker_name,
+        models_dir=models_dir,
+        snapshot_path=tmp_path / f"{tracker_name.lower()}.png",
+        max_frames=5,
+    )
+    assert summary["tracker"] == tracker_name
+    assert summary["frames_processed"] == 5
+    assert summary["successful_updates"] >= 1
 
 
 def test_missing_input_is_reported(tmp_path: Path) -> None:

--- a/tracking/tracker.cpp
+++ b/tracking/tracker.cpp
@@ -1,8 +1,10 @@
+#include <opencv2/dnn.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/video/tracking.hpp>
 #include <opencv2/videoio.hpp>
 
+// KCF and CSRT live in opencv_contrib when that optional header is installed.
 #if __has_include(<opencv2/tracking.hpp>)
 #include <opencv2/tracking.hpp>
 #define LEARNOPENCV_HAS_CONTRIB_TRACKING 1
@@ -12,14 +14,20 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace {
 
+// The filesystem alias keeps model-path validation concise and type-safe.
+namespace fs = std::filesystem;
+
+// Tracker names are case-insensitive at the command line.
 std::string upper(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(),
                    [](unsigned char character) {
@@ -28,9 +36,52 @@ std::string upper(std::string value) {
     return value;
 }
 
-cv::Ptr<cv::Tracker> createTracker(const std::string& requestedName) {
+// The downloader accepts lowercase tracker group names.
+std::string lower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char character) {
+                       return static_cast<char>(std::tolower(character));
+                   });
+    return value;
+}
+
+// Fail before calling OpenCV when a tracker model set is incomplete.
+void requireModels(
+    const std::string& trackerName,
+    const fs::path& modelsDir,
+    const std::vector<std::string>& filenames) {
+    std::vector<std::string> missing;
+    // Report every missing file together so the reader can fix one download.
+    for (const std::string& filename : filenames) {
+        if (!fs::is_regular_file(modelsDir / filename)) {
+            missing.push_back(filename);
+        }
+    }
+    if (missing.empty()) {
+        return;
+    }
+
+    // Include the exact recovery command in the reader-facing error.
+    std::ostringstream message;
+    message << trackerName << " requires model files in " << modelsDir
+            << "; missing: ";
+    for (std::size_t index = 0; index < missing.size(); ++index) {
+        if (index != 0) {
+            message << ", ";
+        }
+        message << missing[index];
+    }
+    message << ". Run: python download_models.py --tracker "
+            << lower(trackerName);
+    throw std::runtime_error(message.str());
+}
+
+// Construct only trackers exposed by the linked OpenCV installation.
+cv::Ptr<cv::Tracker> createTracker(
+    const std::string& requestedName, const fs::path& modelsDir) {
     const std::string name = upper(requestedName);
 #if LEARNOPENCV_HAS_CONTRIB_TRACKING
+    // These factories compile only when the contrib tracking header exists.
     if (name == "CSRT") {
         return cv::TrackerCSRT::create();
     }
@@ -41,10 +92,53 @@ cv::Ptr<cv::Tracker> createTracker(const std::string& requestedName) {
     if (name == "MIL") {
         return cv::TrackerMIL::create();
     }
+    if (name == "DASIAMRPN") {
+        // DaSiamRPN separates its search network from two template kernels.
+        requireModels(
+            name, modelsDir,
+            {"dasiamrpn_model.onnx", "dasiamrpn_kernel_cls1.onnx",
+             "dasiamrpn_kernel_r1.onnx"});
+        cv::TrackerDaSiamRPN::Params parameters;
+        // Pass absolute or working-directory-relative paths explicitly.
+        parameters.model = (modelsDir / "dasiamrpn_model.onnx").string();
+        parameters.kernel_cls1 =
+            (modelsDir / "dasiamrpn_kernel_cls1.onnx").string();
+        parameters.kernel_r1 =
+            (modelsDir / "dasiamrpn_kernel_r1.onnx").string();
+        // The documented CPU backend is reproducible across OpenCV 4 and 5.
+        parameters.backend = cv::dnn::DNN_BACKEND_OPENCV;
+        parameters.target = cv::dnn::DNN_TARGET_CPU;
+        return cv::TrackerDaSiamRPN::create(parameters);
+    }
+    if (name == "NANO") {
+        // NanoTrack v2 uses one template backbone and one prediction head.
+        requireModels(
+            name, modelsDir,
+            {"nanotrack_backbone_sim.onnx", "nanotrack_head_sim.onnx"});
+        cv::TrackerNano::Params parameters;
+        parameters.backbone =
+            (modelsDir / "nanotrack_backbone_sim.onnx").string();
+        parameters.neckhead =
+            (modelsDir / "nanotrack_head_sim.onnx").string();
+        parameters.backend = cv::dnn::DNN_BACKEND_OPENCV;
+        parameters.target = cv::dnn::DNN_TARGET_CPU;
+        return cv::TrackerNano::create(parameters);
+    }
+    if (name == "VIT") {
+        // VitTrack packages its compact transformer into one ONNX graph.
+        requireModels(
+            name, modelsDir, {"object_tracking_vittrack_2023sep.onnx"});
+        cv::TrackerVit::Params parameters;
+        parameters.net =
+            (modelsDir / "object_tracking_vittrack_2023sep.onnx").string();
+        parameters.backend = cv::dnn::DNN_BACKEND_OPENCV;
+        parameters.target = cv::dnn::DNN_TARGET_CPU;
+        return cv::TrackerVit::create(parameters);
+    }
     throw std::invalid_argument(
         "Tracker '" + requestedName +
-        "' is unavailable in this OpenCV build. MIL works in OpenCV 4 and 5; "
-        "CSRT and KCF require the OpenCV 4 contrib tracking module.");
+        "' is unavailable. Choose MIL, CSRT, KCF, DASIAMRPN, NANO, or VIT. "
+        "CSRT and KCF are capability-gated contrib options.");
 }
 
 cv::Rect parseBoundingBox(const std::string& text) {
@@ -93,10 +187,12 @@ cv::VideoWriter openWriter(
 }  // namespace
 
 int main(int argc, char** argv) {
+    // CommandLineParser supplies defaults that match the bundled Chaplin clip.
     const std::string keys =
         "{help h usage ?||Show this help message}"
         "{input|videos/chaplin.mp4|Input video path}"
-        "{tracker|MIL|MIL works in OpenCV 4/5; CSRT/KCF require OpenCV 4 contrib}"
+        "{tracker|MIL|MIL, CSRT, KCF, DASIAMRPN, NANO, or VIT}"
+        "{models-dir|models|Directory containing verified ONNX tracker models}"
         "{bbox|287,23,86,320|Initial x,y,width,height}"
         "{select-roi||Select the initial box interactively}"
         "{output||Optional annotated output video}"
@@ -116,6 +212,9 @@ int main(int argc, char** argv) {
     try {
         const std::string inputPath = parser.get<std::string>("input");
         const std::string trackerName = upper(parser.get<std::string>("tracker"));
+        // Keep models outside the executable so the downloader can verify them.
+        const fs::path modelsDir =
+            fs::path(parser.get<std::string>("models-dir"));
         const std::string outputPath = parser.get<std::string>("output");
         const std::string snapshotPath = parser.get<std::string>("snapshot");
         const int maxFrames = parser.get<int>("max-frames");
@@ -143,7 +242,8 @@ int main(int argc, char** argv) {
         }
         validateBoundingBox(box, frame.size());
 
-        cv::Ptr<cv::Tracker> tracker = createTracker(trackerName);
+        // Every tracker receives the same validated first-frame rectangle.
+        cv::Ptr<cv::Tracker> tracker = createTracker(trackerName, modelsDir);
         tracker->init(frame, box);
 
         double sourceFps = capture.get(cv::CAP_PROP_FPS);

--- a/tracking/tracker.py
+++ b/tracking/tracker.py
@@ -13,17 +13,133 @@ from typing import Any
 import cv2
 
 
-TRACKER_NAMES = ("MIL", "CSRT", "KCF")
+# Resolve the default model folder beside this script, independent of cwd.
+DEFAULT_MODELS_DIR = Path(__file__).resolve().parent / "models"
+# Classic trackers construct without external neural-network weights.
+CLASSIC_TRACKER_NAMES = ("MIL", "CSRT", "KCF")
+# Each model-backed tracker must receive exactly the files its Params object uses.
+MODEL_TRACKER_FILES = {
+    "DASIAMRPN": (
+        "dasiamrpn_model.onnx",
+        "dasiamrpn_kernel_cls1.onnx",
+        "dasiamrpn_kernel_r1.onnx",
+    ),
+    "NANO": (
+        "nanotrack_backbone_sim.onnx",
+        "nanotrack_head_sim.onnx",
+    ),
+    "VIT": ("object_tracking_vittrack_2023sep.onnx",),
+}
+# Class names are kept as data because Python bindings expose two layouts.
+MODEL_TRACKER_CLASSES = {
+    "DASIAMRPN": "TrackerDaSiamRPN",
+    "NANO": "TrackerNano",
+    "VIT": "TrackerVit",
+}
+# Accept the longer names readers commonly use while keeping a compact CLI.
+TRACKER_ALIASES = {"NANOTRACK": "NANO", "VITTRACK": "VIT"}
+TRACKER_NAMES = (*CLASSIC_TRACKER_NAMES, *MODEL_TRACKER_FILES)
 
 
-def create_tracker(name: str) -> Any:
-    """Create a tracker from the current namespace, then try OpenCV 4's legacy one."""
+def _normalized_tracker_name(name: str) -> str:
+    """Return the canonical command-line name used in summaries and errors."""
     normalized = name.upper()
+    return TRACKER_ALIASES.get(normalized, normalized)
+
+
+def _tracker_creator(class_name: str) -> Any | None:
+    """Resolve either spelling used by OpenCV's Python tracker bindings."""
+    flat_creator = getattr(cv2, f"{class_name}_create", None)
+    if flat_creator is not None:
+        return flat_creator
+    tracker_class = getattr(cv2, class_name, None)
+    if tracker_class is not None:
+        return getattr(tracker_class, "create", None)
+    return None
+
+
+def _tracker_params(class_name: str) -> Any | None:
+    """Create the Params object exposed by either binding layout."""
+    params_class = getattr(cv2, f"{class_name}_Params", None)
+    if params_class is None:
+        tracker_class = getattr(cv2, class_name, None)
+        params_class = (
+            getattr(tracker_class, "Params", None)
+            if tracker_class is not None
+            else None
+        )
+    return params_class() if params_class is not None else None
+
+
+def _create_model_tracker(name: str, models_dir: Path) -> Any:
+    """Validate model assets, configure the DNN backend, and create a tracker."""
+    required_files = MODEL_TRACKER_FILES[name]
+    # Check the complete set before OpenCV emits a less actionable load error.
+    missing = [
+        models_dir / filename
+        for filename in required_files
+        if not (models_dir / filename).is_file()
+    ]
+    if missing:
+        missing_names = ", ".join(path.name for path in missing)
+        raise FileNotFoundError(
+            f"{name} requires model files in {models_dir}; missing: "
+            f"{missing_names}. Run: python download_models.py "
+            f"--tracker {name.lower()}"
+        )
+
+    # Resolve both factory spellings used across wheel and source builds.
+    class_name = MODEL_TRACKER_CLASSES[name]
+    creator = _tracker_creator(class_name)
+    params = _tracker_params(class_name)
+    if creator is None or params is None:
+        raise RuntimeError(
+            f"{name} is unavailable in this OpenCV build. Use OpenCV 4.9 or "
+            "newer with the video and DNN modules."
+        )
+    # Tracker classes can be present in a build whose DNN module was disabled.
+    dnn = getattr(cv2, "dnn", None)
+    if dnn is None:
+        raise RuntimeError(
+            f"{name} requires an OpenCV build that includes the DNN module."
+        )
+
+    # Populate the differently named path fields in each OpenCV Params class.
+    if name == "DASIAMRPN":
+        params.model = str(models_dir / required_files[0])
+        params.kernel_cls1 = str(models_dir / required_files[1])
+        params.kernel_r1 = str(models_dir / required_files[2])
+    elif name == "NANO":
+        params.backbone = str(models_dir / required_files[0])
+        params.neckhead = str(models_dir / required_files[1])
+    else:
+        params.net = str(models_dir / required_files[0])
+
+    # Explicit CPU settings provide the same documented path in OpenCV 4 and 5.
+    params.backend = dnn.DNN_BACKEND_OPENCV
+    params.target = dnn.DNN_TARGET_CPU
+    try:
+        return creator(params)
+    except cv2.error as exc:
+        raise RuntimeError(
+            f"OpenCV could not create {name}. Confirm that this build includes "
+            "the DNN module and that download_models.py verified every model."
+        ) from exc
+
+
+def create_tracker(name: str, models_dir: Path = DEFAULT_MODELS_DIR) -> Any:
+    """Create a classic or model-backed tracker exposed by this OpenCV build."""
+    normalized = _normalized_tracker_name(name)
     if normalized not in TRACKER_NAMES:
         raise ValueError(
             f"Unsupported tracker '{name}'. Choose one of: {', '.join(TRACKER_NAMES)}"
         )
 
+    # Neural trackers need explicit, checksum-verified model paths.
+    if normalized in MODEL_TRACKER_FILES:
+        return _create_model_tracker(normalized, Path(models_dir))
+
+    # Classic factories may be in the main namespace or OpenCV 4's legacy one.
     factory_name = f"Tracker{normalized}_create"
     for namespace in (cv2, getattr(cv2, "legacy", None)):
         if namespace is None:
@@ -36,9 +152,9 @@ def create_tracker(name: str) -> Any:
 
     if normalized in {"CSRT", "KCF"}:
         raise RuntimeError(
-            f"{normalized} is unavailable. It requires an OpenCV 4 contrib "
-            "build and is absent from the tested OpenCV 5.0 API; use MIL for "
-            "the cross-version example."
+            f"{normalized} is unavailable in this build. It is a contrib tracker "
+            "when exposed and was absent from the exact OpenCV 5.0 builds tested "
+            "here; use MIL for the verified cross-version example."
         )
     raise RuntimeError(
         "MIL is unavailable. Install an OpenCV build that includes the video "
@@ -100,6 +216,7 @@ def run_tracking(
     bbox: tuple[int, int, int, int] | None,
     *,
     tracker_name: str = "MIL",
+    models_dir: Path = DEFAULT_MODELS_DIR,
     output_path: Path | None = None,
     snapshot_path: Path | None = None,
     max_frames: int | None = None,
@@ -130,7 +247,7 @@ def run_tracking(
             raise ValueError("Provide --bbox or use --select-roi")
         bbox = _checked_bbox(bbox, frame_width, frame_height)
 
-        tracker = create_tracker(tracker_name)
+        tracker = create_tracker(tracker_name, models_dir)
         init_result = tracker.init(frame, bbox)
         if init_result is False:
             raise RuntimeError("Tracker initialization failed")
@@ -208,7 +325,7 @@ def run_tracking(
                 raise RuntimeError(f"Could not write snapshot: {snapshot_path}")
 
         return {
-            "tracker": tracker_name.upper(),
+            "tracker": _normalized_tracker_name(tracker_name),
             "frames_processed": frames_processed,
             "successful_updates": successful_updates,
             "success_rate": successful_updates / frames_processed,
@@ -236,7 +353,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--tracker",
         choices=TRACKER_NAMES,
         default="MIL",
-        help="MIL works in OpenCV 4 and 5; CSRT/KCF require an OpenCV 4 contrib build",
+        help=(
+            "MIL/CSRT/KCF are model-free; DASIAMRPN/NANO/VIT use ONNX files"
+        ),
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=DEFAULT_MODELS_DIR,
+        help=f"verified ONNX directory (default: {DEFAULT_MODELS_DIR})",
     )
     parser.add_argument(
         "--bbox",
@@ -259,6 +384,7 @@ def main() -> int:
             args.input,
             args.bbox,
             tracker_name=args.tracker,
+            models_dir=args.models_dir,
             output_path=args.output,
             snapshot_path=args.snapshot,
             max_frames=args.max_frames,


### PR DESCRIPTION
## Summary
- Add checksum-pinned downloads and runnable Python/C++ paths for DaSiamRPN, NanoTrack v2, and VitTrack while retaining MIL, KCF, and CSRT capability checks.
- Add deterministic four-tracker comparison rendering with paired JSON provenance and failure-safe output installation.
- Update the project README, immutable-release links, exact 15-file release manifest, and root article index.

## Validation
- Python: 17/17 tests passed on exact OpenCV 4.13.0, 4.14.0, and 5.0.0 with all six verified ONNX models.
- C++: strict warning-as-error builds and 4/4 CTests passed on exact OpenCV 4.13.0, 4.14.0, and 5.0.0 with video and dnn.
- Direct Python and C++ CLI runs from an unrelated working directory passed for MIL, DaSiamRPN, NanoTrack, and VitTrack.
- Full four-panel Chaplin render verified as H.264/yuv420p, 1280x720, 150 decoded frames, with fast-start MP4 metadata.
- git diff --check passed; model binaries, caches, generated media, and credentials are excluded.

## Publication gate
After merge, tag the tested merge commit as object-tracking-opencv-2026.07.29, generate the reproducible one-folder ZIP plus checksum from Git, verify the draft assets byte-for-byte, and publish with latest=false.