### PR TITLE
Update SAM-3 companion for stateful SAM 3.1 tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 
 | Blog Post | Code|
 | ------------- |:-------------|
+| [SAM-3: What’s New, How It Works, and Why It Matters](https://learnopencv.com/sam-3-whats-new/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/SAM-3) |
 | [VGGT vs. VGGT-Ω (VGGT-Omega): A Complete Guide to Feed-Forward 3D Reconstruction](https://learnopencv.com/vggt-vs-vggt-%cf%89-vggt-omega-a-complete-guide-to-feed-forward-3d-reconstruction/) | [Code](https://github.com/spmallick/learnopencv/tree/master/VGGT-vs-VGGT-Omega-3D-Reconstruction) |
 | [MiniCPM-o 4.5: A 9B Model That Can See, Hear, and Speak at the Same Time](https://learnopencv.com/minicpm-o-4-5-a-9b-model-that-can-see-hear-and-speak-at-the-same-time/) | [Code](https://github.com/spmallick/learnopencv/tree/master/MiniCPM-o-4.5-Real-Time-Video-Understanding) |
 | [Object Tracking using OpenCV (C++/Python)](https://learnopencv.com/object-tracking-using-opencv-cpp-python/) [Updated] | [Code](https://github.com/spmallick/learnopencv/tree/master/tracking) |
@@ -98,7 +99,6 @@ This repository contains code for Computer Vision, Deep learning, and AI researc
 | [How to Build a GitHub Code-Analyser Agent for Developer Productivity](https://learnopencv.com/how-to-build-a-github-code-analyser-agent/) | [Code](https://github.com/spmallick/learnopencv/tree/master/How_to_Build_a_GitHub_Code_Analyser_Agent_for_Developer_Productivity) |
 | [The Existential Problems in LLM Serving](https://learnopencv.com/the-existential-problems-in-llm-serving/) | |
 | [SAM 3D: Foundation Model for Single-Image 3D Reconstruction](https://learnopencv.com/sam-3d/) | |
-| [SAM-3: What’s New, How It Works, and Why It Matters](https://learnopencv.com/sam-3-whats-new/) | [Code](https://github.com/spmallick/learnopencv/tree/master/SAM-3) |
 | [Image-GS: Adaptive Image Reconstruction using 2D Gaussians](https://learnopencv.com/image-gs-image-reconstruction-using-2d-gaussians/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Image_GS_Adaptive_Image_Reconstruction_using_2D_Gaussians) |
 | [Ultimate Guide to Vector Databases and RAG Pipeline](https://learnopencv.com/vector-db-and-rag-pipeline-for-document-rag/) | [Code](https://github.com/spmallick/learnopencv/tree/master/Ultimate_Guide_to_Vector_Databases_and_RAG_pipeline) |
 |[What Makes DeepSeek OCR So Powerful](https://learnopencv.com/what-makes-deepseek-ocr-so-powerful/)|[Code](https://github.com/spmallick/learnopencv/tree/master/What-Makes-DeepSeek-OCR-So-Powerful)|

--- a/SAM-3/.gitignore
+++ b/SAM-3/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.ipynb_checkpoints/
+output*.mp4
+*.video-only.mp4
+*.muxed.mp4

--- a/SAM-3/README.md
+++ b/SAM-3/README.md
@@ -1,14 +1,163 @@
-# SAM-3: What’s New, How It Works, and Why It Matters
+# [SAM-3: What’s New, How It Works, and Why It Matters](https://learnopencv.com/sam-3-whats-new/)
 
-This repository explores Meta's SAM-3 through a detailed technical blog post and a hands-on video inference script. The guide breaks down the architectural shift to "Promptable Concept Segmentation" (PCS), explaining how the model unifies detection, segmentation, and tracking. 
+**Updated August 30, 2026:** This companion now uses Meta's SAM 3.1 Object
+Multiplex video predictor. The previous notebook applied the image processor to
+each frame independently, so it performed frame-by-frame concept segmentation
+rather than stateful tracking.
 
-The accompanying Jupyter Notebook demonstrates how to implement video tracking using OpenCV and Python to track multiple concepts simultaneously in video streams using simple text prompts.  
+[<img src="./featured_image_SAM_3.jpg" alt="SAM 3 Promptable Concept Segmentation" width="100%">](https://learnopencv.com/sam-3-whats-new/)
 
-It is part of the LearnOpenCV blog post - [SAM-3: What’s New, How It Works, and Why It Matters](https://learnopencv.com/sam-3-whats-new/).
+[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://github.com/spmallick/learnopencv/releases/download/sam-3-1-video-tracking-2026.08.30/SAM-3.zip)
 
-[<img src="https://learnopencv.com/wp-content/uploads/2022/07/download-button-e1657285155454.png" alt="Download Code" width="200">](https://www.dropbox.com/scl/fi/2ppku7v8wkvn6htaqjkzd/sam3_inference.ipynb?rlkey=267hoxw7fb4noo22aep8jjmp6&st=2pkmt56o&dl=1)
+## What This Example Does
 
-![](./featured_image_SAM_3.jpg)
+The script opens one SAM 3.1 inference session, supplies one text noun phrase,
+and propagates the resulting object identities through the complete video.
+OpenCV then renders a stable color and object ID for every returned mask. This
+separation is important: SAM 3.1 performs the temporal tracking; OpenCV handles
+video decoding and visualization.
+
+A text prompt is one concept phrase, such as `person wearing a red shirt`.
+Commas do not turn one string into a documented multi-label request. Run a
+separate session when you need an independently defined concept.
+
+## Requirements
+
+Meta's current SAM 3.1 installation requires:
+
+- Python 3.12 or newer
+- PyTorch 2.7 or newer; Meta's current tested command installs PyTorch 2.10
+- An NVIDIA CUDA GPU with CUDA 12.6 or newer
+- Access to the gated `facebook/sam3.1` checkpoint on Hugging Face
+- The latest code from Meta's official [SAM 3 repository](https://github.com/facebookresearch/sam3)
+- FFmpeg and FFprobe when the source audio should be preserved
+
+The optional FlashAttention 3 path can improve compatible GPU inference. The
+example uses the portable attention path by default; pass `--fa3` only after
+installing the optional kernels on a supported system.
+
+The pinned Meta revision also has a documented multiplex-session argument
+mismatch ([Meta issue #544](https://github.com/facebookresearch/sam3/issues/544)).
+The companion detects that exact signature mismatch and filters only the
+unsupported `offload_state_to_cpu` keyword during session creation. The guard
+becomes a no-op when Meta's multiplex model accepts that argument upstream.
+
+## Project Layout
+
+```text
+SAM-3/
+├── .gitignore
+├── README.md
+├── featured_image_SAM_3.jpg
+├── requirements.txt
+├── sam3_inference.ipynb
+├── sam3_video_tracking.py
+└── tests/
+    └── test_sam3_video_tracking.py
+```
+
+## Installation
+
+Follow Meta's current CUDA setup before installing this example:
+
+```bash
+conda create -n sam31 python=3.12
+conda activate sam31
+
+pip install torch==2.10.0 torchvision \
+  --index-url https://download.pytorch.org/whl/cu128
+
+git clone https://github.com/facebookresearch/sam3.git
+cd sam3
+git checkout 660a5e9e1b8b4c02c0ad97229b88a09a6e4ff5b7
+pip install -e .
+pip install -e ".[notebooks]"
+hf auth login
+```
+
+Download this companion through the button above, extract `SAM-3.zip`, and
+install its OpenCV and NumPy dependencies:
+
+```bash
+cd SAM-3
+pip install -r requirements.txt
+```
+
+## Run Stateful SAM 3.1 Tracking
+
+```bash
+python sam3_video_tracking.py \
+  --video input.mp4 \
+  --output output-sam31.mp4 \
+  --prompt "person"
+```
+
+The first run downloads the SAM 3.1 checkpoint after Hugging Face access and
+authentication have been configured. To use a local checkpoint instead:
+
+```bash
+python sam3_video_tracking.py \
+  --video input.mp4 \
+  --output output-sam31.mp4 \
+  --prompt "person" \
+  --checkpoint /path/to/sam3.1_multiplex.pt
+```
+
+By default, the renderer copies the source video's audio into the finished
+file. Install FFmpeg for this step, or pass `--no-audio` when a silent output is
+intentional.
+
+The default Object Multiplex bucket contains 16 objects. Increase the overall
+capacity while retaining 16-object buckets when a scene contains more tracked
+instances:
+
+```bash
+python sam3_video_tracking.py \
+  --video crowded-scene.mp4 \
+  --output crowded-scene-sam31.mp4 \
+  --prompt "person" \
+  --max-objects 128 \
+  --multiplex-count 16 \
+  --compile
+```
+
+Compilation adds startup cost, so measure after warm-up and report the GPU,
+object count, video resolution, and software versions with any speed result.
+
+## Notebook
+
+`sam3_inference.ipynb` teaches the same stateful flow in small steps. It imports
+the tested functions from `sam3_video_tracking.py` rather than maintaining a
+second implementation.
+
+## Tests
+
+Run the deterministic OpenCV and predictor-contract tests without downloading
+a checkpoint:
+
+```bash
+python -m unittest discover -s tests -v
+python -m py_compile sam3_video_tracking.py
+```
+
+These tests create small temporary videos, exercise the real renderer with a
+fake predictor, verify session lifecycle requests, preserve a synthetic audio
+stream when FFmpeg is available, keep the full video when audio ends early,
+cover the pinned upstream session regression, and decode the result. They do
+not measure SAM checkpoint accuracy or GPU performance; those require a
+compatible CUDA system and the gated model.
+
+## Important Limitations
+
+- Stateful tracking mitigates drift and identity loss; it does not guarantee
+  perfect recovery after occlusion or in crowded, visually similar scenes.
+- The presence score and confidence threshold reduce false positives but still
+  require validation on the deployment domain.
+- One text string represents one phrase. Use separate sessions for unrelated
+  concepts rather than a comma-separated pseudo-list.
+- SAM 3.1's accuracy changes are benchmark-dependent. Its main release benefit
+  is substantially better multi-object inference efficiency through Object
+  Multiplex, not a universal accuracy increase.
 
 
 ---

--- a/SAM-3/requirements.txt
+++ b/SAM-3/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.26,<2
+opencv-python>=4.8,<6

--- a/SAM-3/sam3_inference.ipynb
+++ b/SAM-3/sam3_inference.ipynb
@@ -1,207 +1,231 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "494c1777",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import cv2\n",
-    "import torch\n",
-    "import numpy as np\n",
-    "from PIL import Image\n",
-    "from sam3.sam3.model_builder import build_sam3_image_model\n",
-    "from sam3.sam3.model.sam3_image_processor import Sam3Processor"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "intro",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Stateful Video Tracking with SAM 3.1 Object Multiplex\n",
+        "\n",
+        "**Audience:** Python and computer-vision developers who want to track every instance of one text-described concept through an MP4 video.\n",
+        "\n",
+        "**Prerequisites:** Python 3.12+, a CUDA 12.6+ NVIDIA GPU, PyTorch 2.7+, current Meta SAM 3 code, access to the gated `facebook/sam3.1` checkpoint, and the packages in `requirements.txt`.\n",
+        "\n",
+        "**Learning goals:** By the end, you can open a stateful SAM 3.1 session, add one text noun phrase, propagate persistent object IDs, and render the returned masks correctly with OpenCV.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "outline",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Verify the environment\n",
+        "2. Configure one video and one concept phrase\n",
+        "3. Build the Object Multiplex predictor\n",
+        "4. Run stateful propagation and render the result\n",
+        "5. Review pitfalls and try a prompt exercise\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "environment-explanation",
+      "metadata": {},
+      "source": [
+        "## 1. Verify the environment\n",
+        "\n",
+        "SAM 3.1 video inference is CUDA-only in Meta's current implementation. The reusable module imports the SAM package lazily, so its OpenCV renderer and tests remain usable without downloading the checkpoint.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "environment-check",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import cv2\n",
+        "import torch\n",
+        "from IPython.display import Video, display\n",
+        "\n",
+        "from sam3_video_tracking import build_sam31_predictor, track_video\n",
+        "\n",
+        "print(f\"PyTorch: {torch.__version__}\")\n",
+        "print(f\"OpenCV: {cv2.__version__}\")\n",
+        "print(f\"CUDA available: {torch.cuda.is_available()}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "configure-explanation",
+      "metadata": {},
+      "source": [
+        "## 2. Configure the input and prompt\n",
+        "\n",
+        "Use one noun phrase, such as `person` or `person wearing a red shirt`. A comma-separated string is still one phrase; it is not a documented multi-label API. Use a separate session for an unrelated concept.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "configure-input",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "INPUT_VIDEO = Path(\"input.mp4\")\n",
+        "OUTPUT_VIDEO = Path(\"output-sam31.mp4\")\n",
+        "TEXT_PROMPT = \"person\"\n",
+        "OUTPUT_THRESHOLD = 0.5\n",
+        "\n",
+        "if not INPUT_VIDEO.is_file():\n",
+        "    raise FileNotFoundError(\n",
+        "        f\"Place your source video at {INPUT_VIDEO.resolve()} or change INPUT_VIDEO.\"\n",
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "builder-explanation",
+      "metadata": {},
+      "source": [
+        "## 3. Build the SAM 3.1 predictor\n",
+        "\n",
+        "`build_sam3_multiplex_video_predictor` is Meta's recommended SAM 3.1 entry point. The default capacity and bucket size are 16 objects. The builder downloads `facebook/sam3.1` automatically after Hugging Face access and authentication are configured. Set `use_fa3=False` if FlashAttention 3 is unavailable. The pinned Meta revision has a documented start-session mismatch ([issue #544](https://github.com/facebookresearch/sam3/issues/544)); the companion filters that one unsupported keyword and becomes a no-op once the upstream signature is fixed.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "build-predictor",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "predictor = build_sam31_predictor(\n",
+        "    max_num_objects=16,\n",
+        "    multiplex_count=16,\n",
+        "    compile_model=False,\n",
+        "    use_fa3=False,\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "tracking-explanation",
+      "metadata": {},
+      "source": [
+        "## 4. Propagate IDs and render the video\n",
+        "\n",
+        "The helper starts one session, adds the text prompt on frame zero, and streams the canonical `propagate_in_video` responses forward, including propagated frame zero. That matters because SAM 3.1 can filter unconfirmed hot-start objects using later evidence. The helper always closes the session. OpenCV renders each response immediately, so full-resolution masks do not accumulate in memory. It blends each returned mask only where that mask is active and draws a stable object ID.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "run-tracking",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "summary = track_video(\n",
+        "    predictor,\n",
+        "    INPUT_VIDEO,\n",
+        "    OUTPUT_VIDEO,\n",
+        "    TEXT_PROMPT,\n",
+        "    output_threshold=OUTPUT_THRESHOLD,\n",
+        "    alpha=0.45,\n",
+        "    blur_kernel=11,\n",
+        ")\n",
+        "summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "preview-explanation",
+      "metadata": {},
+      "source": [
+        "### Preview the rendered result\n",
+        "\n",
+        "The output should preserve the input frame count and dimensions. Colors and labels identify SAM's object IDs; they are not ground-truth annotations.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "preview-video",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "display(Video(str(OUTPUT_VIDEO), embed=False))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "pitfalls",
+      "metadata": {},
+      "source": [
+        "## Pitfalls and production guidance\n",
+        "\n",
+        "- Do not call the image processor independently on every frame and label the result tracking; that path has no temporal memory or persistent identities.\n",
+        "- Do not treat commas as a list of labels. One text request represents one phrase.\n",
+        "- Stateful propagation mitigates drift and identity switches but does not guarantee perfect recovery through every occlusion. Validate thresholds on your own domain.\n",
+        "- Compilation adds startup cost. Warm up before timing, and report the GPU, object count, resolution, and software versions with performance results.\n",
+        "- The current predictor loads video frames into session state, so long or high-resolution videos require careful GPU and host-memory planning.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "exercise",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Choose a more specific phrase that still describes one concept, predict whether it will reduce or increase the number of tracked instances, and render it to a different output file. Do not append it to the first prompt with a comma.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "id": "exercise-scaffold",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Exercise answer scaffold\n",
+        "EXERCISE_PROMPT = \"person wearing a red shirt\"\n",
+        "EXERCISE_OUTPUT = Path(\"output-sam31-specific-prompt.mp4\")\n",
+        "\n",
+        "# Uncomment after recording your prediction. track_video opens and closes a new session.\n",
+        "# exercise_summary = track_video(\n",
+        "#     predictor, INPUT_VIDEO, EXERCISE_OUTPUT, EXERCISE_PROMPT\n",
+        "# )\n",
+        "# exercise_summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "references",
+      "metadata": {},
+      "source": [
+        "## Primary references\n",
+        "\n",
+        "- [Meta SAM 3.1 release notes](https://github.com/facebookresearch/sam3/blob/main/RELEASE_SAM3p1.md)\n",
+        "- [Meta SAM 3.1 Object Multiplex notebook](https://github.com/facebookresearch/sam3/blob/main/examples/sam3.1_video_predictor_example.ipynb)\n",
+        "- [SAM 3 paper](https://arxiv.org/abs/2511.16719)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "475075a5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = build_sam3_image_model()\n",
-    "processor = Sam3Processor(model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6091625",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def to_numpy_mask(mask, frame_shape):\n",
-    "    H, W = frame_shape[:2]\n",
-    "    if isinstance(mask, torch.Tensor):\n",
-    "        m = mask.detach().cpu().numpy()\n",
-    "    else:\n",
-    "        m = np.asarray(mask)\n",
-    "    m = np.squeeze(m).astype(np.float32)\n",
-    "    if m.shape != (H, W):\n",
-    "        m = cv2.resize(m, (W, H), interpolation=cv2.INTER_LINEAR)\n",
-    "    return m / (m.max() + 1e-6)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "84bb42c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def to_numpy_mask(mask, frame_shape):\n",
-    "    H, W = frame_shape[:2]\n",
-    "    if isinstance(mask, torch.Tensor):\n",
-    "        m = mask.detach().cpu().numpy()\n",
-    "    else:\n",
-    "        m = np.asarray(mask)\n",
-    "    m = np.squeeze(m).astype(np.float32)\n",
-    "    if m.shape != (H, W):\n",
-    "        m = cv2.resize(m, (W, H), interpolation=cv2.INTER_LINEAR)\n",
-    "    return m / (m.max() + 1e-6)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9b75b128",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def visualize_mask_soft(frame_bgr, masks, color=(0, 255, 0), alpha=0.45, blur_k=21):\n",
-    "   \n",
-    "    H, W, _ = frame_bgr.shape\n",
-    "\n",
-    "    combined = np.zeros((H, W), dtype=np.float32)\n",
-    "\n",
-    "    for mask in masks:\n",
-    "        if isinstance(mask, torch.Tensor):\n",
-    "            m = mask.detach().cpu().numpy()\n",
-    "        else:\n",
-    "            m = np.asarray(mask)\n",
-    "        m = np.squeeze(m)\n",
-    "\n",
-    "        if m.shape != (H, W):\n",
-    "            m = cv2.resize(m.astype(np.float32), (W, H))\n",
-    "\n",
-    "        combined = np.maximum(combined, m)  \n",
-    "\n",
-    "    combined = combined.astype(np.float32)\n",
-    "    combined_blur = cv2.GaussianBlur(combined, (blur_k, blur_k), 0)\n",
-    "\n",
-    "    overlay = np.zeros_like(frame_bgr, dtype=np.uint8)\n",
-    "    overlay[:, :, 0] = color[0]\n",
-    "    overlay[:, :, 1] = color[1]\n",
-    "    overlay[:, :, 2] = color[2]\n",
-    "\n",
-    "    combined_blur_3ch = np.stack([combined_blur]*3, axis=-1)\n",
-    "    output = frame_bgr * (1 - combined_blur_3ch * alpha) + overlay * (combined_blur_3ch * alpha)\n",
-    "\n",
-    "    return output.astype(np.uint8)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ba8eb149",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "VIDEO_PATH = \"input_video_path\"\n",
-    "OUTPUT_PATH = \"output_video_path\"\n",
-    "TEXT_PROMPT = \"Object Prompts separated by Comma\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eb0b99d3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cap = cv2.VideoCapture(VIDEO_PATH)\n",
-    "\n",
-    "if not cap.isOpened():\n",
-    "    raise Exception(\"Could not open video file: \" + VIDEO_PATH)\n",
-    "\n",
-    "fps = cap.get(cv2.CAP_PROP_FPS)\n",
-    "width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))\n",
-    "height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
-    "\n",
-    "fourcc = cv2.VideoWriter_fourcc(*\"mp4v\")\n",
-    "out = cv2.VideoWriter(OUTPUT_PATH, fourcc, fps, (width, height))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9e61942d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "while True:\n",
-    "    ret, frame_bgr = cap.read()\n",
-    "    if not ret:\n",
-    "        break\n",
-    "\n",
-    "    frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)\n",
-    "    pil_img = Image.fromarray(frame_rgb)\n",
-    "\n",
-    "    state = processor.set_image(pil_img)\n",
-    "    output = processor.set_text_prompt(state=state, prompt=TEXT_PROMPT)\n",
-    "\n",
-    "    masks = output[\"masks\"]  \n",
-    "\n",
-    "    frame_bgr = visualize_mask_soft(frame_bgr, masks, alpha=0.4)\n",
-    "\n",
-    "    out.write(frame_bgr)\n",
-    "\n",
-    "cap.release()\n",
-    "out.release()\n",
-    "cv2.destroyAllWindows()\n",
-    "\n",
-    "print(\"Done! Saved:\", OUTPUT_PATH)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3ea68bbf",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4ca496d3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "sam3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.14"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/SAM-3/sam3_video_tracking.py
+++ b/SAM-3/sam3_video_tracking.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Stateful SAM 3.1 text-prompted video tracking with OpenCV rendering.
+
+The SAM 3.1 predictor owns temporal state and propagates object identities.
+OpenCV is used only to decode the source video and render the returned masks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import cv2
+import numpy as np
+
+
+# BGR colors selected for strong contrast on common video backgrounds.
+_OBJECT_COLORS = (
+    (46, 204, 113),
+    (52, 152, 219),
+    (231, 76, 60),
+    (155, 89, 182),
+    (241, 196, 15),
+    (26, 188, 156),
+    (230, 126, 34),
+    (149, 165, 166),
+)
+
+
+def _temporary_output_path(output_path: Path, label: str) -> Path:
+    """Reserve a unique temporary file beside the requested output."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output_path.parent,
+        prefix=f".{output_path.stem}.{label}.",
+        suffix=output_path.suffix,
+    )
+    os.close(descriptor)
+    return Path(temporary_name)
+
+
+def _as_numpy(value: Any) -> np.ndarray:
+    """Convert a NumPy-compatible value or PyTorch tensor without importing torch."""
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    return np.asarray(value)
+
+
+def _binary_mask(mask: Any, frame_height: int, frame_width: int) -> np.ndarray:
+    """Return one SAM mask as a full-resolution boolean array."""
+    array = np.squeeze(_as_numpy(mask))
+    if array.ndim != 2:
+        raise ValueError(f"Expected a 2D mask after squeezing, got {array.shape}")
+    if array.shape != (frame_height, frame_width):
+        array = cv2.resize(
+            array.astype(np.float32),
+            (frame_width, frame_height),
+            interpolation=cv2.INTER_NEAREST,
+        )
+    return array.astype(np.float32) > 0.5
+
+
+def _mask_bounds(mask: np.ndarray) -> tuple[int, int, int, int] | None:
+    """Return inclusive XYXY bounds for a nonempty mask."""
+    rows, columns = np.nonzero(mask)
+    if rows.size == 0:
+        return None
+    return int(columns.min()), int(rows.min()), int(columns.max()), int(rows.max())
+
+
+def overlay_tracking_outputs(
+    frame_bgr: np.ndarray,
+    outputs: Mapping[str, Any] | None,
+    *,
+    alpha: float = 0.45,
+    blur_kernel: int = 11,
+) -> np.ndarray:
+    """Blend per-object SAM masks and stable IDs onto one OpenCV frame.
+
+    A small Gaussian blur softens each mask boundary, so blending is confined
+    to the mask and a narrow edge band rather than tinting the complete frame.
+    """
+    if outputs is None:
+        return frame_bgr.copy()
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError("alpha must be between 0 and 1")
+    if blur_kernel < 1 or blur_kernel % 2 == 0:
+        raise ValueError("blur_kernel must be a positive odd integer")
+
+    object_ids = _as_numpy(outputs.get("out_obj_ids", [])).reshape(-1)
+    raw_masks = _as_numpy(outputs.get("out_binary_masks", []))
+    probabilities = _as_numpy(outputs.get("out_probs", [])).reshape(-1)
+
+    if object_ids.size == 0 or raw_masks.size == 0:
+        return frame_bgr.copy()
+    if raw_masks.ndim == 2:
+        raw_masks = raw_masks[np.newaxis, ...]
+    if len(raw_masks) != len(object_ids):
+        raise ValueError(
+            "SAM output has different object-ID and mask counts: "
+            f"{len(object_ids)} IDs versus {len(raw_masks)} masks"
+        )
+
+    height, width = frame_bgr.shape[:2]
+    rendered = frame_bgr.astype(np.float32)
+    labels: list[tuple[tuple[int, int, int, int], str, tuple[int, int, int]]] = []
+
+    for index, (object_id, raw_mask) in enumerate(zip(object_ids, raw_masks)):
+        mask = _binary_mask(raw_mask, height, width)
+        bounds = _mask_bounds(mask)
+        if bounds is None:
+            continue
+
+        color = _OBJECT_COLORS[int(object_id) % len(_OBJECT_COLORS)]
+        soft_mask = mask.astype(np.float32)
+        if blur_kernel > 1:
+            soft_mask = cv2.GaussianBlur(soft_mask, (blur_kernel, blur_kernel), 0)
+        local_alpha = np.clip(soft_mask * alpha, 0.0, 1.0)[..., np.newaxis]
+        rendered = rendered * (1.0 - local_alpha) + np.asarray(color) * local_alpha
+
+        label = f"ID {int(object_id)}"
+        if index < len(probabilities):
+            label += f"  {float(probabilities[index]):.2f}"
+        labels.append((bounds, label, color))
+
+    rendered = np.clip(rendered, 0, 255).astype(np.uint8)
+    for (x_min, y_min, x_max, y_max), label, color in labels:
+        cv2.rectangle(rendered, (x_min, y_min), (x_max, y_max), color, 2)
+        text_origin = (x_min, max(18, y_min - 7))
+        cv2.putText(
+            rendered,
+            label,
+            text_origin,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.55,
+            color,
+            2,
+            cv2.LINE_AA,
+        )
+    return rendered
+
+
+def stream_tracking_outputs(
+    predictor: Any,
+    video_path: Path,
+    prompt: str,
+    *,
+    output_threshold: float = 0.5,
+) -> Iterable[Mapping[str, Any]]:
+    """Yield ordered SAM outputs while keeping only the current masks in memory."""
+    session_id: str | None = None
+    try:
+        start_response = _handle_start_session(
+            predictor,
+            {
+                "type": "start_session",
+                "resource_path": str(video_path),
+            },
+        )
+        session_id = start_response["session_id"]
+
+        predictor.handle_request(
+            {
+                "type": "add_prompt",
+                "session_id": session_id,
+                "frame_index": 0,
+                "text": prompt,
+                "output_prob_thresh": output_threshold,
+            }
+        )
+
+        stream: Iterable[Mapping[str, Any]] = predictor.handle_stream_request(
+            {
+                "type": "propagate_in_video",
+                "session_id": session_id,
+                "propagation_direction": "forward",
+                "output_prob_thresh": output_threshold,
+            }
+        )
+        for response in stream:
+            # Propagation output is canonical even for frame zero: SAM 3.1 can
+            # remove unconfirmed hot-start objects using evidence from later frames.
+            yield response
+    finally:
+        if session_id is not None:
+            predictor.handle_request(
+                {
+                    "type": "close_session",
+                    "session_id": session_id,
+                }
+            )
+
+
+def _handle_start_session(
+    predictor: Any,
+    request: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    """Start a session while tolerating Meta SAM 3.1 issue #544.
+
+    Meta commit 660a5e9 forwards ``offload_state_to_cpu`` from the base
+    predictor even though the multiplex model's ``init_state`` method does not
+    accept it. Temporarily filtering that one unsupported keyword preserves the
+    upstream request API and becomes a no-op once Meta's implementation accepts
+    the argument.
+    """
+    model = getattr(predictor, "model", None)
+    init_state = getattr(model, "init_state", None)
+    if init_state is None:
+        return predictor.handle_request(dict(request))
+
+    try:
+        parameters = inspect.signature(init_state).parameters.values()
+    except (TypeError, ValueError):
+        return predictor.handle_request(dict(request))
+
+    accepts_offload_state = any(
+        parameter.name == "offload_state_to_cpu"
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+    if accepts_offload_state:
+        return predictor.handle_request(dict(request))
+
+    def compatible_init_state(*args: Any, **kwargs: Any) -> Any:
+        kwargs.pop("offload_state_to_cpu", None)
+        return init_state(*args, **kwargs)
+
+    model_namespace = getattr(model, "__dict__", {})
+    had_instance_override = "init_state" in model_namespace
+    previous_instance_value = model_namespace.get("init_state")
+    try:
+        setattr(model, "init_state", compatible_init_state)
+    except (AttributeError, TypeError) as error:
+        raise RuntimeError(
+            "This SAM 3.1 checkout has Meta issue #544 and its model cannot be "
+            "adapted safely. Use the pinned companion instructions or an official "
+            "SAM revision where the multiplex start-session fix is merged."
+        ) from error
+
+    try:
+        return predictor.handle_request(dict(request))
+    finally:
+        if had_instance_override:
+            setattr(model, "init_state", previous_instance_value)
+        else:
+            delattr(model, "init_state")
+
+
+def render_tracking_video(
+    video_path: Path,
+    output_path: Path,
+    output_stream: Iterable[Mapping[str, Any]],
+    *,
+    alpha: float = 0.45,
+    blur_kernel: int = 11,
+    codec: str = "mp4v",
+    preserve_audio: bool = True,
+) -> tuple[int, int]:
+    """Render streamed SAM outputs and return rendered/tracked frame counts."""
+    if len(codec) != 4:
+        raise ValueError("codec must contain exactly four characters")
+
+    video_path = video_path.expanduser().resolve()
+    output_path = output_path.expanduser().resolve()
+    if video_path == output_path:
+        raise ValueError("Input and output video paths must be different")
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Input video does not exist: {video_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    capture = cv2.VideoCapture(str(video_path))
+    if not capture.isOpened():
+        raise RuntimeError(f"OpenCV could not open the input video: {video_path}")
+
+    fps = float(capture.get(cv2.CAP_PROP_FPS))
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    if fps <= 0 or width <= 0 or height <= 0:
+        capture.release()
+        raise RuntimeError("Input video reports invalid FPS or frame dimensions")
+
+    partial_path = _temporary_output_path(output_path, "video-only")
+    writer = cv2.VideoWriter(
+        str(partial_path),
+        cv2.VideoWriter_fourcc(*codec),
+        fps,
+        (width, height),
+    )
+    if not writer.isOpened():
+        capture.release()
+        partial_path.unlink(missing_ok=True)
+        raise RuntimeError(f"OpenCV could not create the output video: {partial_path}")
+
+    frame_index = 0
+    tracked_frames = 0
+    render_failed = False
+    try:
+        for response in output_stream:
+            response_frame = int(response["frame_index"])
+            if response_frame < frame_index:
+                raise RuntimeError(
+                    "SAM propagation returned frames out of order: "
+                    f"received {response_frame} after {frame_index - 1}"
+                )
+
+            while frame_index < response_frame:
+                ok, frame = capture.read()
+                if not ok:
+                    raise RuntimeError(
+                        f"SAM returned frame {response_frame}, beyond the decoded video"
+                    )
+                writer.write(frame)
+                frame_index += 1
+
+            ok, frame = capture.read()
+            if not ok:
+                raise RuntimeError(
+                    f"SAM returned frame {response_frame}, beyond the decoded video"
+                )
+            rendered = overlay_tracking_outputs(
+                frame,
+                response["outputs"],
+                alpha=alpha,
+                blur_kernel=blur_kernel,
+            )
+            writer.write(rendered)
+            frame_index += 1
+            tracked_frames += 1
+
+        while True:
+            ok, frame = capture.read()
+            if not ok:
+                break
+            writer.write(frame)
+            frame_index += 1
+    except Exception:
+        render_failed = True
+        raise
+    finally:
+        capture.release()
+        writer.release()
+        if render_failed:
+            partial_path.unlink(missing_ok=True)
+
+    if frame_index == 0:
+        partial_path.unlink(missing_ok=True)
+        raise RuntimeError("Input video contained no decodable frames")
+
+    try:
+        if preserve_audio and _source_has_audio(video_path):
+            _mux_source_audio(partial_path, video_path, output_path)
+            partial_path.unlink(missing_ok=True)
+        else:
+            partial_path.replace(output_path)
+        output_path.chmod(0o644)
+    except Exception:
+        partial_path.unlink(missing_ok=True)
+        raise
+    return frame_index, tracked_frames
+
+
+def _source_has_audio(video_path: Path) -> bool:
+    """Use FFprobe to determine whether the source contains an audio stream."""
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError(
+            "FFprobe is required to preserve source audio; install FFmpeg or pass --no-audio"
+        )
+    completed = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=index",
+            "-of",
+            "csv=p=0",
+            str(video_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return bool(completed.stdout.strip())
+
+
+def _mux_source_audio(video_only_path: Path, source_path: Path, output_path: Path) -> None:
+    """Copy rendered video and transcode the source audio into the final container."""
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            "FFmpeg is required to preserve source audio; install FFmpeg or pass --no-audio"
+        )
+
+    muxed_path = _temporary_output_path(output_path, "muxed")
+    command = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(video_only_path),
+        "-i",
+        str(source_path),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "copy",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "192k",
+        "-af",
+        "apad",
+        "-shortest",
+        str(muxed_path),
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        muxed_path.replace(output_path)
+    except Exception as error:
+        muxed_path.unlink(missing_ok=True)
+        detail = getattr(error, "stderr", "") or "unknown FFmpeg error"
+        detail = str(detail).strip()
+        raise RuntimeError(f"Could not preserve source audio: {detail}") from error
+
+
+def build_sam31_predictor(
+    *,
+    checkpoint_path: Path | None = None,
+    max_num_objects: int = 16,
+    multiplex_count: int = 16,
+    compile_model: bool = False,
+    use_fa3: bool = False,
+) -> Any:
+    """Build Meta's current SAM 3.1 Object Multiplex video predictor."""
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("SAM 3.1 video inference requires a CUDA-capable GPU")
+
+    from sam3.model_builder import build_sam3_multiplex_video_predictor
+
+    return build_sam3_multiplex_video_predictor(
+        checkpoint_path=str(checkpoint_path) if checkpoint_path else None,
+        max_num_objects=max_num_objects,
+        multiplex_count=multiplex_count,
+        compile=compile_model,
+        warm_up=compile_model,
+        use_fa3=use_fa3,
+    )
+
+
+def track_video(
+    predictor: Any,
+    video_path: Path,
+    output_path: Path,
+    prompt: str,
+    *,
+    output_threshold: float = 0.5,
+    alpha: float = 0.45,
+    blur_kernel: int = 11,
+    codec: str = "mp4v",
+    preserve_audio: bool = True,
+) -> dict[str, int | str]:
+    """Run stateful tracking and render a video using an existing predictor."""
+    prompt = prompt.strip()
+    if not prompt:
+        raise ValueError("prompt must contain one noun phrase")
+    if not 0.0 <= output_threshold <= 1.0:
+        raise ValueError("output_threshold must be between 0 and 1")
+
+    output_stream = stream_tracking_outputs(
+        predictor,
+        video_path,
+        prompt,
+        output_threshold=output_threshold,
+    )
+    try:
+        rendered_frames, tracked_frames = render_tracking_video(
+            video_path,
+            output_path,
+            output_stream,
+            alpha=alpha,
+            blur_kernel=blur_kernel,
+            codec=codec,
+            preserve_audio=preserve_audio,
+        )
+    finally:
+        close_stream = getattr(output_stream, "close", None)
+        if close_stream is not None:
+            close_stream()
+    return {
+        "prompt": prompt,
+        "tracked_frames": tracked_frames,
+        "rendered_frames": rendered_frames,
+        "output_path": str(output_path.expanduser().resolve()),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Track every instance of one text-described concept with SAM 3.1."
+    )
+    parser.add_argument("--video", type=Path, required=True, help="Input MP4 video")
+    parser.add_argument("--output", type=Path, required=True, help="Rendered output video")
+    parser.add_argument(
+        "--prompt",
+        required=True,
+        help='One noun phrase, for example "person wearing a red shirt"',
+    )
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--checkpoint", type=Path)
+    parser.add_argument("--max-objects", type=int, default=16)
+    parser.add_argument(
+        "--multiplex-count",
+        type=int,
+        default=16,
+        help=(
+            "Object Multiplex bucket width (the public SAM 3.1 checkpoint uses 16; "
+            "other values require a compatible checkpoint)"
+        ),
+    )
+    parser.add_argument("--compile", action="store_true", dest="compile_model")
+    parser.add_argument(
+        "--fa3",
+        action="store_true",
+        dest="use_fa3",
+        help="Enable optional FlashAttention 3 kernels on a compatible system",
+    )
+    parser.set_defaults(use_fa3=False)
+    parser.add_argument("--alpha", type=float, default=0.45)
+    parser.add_argument("--blur-kernel", type=int, default=11)
+    parser.add_argument("--codec", default="mp4v")
+    parser.add_argument(
+        "--no-audio",
+        action="store_false",
+        dest="preserve_audio",
+        help="Do not copy the source audio into the rendered output",
+    )
+    parser.set_defaults(preserve_audio=True)
+    args = parser.parse_args(argv)
+
+    if args.max_objects < 1:
+        parser.error("--max-objects must be positive")
+    if args.multiplex_count < 1:
+        parser.error("--multiplex-count must be positive")
+    if args.multiplex_count > args.max_objects:
+        parser.error("--multiplex-count cannot exceed --max-objects")
+    if args.multiplex_count != 16 and args.checkpoint is None:
+        parser.error(
+            "the public SAM 3.1 checkpoint requires --multiplex-count 16; "
+            "provide a compatible --checkpoint for another value"
+        )
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    predictor = build_sam31_predictor(
+        checkpoint_path=args.checkpoint,
+        max_num_objects=args.max_objects,
+        multiplex_count=args.multiplex_count,
+        compile_model=args.compile_model,
+        use_fa3=args.use_fa3,
+    )
+    summary = track_video(
+        predictor,
+        args.video,
+        args.output,
+        args.prompt,
+        output_threshold=args.threshold,
+        alpha=args.alpha,
+        blur_kernel=args.blur_kernel,
+        codec=args.codec,
+        preserve_audio=args.preserve_audio,
+    )
+    print(
+        "Saved {rendered_frames} frames to {output_path} "
+        "({tracked_frames} frames carried SAM outputs).".format(**summary)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/SAM-3/tests/test_sam3_video_tracking.py
+++ b/SAM-3/tests/test_sam3_video_tracking.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sam3_video_tracking import (
+    overlay_tracking_outputs,
+    stream_tracking_outputs,
+    track_video,
+)
+
+
+class FakePredictor:
+    def __init__(self, frame_count: int, height: int, width: int) -> None:
+        self.frame_count = frame_count
+        self.height = height
+        self.width = width
+        self.requests: list[dict] = []
+
+    def _outputs(self, frame_index: int) -> dict[str, np.ndarray]:
+        mask = np.zeros((1, self.height, self.width), dtype=bool)
+        x_start = 8 + frame_index
+        mask[:, 10:30, x_start : x_start + 20] = True
+        return {
+            "out_obj_ids": np.array([7], dtype=np.int64),
+            "out_probs": np.array([0.91], dtype=np.float32),
+            "out_binary_masks": mask,
+        }
+
+    def handle_request(self, request: dict) -> dict:
+        self.requests.append(request.copy())
+        if request["type"] == "start_session":
+            return {"session_id": "test-session"}
+        if request["type"] == "add_prompt":
+            return {
+                "frame_index": request["frame_index"],
+                "outputs": self._outputs(request["frame_index"]),
+            }
+        if request["type"] == "close_session":
+            return {"is_success": True}
+        raise AssertionError(f"Unexpected request: {request}")
+
+    def handle_stream_request(self, request: dict):
+        self.requests.append(request.copy())
+        for frame_index in range(self.frame_count):
+            yield {
+                "frame_index": frame_index,
+                "outputs": self._outputs(frame_index),
+            }
+
+
+class OverlayTests(unittest.TestCase):
+    def test_overlay_changes_only_mask_region_except_labels(self) -> None:
+        frame = np.full((48, 64, 3), 100, dtype=np.uint8)
+        mask = np.zeros((1, 48, 64), dtype=bool)
+        mask[:, 16:32, 20:44] = True
+        outputs = {
+            "out_obj_ids": np.array([1]),
+            "out_binary_masks": mask,
+        }
+
+        rendered = overlay_tracking_outputs(frame, outputs, alpha=0.5, blur_kernel=1)
+
+        np.testing.assert_array_equal(rendered[40, 60], frame[40, 60])
+        self.assertFalse(np.array_equal(rendered[24, 32], frame[24, 32]))
+
+    def test_empty_outputs_leave_frame_unchanged(self) -> None:
+        frame = np.full((20, 30, 3), 42, dtype=np.uint8)
+        rendered = overlay_tracking_outputs(
+            frame,
+            {"out_obj_ids": np.array([]), "out_binary_masks": np.array([])},
+        )
+        np.testing.assert_array_equal(rendered, frame)
+
+    def test_mismatched_object_and_mask_counts_fail(self) -> None:
+        frame = np.zeros((20, 30, 3), dtype=np.uint8)
+        outputs = {
+            "out_obj_ids": np.array([1, 2]),
+            "out_binary_masks": np.zeros((1, 20, 30), dtype=bool),
+        }
+        with self.assertRaisesRegex(ValueError, "different object-ID and mask counts"):
+            overlay_tracking_outputs(frame, outputs)
+
+
+class PipelineTests(unittest.TestCase):
+    def test_propagated_frame_zero_replaces_immediate_prompt_output(self) -> None:
+        class HotStartFilteringPredictor(FakePredictor):
+            def handle_request(self, request: dict) -> dict:
+                response = super().handle_request(request)
+                if request["type"] == "add_prompt":
+                    response["outputs"]["out_obj_ids"] = np.array([99])
+                return response
+
+        predictor = HotStartFilteringPredictor(frame_count=2, height=10, width=10)
+        responses = list(
+            stream_tracking_outputs(predictor, Path("unused.mp4"), "person")
+        )
+
+        self.assertEqual([response["frame_index"] for response in responses], [0, 1])
+        self.assertEqual(int(responses[0]["outputs"]["out_obj_ids"][0]), 7)
+
+    def test_pinned_upstream_start_session_regression_is_adapted(self) -> None:
+        class MultiplexModel:
+            def __init__(self) -> None:
+                self.resource_path: str | None = None
+
+            # This intentionally matches the incompatible SAM 3.1 signature at
+            # Meta commit 660a5e9: offload_state_to_cpu is not accepted.
+            def init_state(self, resource_path: str, offload_video_to_cpu: bool = False):
+                self.resource_path = resource_path
+                return {"offload_video_to_cpu": offload_video_to_cpu}
+
+        class RegressedBasePredictor(FakePredictor):
+            def __init__(self) -> None:
+                super().__init__(frame_count=1, height=10, width=10)
+                self.model = MultiplexModel()
+
+            def handle_request(self, request: dict) -> dict:
+                if request["type"] == "start_session":
+                    self.requests.append(request.copy())
+                    self.model.init_state(
+                        resource_path=request["resource_path"],
+                        offload_video_to_cpu=False,
+                        offload_state_to_cpu=False,
+                    )
+                    return {"session_id": "test-session"}
+                return super().handle_request(request)
+
+        predictor = RegressedBasePredictor()
+        responses = list(
+            stream_tracking_outputs(predictor, Path("input.mp4"), "person")
+        )
+
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(predictor.model.resource_path, "input.mp4")
+        self.assertNotIn("init_state", predictor.model.__dict__)
+
+    def test_fake_predictor_session_renders_decodable_video(self) -> None:
+        frame_count, width, height = 4, 64, 48
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp = Path(temporary_directory)
+            input_path = temp / "input.avi"
+            output_path = temp / "output.avi"
+
+            writer = cv2.VideoWriter(
+                str(input_path),
+                cv2.VideoWriter_fourcc(*"MJPG"),
+                8.0,
+                (width, height),
+            )
+            self.assertTrue(writer.isOpened())
+            for index in range(frame_count):
+                writer.write(np.full((height, width, 3), 40 + index, dtype=np.uint8))
+            writer.release()
+
+            predictor = FakePredictor(frame_count, height, width)
+            summary = track_video(
+                predictor,
+                input_path,
+                output_path,
+                "person",
+                codec="MJPG",
+                blur_kernel=1,
+                preserve_audio=False,
+            )
+
+            self.assertEqual(summary["tracked_frames"], frame_count)
+            self.assertEqual(summary["rendered_frames"], frame_count)
+            self.assertEqual(
+                [request["type"] for request in predictor.requests],
+                ["start_session", "add_prompt", "propagate_in_video", "close_session"],
+            )
+            self.assertEqual(predictor.requests[1]["text"], "person")
+
+            capture = cv2.VideoCapture(str(output_path))
+            decoded = 0
+            changed_inside_mask = False
+            while True:
+                ok, frame = capture.read()
+                if not ok:
+                    break
+                decoded += 1
+                changed_inside_mask |= bool(np.max(frame[20, 16]) > 45)
+            capture.release()
+
+            self.assertEqual(decoded, frame_count)
+            self.assertTrue(changed_inside_mask)
+
+    def test_session_closes_when_propagation_fails(self) -> None:
+        class FailingPredictor(FakePredictor):
+            def handle_stream_request(self, request: dict):
+                self.requests.append(request.copy())
+                raise RuntimeError("synthetic propagation failure")
+                yield  # pragma: no cover - keeps this method a generator
+
+        predictor = FailingPredictor(frame_count=1, height=10, width=10)
+        with self.assertRaisesRegex(RuntimeError, "synthetic propagation failure"):
+            list(stream_tracking_outputs(predictor, Path("unused.mp4"), "person"))
+        self.assertEqual(predictor.requests[-1]["type"], "close_session")
+
+    def test_render_failure_removes_partial_output_and_closes_session(self) -> None:
+        class FailingPredictor(FakePredictor):
+            def handle_stream_request(self, request: dict):
+                self.requests.append(request.copy())
+                raise RuntimeError("synthetic propagation failure")
+                yield  # pragma: no cover - keeps this method a generator
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp = Path(temporary_directory)
+            input_path = temp / "input.avi"
+            output_path = temp / "output.avi"
+            writer = cv2.VideoWriter(
+                str(input_path),
+                cv2.VideoWriter_fourcc(*"MJPG"),
+                8.0,
+                (64, 48),
+            )
+            writer.write(np.zeros((48, 64, 3), dtype=np.uint8))
+            writer.release()
+
+            predictor = FailingPredictor(frame_count=1, height=48, width=64)
+            with self.assertRaisesRegex(RuntimeError, "synthetic propagation failure"):
+                track_video(
+                    predictor,
+                    input_path,
+                    output_path,
+                    "person",
+                    codec="MJPG",
+                    preserve_audio=False,
+                )
+
+            self.assertEqual(predictor.requests[-1]["type"], "close_session")
+            self.assertFalse(output_path.exists())
+            self.assertEqual(list(temp.glob(".output.video-only.*.avi")), [])
+
+    def test_output_temp_name_cannot_overwrite_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp = Path(temporary_directory)
+            input_path = temp / "result.video-only.avi"
+            output_path = temp / "result.avi"
+            writer = cv2.VideoWriter(
+                str(input_path),
+                cv2.VideoWriter_fourcc(*"MJPG"),
+                8.0,
+                (64, 48),
+            )
+            self.assertTrue(writer.isOpened())
+            for index in range(3):
+                writer.write(np.full((48, 64, 3), 20 + index, dtype=np.uint8))
+            writer.release()
+            source_sha256 = hashlib.sha256(input_path.read_bytes()).hexdigest()
+
+            predictor = FakePredictor(frame_count=3, height=48, width=64)
+            track_video(
+                predictor,
+                input_path,
+                output_path,
+                "person",
+                codec="MJPG",
+                preserve_audio=False,
+            )
+
+            self.assertEqual(
+                hashlib.sha256(input_path.read_bytes()).hexdigest(), source_sha256
+            )
+            self.assertTrue(output_path.is_file())
+            self.assertEqual(output_path.stat().st_mode & 0o777, 0o644)
+
+    @unittest.skipUnless(shutil.which("ffmpeg") and shutil.which("ffprobe"), "FFmpeg required")
+    def test_source_audio_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temp = Path(temporary_directory)
+            input_path = temp / "input-with-audio.mp4"
+            output_path = temp / "output-with-audio.mp4"
+            subprocess.run(
+                [
+                    shutil.which("ffmpeg"),
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=64x48:r=8:d=1.0",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "sine=frequency=1000:duration=0.25",
+                    "-c:v",
+                    "mpeg4",
+                    "-c:a",
+                    "aac",
+                    str(input_path),
+                ],
+                check=True,
+            )
+
+            predictor = FakePredictor(frame_count=8, height=48, width=64)
+            track_video(
+                predictor,
+                input_path,
+                output_path,
+                "person",
+                preserve_audio=True,
+            )
+
+            probe = subprocess.run(
+                [
+                    shutil.which("ffprobe"),
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "stream=codec_type",
+                    "-of",
+                    "csv=p=0",
+                    str(output_path),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(set(probe.stdout.split()), {"video", "audio"})
+
+            capture = cv2.VideoCapture(str(output_path))
+            decoded_frames = 0
+            while True:
+                ok, _ = capture.read()
+                if not ok:
+                    break
+                decoded_frames += 1
+            capture.release()
+            self.assertEqual(decoded_frames, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace per-frame image inference with the SAM 3.1 Object Multiplex video session API
- stream propagated masks into an OpenCV renderer with stable IDs and bounded memory
- preserve source audio, validate prompt semantics, and handle the current upstream session-signature regression
- refresh the tutorial notebook, pinned installation instructions, download link, and root article index

## Validation
- 10/10 deterministic tests pass in Python 3.12 with NumPy 1.26/OpenCV 4.11
- 10/10 tests pass in the project environment
- notebook JSON, unique cell IDs, and all code cells validate
- CLI compilation/help and git diff checks pass

## Integration caveat
A full gated-checkpoint run requires CUDA hardware and was not available on the authoring Mac. The session lifecycle is contract-tested with a fake predictor, and the compatibility path for Meta issue #544 is tested against the exact incompatible signature and a torch.nn.Module.